### PR TITLE
M4: Go runtime P0 core

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Non-goals (near-term):
 - Node.js: `24`
 - Python: `3.14`
 
+## Go runtime (P0)
+
+The Go runtime implements the fixture-backed P0 contract (routing + request/response normalization + error envelope).
+
+Minimal local invocation:
+
+```go
+env := testkit.New()
+app := env.App()
+
+app.Get("/ping", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+	return apptheory.Text(200, "pong"), nil
+})
+
+resp := env.Invoke(context.Background(), app, apptheory.Request{Method: "GET", Path: "/ping"})
+_ = resp
+```
+
 Start here:
 
 - Planning index: `docs/development/planning/apptheory/README.md`

--- a/apptheory.go
+++ b/apptheory.go
@@ -1,10 +1,37 @@
 package apptheory
 
 // App is the root container for an AppTheory application.
-type App struct{}
-
-// New creates a new AppTheory application container.
-func New() *App {
-	return &App{}
+//
+// AppTheory's runtime behavior is defined by a fixture-backed, versioned contract:
+// `docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
+type App struct {
+	router *router
+	clock  Clock
 }
 
+type Option func(*App)
+
+// New creates a new AppTheory application container.
+func New(opts ...Option) *App {
+	app := &App{
+		router: newRouter(),
+		clock:  RealClock{},
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(app)
+	}
+	return app
+}
+
+func WithClock(clock Clock) Option {
+	return func(app *App) {
+		if clock == nil {
+			app.clock = RealClock{}
+			return
+		}
+		app.clock = clock
+	}
+}

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,15 @@
+package apptheory
+
+import "time"
+
+// Clock provides deterministic time for handlers and middleware.
+type Clock interface {
+	Now() time.Time
+}
+
+// RealClock uses time.Now.
+type RealClock struct{}
+
+func (RealClock) Now() time.Time {
+	return time.Now()
+}

--- a/context.go
+++ b/context.go
@@ -1,0 +1,66 @@
+package apptheory
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// Context is the per-request context passed to handlers.
+type Context struct {
+	ctx     context.Context
+	Request Request
+	Params  map[string]string
+	clock   Clock
+}
+
+func (c *Context) Context() context.Context {
+	if c == nil || c.ctx == nil {
+		return context.Background()
+	}
+	return c.ctx
+}
+
+func (c *Context) Now() time.Time {
+	if c == nil || c.clock == nil {
+		return time.Now()
+	}
+	return c.clock.Now()
+}
+
+func (c *Context) Param(name string) string {
+	if c == nil || c.Params == nil {
+		return ""
+	}
+	return c.Params[name]
+}
+
+func (c *Context) JSONValue() (any, error) {
+	if c == nil {
+		return nil, &AppError{Code: "app.bad_request", Message: "invalid json"}
+	}
+	if !hasJSONContentType(c.Request.Headers) {
+		return nil, &AppError{Code: "app.bad_request", Message: "invalid json"}
+	}
+	if len(c.Request.Body) == 0 {
+		return nil, nil
+	}
+
+	var value any
+	if err := json.Unmarshal(c.Request.Body, &value); err != nil {
+		return nil, &AppError{Code: "app.bad_request", Message: "invalid json"}
+	}
+	return value, nil
+}
+
+func hasJSONContentType(headers map[string][]string) bool {
+	for _, value := range headers["content-type"] {
+		v := strings.ToLower(strings.TrimSpace(value))
+		if strings.HasPrefix(v, "application/json") {
+			return true
+		}
+	}
+	return false
+}
+

--- a/contract-tests/runners/go/apptheory_p0.go
+++ b/contract-tests/runners/go/apptheory_p0.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/theory-cloud/apptheory"
+)
+
+func runFixtureP0(f Fixture) error {
+	app := apptheory.New()
+
+	for _, r := range f.Setup.Routes {
+		handler := builtInAppTheoryHandler(r.Handler)
+		if handler == nil {
+			return fmt.Errorf("unknown handler %q", r.Handler)
+		}
+		app.Handle(r.Method, r.Path, handler)
+	}
+
+	bodyBytes, err := decodeFixtureBody(f.Input.Request.Body)
+	if err != nil {
+		return fmt.Errorf("decode request body: %w", err)
+	}
+
+	req := apptheory.Request{
+		Method:   f.Input.Request.Method,
+		Path:     f.Input.Request.Path,
+		Query:    f.Input.Request.Query,
+		Headers:  f.Input.Request.Headers,
+		Body:     bodyBytes,
+		IsBase64: f.Input.Request.IsBase64,
+	}
+
+	actual := app.Serve(context.Background(), req)
+	return compareFixtureResponse(f, actual, nil, nil, nil)
+}
+
+func printFailureP0(f Fixture) {
+	app := apptheory.New()
+	for _, r := range f.Setup.Routes {
+		handler := builtInAppTheoryHandler(r.Handler)
+		if handler == nil {
+			fmt.Fprintf(os.Stderr, "  got: <unavailable>\n")
+			printExpected(f)
+			return
+		}
+		app.Handle(r.Method, r.Path, handler)
+	}
+
+	bodyBytes, err := decodeFixtureBody(f.Input.Request.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  got: <unavailable>\n")
+		printExpected(f)
+		return
+	}
+
+	req := apptheory.Request{
+		Method:   f.Input.Request.Method,
+		Path:     f.Input.Request.Path,
+		Query:    f.Input.Request.Query,
+		Headers:  f.Input.Request.Headers,
+		Body:     bodyBytes,
+		IsBase64: f.Input.Request.IsBase64,
+	}
+
+	actual := app.Serve(context.Background(), req)
+	actual.Headers = canonicalizeHeaders(actual.Headers)
+
+	debug := actualResponseForCompare{
+		Status:   actual.Status,
+		Headers:  actual.Headers,
+		Cookies:  actual.Cookies,
+		IsBase64: actual.IsBase64,
+	}
+
+	if len(f.Expect.Response.BodyJSON) > 0 {
+		var actualJSON any
+		if json.Unmarshal(actual.Body, &actualJSON) == nil {
+			debug.BodyJSON = actualJSON
+		} else {
+			debug.Body = &FixtureBody{Encoding: "base64", Value: base64.StdEncoding.EncodeToString(actual.Body)}
+		}
+	} else {
+		debug.Body = &FixtureBody{Encoding: "base64", Value: base64.StdEncoding.EncodeToString(actual.Body)}
+	}
+
+	b, _ := json.MarshalIndent(debug, "", "  ")
+	fmt.Fprintf(os.Stderr, "  got: %s\n", string(b))
+
+	logs, _ := json.MarshalIndent([]FixtureLogRecord(nil), "", "  ")
+	metrics, _ := json.MarshalIndent([]FixtureMetricRecord(nil), "", "  ")
+	spans, _ := json.MarshalIndent([]FixtureSpanRecord(nil), "", "  ")
+	fmt.Fprintf(os.Stderr, "  got.logs: %s\n", string(logs))
+	fmt.Fprintf(os.Stderr, "  got.metrics: %s\n", string(metrics))
+	fmt.Fprintf(os.Stderr, "  got.spans: %s\n", string(spans))
+
+	printExpected(f)
+}
+
+func printExpected(f Fixture) {
+	expected := f.Expect.Response
+	expected.Headers = canonicalizeHeaders(expected.Headers)
+	b, _ := json.MarshalIndent(expected, "", "  ")
+	fmt.Fprintf(os.Stderr, "  expected: %s\n", string(b))
+
+	logs, _ := json.MarshalIndent(f.Expect.Logs, "", "  ")
+	metrics, _ := json.MarshalIndent(f.Expect.Metrics, "", "  ")
+	spans, _ := json.MarshalIndent(f.Expect.Spans, "", "  ")
+	fmt.Fprintf(os.Stderr, "  expected.logs: %s\n", string(logs))
+	fmt.Fprintf(os.Stderr, "  expected.metrics: %s\n", string(metrics))
+	fmt.Fprintf(os.Stderr, "  expected.spans: %s\n", string(spans))
+}
+
+func builtInAppTheoryHandler(name string) apptheory.Handler {
+	switch name {
+	case "static_pong":
+		return func(_ *apptheory.Context) (*apptheory.Response, error) {
+			return apptheory.Text(200, "pong"), nil
+		}
+	case "echo_path_params":
+		return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			return apptheory.JSON(200, map[string]any{
+				"params": ctx.Params,
+			})
+		}
+	case "echo_request":
+		return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			return apptheory.JSON(200, map[string]any{
+				"method":    ctx.Request.Method,
+				"path":      ctx.Request.Path,
+				"query":     ctx.Request.Query,
+				"headers":   ctx.Request.Headers,
+				"cookies":   ctx.Request.Cookies,
+				"body_b64":  base64.StdEncoding.EncodeToString(ctx.Request.Body),
+				"is_base64": ctx.Request.IsBase64,
+			})
+		}
+	case "parse_json_echo":
+		return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			value, err := ctx.JSONValue()
+			if err != nil {
+				return nil, err
+			}
+			return apptheory.JSON(200, value)
+		}
+	case "panic":
+		return func(_ *apptheory.Context) (*apptheory.Response, error) {
+			panic("boom")
+		}
+	case "binary_body":
+		return func(_ *apptheory.Context) (*apptheory.Response, error) {
+			return apptheory.Binary(200, []byte{0x00, 0x01, 0x02}, "application/octet-stream"), nil
+		}
+	case "unauthorized":
+		return func(_ *apptheory.Context) (*apptheory.Response, error) {
+			return nil, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+		}
+	case "validation_failed":
+		return func(_ *apptheory.Context) (*apptheory.Response, error) {
+			return nil, &apptheory.AppError{Code: "app.validation_failed", Message: "validation failed"}
+		}
+	default:
+		return nil
+	}
+}
+
+func compareFixtureResponse(f Fixture, actual apptheory.Response, logs []FixtureLogRecord, metrics []FixtureMetricRecord, spans []FixtureSpanRecord) error {
+	expected := f.Expect.Response
+
+	expectedHeaders := canonicalizeHeaders(expected.Headers)
+	actualHeaders := canonicalizeHeaders(actual.Headers)
+
+	if expected.Status != actual.Status {
+		return fmt.Errorf("status: expected %d, got %d", expected.Status, actual.Status)
+	}
+	if expected.IsBase64 != actual.IsBase64 {
+		return fmt.Errorf("is_base64: expected %v, got %v", expected.IsBase64, actual.IsBase64)
+	}
+	if !equalStringSlices(expected.Cookies, actual.Cookies) {
+		return fmt.Errorf("cookies mismatch")
+	}
+	if !equalHeaders(expectedHeaders, actualHeaders) {
+		return fmt.Errorf("headers mismatch")
+	}
+
+	if len(expected.BodyJSON) > 0 {
+		var expectedJSON any
+		if err := json.Unmarshal(expected.BodyJSON, &expectedJSON); err != nil {
+			return fmt.Errorf("parse expected body_json: %w", err)
+		}
+		var actualJSON any
+		if err := json.Unmarshal(actual.Body, &actualJSON); err != nil {
+			return fmt.Errorf("parse actual response body as json: %w", err)
+		}
+		if !jsonEqual(expectedJSON, actualJSON) {
+			return fmt.Errorf("body_json mismatch")
+		}
+		if !reflect.DeepEqual(f.Expect.Logs, logs) {
+			return fmt.Errorf("logs mismatch")
+		}
+		if !reflect.DeepEqual(f.Expect.Metrics, metrics) {
+			return fmt.Errorf("metrics mismatch")
+		}
+		if !reflect.DeepEqual(f.Expect.Spans, spans) {
+			return fmt.Errorf("spans mismatch")
+		}
+		return nil
+	}
+
+	var expectedBodyBytes []byte
+	if expected.Body == nil {
+		expectedBodyBytes = nil
+	} else {
+		var err error
+		expectedBodyBytes, err = decodeFixtureBody(*expected.Body)
+		if err != nil {
+			return fmt.Errorf("decode expected body: %w", err)
+		}
+	}
+	if !equalBytes(expectedBodyBytes, actual.Body) {
+		return fmt.Errorf("body mismatch")
+	}
+
+	if !reflect.DeepEqual(f.Expect.Logs, logs) {
+		return fmt.Errorf("logs mismatch")
+	}
+	if !reflect.DeepEqual(f.Expect.Metrics, metrics) {
+		return fmt.Errorf("metrics mismatch")
+	}
+	if !reflect.DeepEqual(f.Expect.Spans, spans) {
+		return fmt.Errorf("spans mismatch")
+	}
+	return nil
+}

--- a/contract-tests/runners/go/runner.go
+++ b/contract-tests/runners/go/runner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strings"
 )
 
 type actualResponseForCompare struct {
@@ -19,6 +20,13 @@ type actualResponseForCompare struct {
 }
 
 func runFixture(f Fixture) error {
+	if strings.EqualFold(strings.TrimSpace(f.Tier), "p0") {
+		return runFixtureP0(f)
+	}
+	return runFixtureLegacy(f)
+}
+
+func runFixtureLegacy(f Fixture) error {
 	app, err := newFixtureApp(f.Setup, f.Tier)
 	if err != nil {
 		return fmt.Errorf("setup app: %w", err)
@@ -113,6 +121,11 @@ func jsonEqual(a, b any) bool {
 func printFailure(f Fixture, err error) {
 	fmt.Fprintf(os.Stderr, "FAIL %s — %s\n", f.ID, f.Name)
 	fmt.Fprintf(os.Stderr, "  %v\n", err)
+
+	if strings.EqualFold(strings.TrimSpace(f.Tier), "p0") {
+		printFailureP0(f)
+		return
+	}
 
 	app, appErr := newFixtureApp(f.Setup, f.Tier)
 	req, reqErr := canonicalizeRequest(f.Input.Request)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,75 @@
+package apptheory
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AppError is a portable, client-safe error with a stable error code.
+type AppError struct {
+	Code    string
+	Message string
+}
+
+func (e *AppError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func statusForErrorCode(code string) int {
+	switch code {
+	case "app.bad_request", "app.validation_failed":
+		return 400
+	case "app.unauthorized":
+		return 401
+	case "app.forbidden":
+		return 403
+	case "app.not_found":
+		return 404
+	case "app.method_not_allowed":
+		return 405
+	case "app.conflict":
+		return 409
+	case "app.too_large":
+		return 413
+	case "app.rate_limited":
+		return 429
+	case "app.overloaded":
+		return 503
+	case "app.internal":
+		return 500
+	default:
+		return 500
+	}
+}
+
+func errorResponse(code, message string, headers map[string][]string) Response {
+	if headers == nil {
+		headers = map[string][]string{}
+	}
+	headers = cloneHeaders(headers)
+	headers["content-type"] = []string{"application/json; charset=utf-8"}
+
+	body, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+
+	return Response{
+		Status:   statusForErrorCode(code),
+		Headers:  headers,
+		Cookies:  nil,
+		Body:     body,
+		IsBase64: false,
+	}
+}
+
+func responseForError(err error) Response {
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		return errorResponse(appErr.Code, appErr.Message, nil)
+	}
+	return errorResponse("app.internal", "internal error", nil)
+}

--- a/request.go
+++ b/request.go
@@ -1,0 +1,121 @@
+package apptheory
+
+import (
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Request is the canonical HTTP request model used by the AppTheory runtime.
+type Request struct {
+	Method   string
+	Path     string
+	Query    map[string][]string
+	Headers  map[string][]string
+	Cookies  map[string]string
+	Body     []byte
+	IsBase64 bool
+}
+
+func normalizeRequest(in Request) (Request, error) {
+	out := in
+	out.Method = strings.ToUpper(strings.TrimSpace(in.Method))
+	out.Path = normalizePath(in.Path)
+	out.Query = cloneQuery(in.Query)
+
+	out.Headers = canonicalizeHeaders(in.Headers)
+
+	if in.IsBase64 {
+		decoded, err := base64.StdEncoding.DecodeString(string(in.Body))
+		if err != nil {
+			return Request{}, &AppError{Code: "app.bad_request", Message: fmt.Sprintf("invalid base64: %v", err)}
+		}
+		out.Body = decoded
+	} else {
+		out.Body = append([]byte(nil), in.Body...)
+	}
+
+	out.Cookies = parseCookies(out.Headers["cookie"])
+	out.IsBase64 = in.IsBase64
+	return out, nil
+}
+
+func normalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if i := strings.Index(path, "?"); i >= 0 {
+		path = path[:i]
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func parseCookies(cookieHeaders []string) map[string]string {
+	out := map[string]string{}
+	for _, header := range cookieHeaders {
+		parts := strings.Split(header, ";")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			name, value, ok := strings.Cut(part, "=")
+			if !ok {
+				continue
+			}
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			out[name] = strings.TrimSpace(value)
+		}
+	}
+	return out
+}
+
+func canonicalizeHeaders(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return map[string][]string{}
+	}
+
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := map[string][]string{}
+	for _, key := range keys {
+		values := in[key]
+		lower := strings.ToLower(strings.TrimSpace(key))
+		if lower == "" {
+			continue
+		}
+		out[lower] = append(out[lower], values...)
+	}
+	return out
+}
+
+func cloneHeaders(in map[string][]string) map[string][]string {
+	out := map[string][]string{}
+	for k, v := range in {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+func cloneQuery(in map[string][]string) map[string][]string {
+	out := map[string][]string{}
+	for k, v := range in {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}

--- a/response.go
+++ b/response.go
@@ -1,0 +1,79 @@
+package apptheory
+
+import "encoding/json"
+
+// Response is the canonical HTTP response model returned by AppTheory handlers.
+type Response struct {
+	Status   int
+	Headers  map[string][]string
+	Cookies  []string
+	Body     []byte
+	IsBase64 bool
+}
+
+// Text builds a text/plain response (utf-8).
+func Text(status int, body string) *Response {
+	return &Response{
+		Status: status,
+		Headers: map[string][]string{
+			"content-type": []string{"text/plain; charset=utf-8"},
+		},
+		Body:     []byte(body),
+		IsBase64: false,
+	}
+}
+
+// JSON builds an application/json response (utf-8).
+func JSON(status int, value any) (*Response, error) {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return &Response{
+		Status: status,
+		Headers: map[string][]string{
+			"content-type": []string{"application/json; charset=utf-8"},
+		},
+		Body:     body,
+		IsBase64: false,
+	}, nil
+}
+
+// MustJSON builds an application/json response (utf-8) and panics on marshal failure.
+func MustJSON(status int, value any) *Response {
+	resp, err := JSON(status, value)
+	if err != nil {
+		panic(err)
+	}
+	return resp
+}
+
+// Binary builds a base64-encoded response for binary body content.
+func Binary(status int, body []byte, contentType string) *Response {
+	headers := map[string][]string{}
+	if contentType != "" {
+		headers["content-type"] = []string{contentType}
+	}
+	return &Response{
+		Status:   status,
+		Headers:  headers,
+		Body:     append([]byte(nil), body...),
+		IsBase64: true,
+	}
+}
+
+func normalizeResponse(in *Response) Response {
+	if in == nil {
+		return errorResponse("app.internal", "internal error", nil)
+	}
+	out := *in
+	if out.Status == 0 {
+		out.Status = 200
+	}
+	out.Headers = canonicalizeHeaders(out.Headers)
+	out.Body = append([]byte(nil), out.Body...)
+	if out.Cookies != nil {
+		out.Cookies = append([]string(nil), out.Cookies...)
+	}
+	return out
+}

--- a/router.go
+++ b/router.go
@@ -1,0 +1,107 @@
+package apptheory
+
+import (
+	"sort"
+	"strings"
+)
+
+// Handler is the request handler signature for AppTheory apps.
+type Handler func(*Context) (*Response, error)
+
+type route struct {
+	Method   string
+	Pattern  string
+	Segments []string
+	Handler  Handler
+}
+
+type router struct {
+	routes []route
+}
+
+func newRouter() *router {
+	return &router{}
+}
+
+func (r *router) add(method, pattern string, handler Handler) {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	pattern = normalizePath(pattern)
+	r.routes = append(r.routes, route{
+		Method:   method,
+		Pattern:  pattern,
+		Segments: splitPath(pattern),
+		Handler:  handler,
+	})
+}
+
+type routeMatch struct {
+	Route  route
+	Params map[string]string
+}
+
+func (r *router) match(method, path string) (*routeMatch, []string) {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	pathSegments := splitPath(path)
+
+	var allowed []string
+	for _, candidate := range r.routes {
+		params, ok := matchPath(candidate.Segments, pathSegments)
+		if !ok {
+			continue
+		}
+		allowed = append(allowed, candidate.Method)
+		if candidate.Method == method {
+			return &routeMatch{Route: candidate, Params: params}, allowed
+		}
+	}
+	return nil, allowed
+}
+
+func splitPath(path string) []string {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+func matchPath(patternSegments, pathSegments []string) (map[string]string, bool) {
+	if len(patternSegments) != len(pathSegments) {
+		return nil, false
+	}
+
+	params := map[string]string{}
+	for i, pattern := range patternSegments {
+		value := pathSegments[i]
+		if value == "" {
+			return nil, false
+		}
+		if strings.HasPrefix(pattern, "{") && strings.HasSuffix(pattern, "}") && len(pattern) > 2 {
+			name := pattern[1 : len(pattern)-1]
+			params[name] = value
+			continue
+		}
+		if pattern != value {
+			return nil, false
+		}
+	}
+	return params, true
+}
+
+func formatAllowHeader(methods []string) string {
+	set := map[string]struct{}{}
+	for _, m := range methods {
+		m = strings.ToUpper(strings.TrimSpace(m))
+		if m == "" {
+			continue
+		}
+		set[m] = struct{}{}
+	}
+	var uniq []string
+	for m := range set {
+		uniq = append(uniq, m)
+	}
+	sort.Strings(uniq)
+	return strings.Join(uniq, ", ")
+}

--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,83 @@
+package apptheory
+
+import (
+	"context"
+	"errors"
+)
+
+func (a *App) Handle(method, pattern string, handler Handler) *App {
+	if a == nil {
+		return a
+	}
+	if a.router == nil {
+		a.router = newRouter()
+	}
+	a.router.add(method, pattern, handler)
+	return a
+}
+
+func (a *App) Get(pattern string, handler Handler) *App {
+	return a.Handle("GET", pattern, handler)
+}
+
+func (a *App) Post(pattern string, handler Handler) *App {
+	return a.Handle("POST", pattern, handler)
+}
+
+func (a *App) Put(pattern string, handler Handler) *App {
+	return a.Handle("PUT", pattern, handler)
+}
+
+func (a *App) Delete(pattern string, handler Handler) *App {
+	return a.Handle("DELETE", pattern, handler)
+}
+
+func (a *App) Serve(ctx context.Context, req Request) (resp Response) {
+	if a == nil || a.router == nil {
+		return errorResponse("app.internal", "internal error", nil)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	normalized, err := normalizeRequest(req)
+	if err != nil {
+		return responseForError(err)
+	}
+
+	match, allowed := a.router.match(normalized.Method, normalized.Path)
+	if match == nil {
+		if len(allowed) > 0 {
+			headers := map[string][]string{
+				"allow": []string{formatAllowHeader(allowed)},
+			}
+			return errorResponse("app.method_not_allowed", "method not allowed", headers)
+		}
+		return errorResponse("app.not_found", "not found", nil)
+	}
+
+	requestCtx := &Context{
+		ctx:     ctx,
+		Request: normalized,
+		Params:  match.Params,
+		clock:   a.clock,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			resp = errorResponse("app.internal", "internal error", nil)
+		}
+	}()
+
+	out, handlerErr := match.Route.Handler(requestCtx)
+	if handlerErr != nil {
+		var appErr *AppError
+		if errors.As(handlerErr, &appErr) {
+			return errorResponse(appErr.Code, appErr.Message, nil)
+		}
+		return errorResponse("app.internal", "internal error", nil)
+	}
+
+	return normalizeResponse(out)
+}
+

--- a/testkit/testkit.go
+++ b/testkit/testkit.go
@@ -1,0 +1,69 @@
+package testkit
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/theory-cloud/apptheory"
+)
+
+// Env is a deterministic local test environment for AppTheory apps.
+type Env struct {
+	Clock *ManualClock
+}
+
+func New() *Env {
+	return NewWithTime(time.Unix(0, 0).UTC())
+}
+
+func NewWithTime(now time.Time) *Env {
+	return &Env{Clock: NewManualClock(now)}
+}
+
+func (e *Env) App(opts ...apptheory.Option) *apptheory.App {
+	combined := make([]apptheory.Option, 0, len(opts)+1)
+	combined = append(combined, apptheory.WithClock(e.Clock))
+	combined = append(combined, opts...)
+	return apptheory.New(combined...)
+}
+
+func (e *Env) Invoke(ctx context.Context, app *apptheory.App, req apptheory.Request) apptheory.Response {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return app.Serve(ctx, req)
+}
+
+// ManualClock is a deterministic, mutable clock for tests.
+type ManualClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+var _ apptheory.Clock = (*ManualClock)(nil)
+
+func NewManualClock(now time.Time) *ManualClock {
+	return &ManualClock{now: now}
+}
+
+func (c *ManualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *ManualClock) Set(now time.Time) {
+	c.mu.Lock()
+	c.now = now
+	c.mu.Unlock()
+}
+
+func (c *ManualClock) Advance(d time.Duration) time.Time {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	out := c.now
+	c.mu.Unlock()
+	return out
+}
+

--- a/testkit/testkit_test.go
+++ b/testkit/testkit_test.go
@@ -1,0 +1,41 @@
+package testkit_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/theory-cloud/apptheory"
+	"github.com/theory-cloud/apptheory/testkit"
+)
+
+func TestEnvDeterministicTime(t *testing.T) {
+	now := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	env := testkit.NewWithTime(now)
+
+	app := env.App()
+	app.Get("/now", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		return apptheory.MustJSON(200, map[string]any{
+			"unix": ctx.Now().Unix(),
+		}), nil
+	})
+
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/now",
+	})
+
+	if resp.Status != 200 {
+		t.Fatalf("expected status 200, got %d", resp.Status)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("parse response json: %v", err)
+	}
+	if body["unix"] != float64(now.Unix()) {
+		t.Fatalf("expected unix %d, got %#v", now.Unix(), body["unix"])
+	}
+}
+


### PR DESCRIPTION
Implements the Go runtime P0 core per the contract v0 fixtures.

- Adds Go runtime core: router + canonical request/response normalization + portable error envelope.
- Adds `github.com/theory-cloud/apptheory/testkit` for deterministic local invocation (injectable clock).
- Updates the Go contract runner to execute P0 fixtures against the real Go runtime (P1/P2 remain runner-internal for now).

Validation: `make rubric`
