### PR TITLE
M5: TypeScript runtime P0 core

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -2,3 +2,19 @@
 
 This folder contains the TypeScript SDK/runtime for AppTheory.
 
+The portable runtime behavior is defined by the fixture-backed contract:
+`docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
+
+## Minimal local invocation (P0)
+
+```ts
+import { createTestEnv, text } from "@theory-cloud/apptheory";
+
+const env = createTestEnv();
+const app = env.app();
+
+app.get("/ping", () => text(200, "pong"));
+
+const resp = await env.invoke(app, { method: "GET", path: "/ping" });
+console.log(resp.status); // 200
+```

--- a/ts/dist/index.d.ts
+++ b/ts/dist/index.d.ts
@@ -1,2 +1,83 @@
-export declare function createApp(): Record<string, never>;
+export type Headers = Record<string, string[]>;
 
+export type Query = Record<string, string[]>;
+
+export interface Request {
+  method: string;
+  path: string;
+  query?: Query;
+  headers?: Headers;
+  body?: Uint8Array;
+  isBase64?: boolean;
+}
+
+export interface Response {
+  status: number;
+  headers: Headers;
+  cookies: string[];
+  body: Uint8Array;
+  isBase64: boolean;
+}
+
+export interface Clock {
+  now(): Date;
+}
+
+export declare class RealClock implements Clock {
+  now(): Date;
+}
+
+export declare class ManualClock implements Clock {
+  constructor(now?: Date);
+  now(): Date;
+  set(now: Date): void;
+  advance(ms: number): Date;
+}
+
+export declare class AppError extends Error {
+  code: string;
+  constructor(code: string, message: string);
+}
+
+export declare class Context {
+  readonly ctx: unknown | null;
+  readonly request: {
+    method: string;
+    path: string;
+    query: Query;
+    headers: Headers;
+    cookies: Record<string, string>;
+    body: Uint8Array;
+    isBase64: boolean;
+  };
+  readonly params: Record<string, string>;
+  now(): Date;
+  param(name: string): string;
+  jsonValue(): unknown;
+}
+
+export type Handler = (ctx: Context) => Response | Promise<Response>;
+
+export declare class App {
+  handle(method: string, pattern: string, handler: Handler): this;
+  get(pattern: string, handler: Handler): this;
+  post(pattern: string, handler: Handler): this;
+  put(pattern: string, handler: Handler): this;
+  delete(pattern: string, handler: Handler): this;
+  serve(request: Request, ctx?: unknown): Promise<Response>;
+}
+
+export declare function createApp(options?: { clock?: Clock }): App;
+
+export declare function text(status: number, body: string): Response;
+export declare function json(status: number, value: unknown): Response;
+export declare function binary(status: number, body: Uint8Array, contentType?: string): Response;
+
+export declare class TestEnv {
+  readonly clock: ManualClock;
+  constructor(options?: { now?: Date });
+  app(options?: { clock?: Clock }): App;
+  invoke(app: App, request: Request, ctx?: unknown): Promise<Response>;
+}
+
+export declare function createTestEnv(options?: { now?: Date }): TestEnv;

--- a/ts/dist/index.js
+++ b/ts/dist/index.js
@@ -1,4 +1,415 @@
-export function createApp() {
-  return {};
+import { Buffer } from "node:buffer";
+
+export class AppError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+    this.name = "AppError";
+  }
 }
 
+export class RealClock {
+  now() {
+    return new Date();
+  }
+}
+
+export class ManualClock {
+  constructor(now = new Date(0)) {
+    this._now = new Date(now.valueOf());
+  }
+
+  now() {
+    return new Date(this._now.valueOf());
+  }
+
+  set(now) {
+    this._now = new Date(now.valueOf());
+  }
+
+  advance(ms) {
+    this._now = new Date(this._now.valueOf() + ms);
+    return this.now();
+  }
+}
+
+export class Context {
+  constructor({ request, params, clock, ctx }) {
+    this.ctx = ctx ?? null;
+    this.request = request;
+    this.params = params ?? {};
+    this._clock = clock ?? new RealClock();
+  }
+
+  now() {
+    return this._clock.now();
+  }
+
+  param(name) {
+    return this.params?.[name] ?? "";
+  }
+
+  jsonValue() {
+    if (!hasJSONContentType(this.request.headers)) {
+      throw new AppError("app.bad_request", "invalid json");
+    }
+    if (this.request.body.length === 0) {
+      return null;
+    }
+    try {
+      return JSON.parse(this.request.body.toString("utf8"));
+    } catch {
+      throw new AppError("app.bad_request", "invalid json");
+    }
+  }
+}
+
+export function text(status, body) {
+  return normalizeResponse({
+    status,
+    headers: { "content-type": ["text/plain; charset=utf-8"] },
+    cookies: [],
+    body: Buffer.from(String(body), "utf8"),
+    isBase64: false,
+  });
+}
+
+export function json(status, value) {
+  let serialized;
+  try {
+    serialized = JSON.stringify(value);
+  } catch (err) {
+    throw new Error(`json serialization failed: ${String(err)}`);
+  }
+
+  return normalizeResponse({
+    status,
+    headers: { "content-type": ["application/json; charset=utf-8"] },
+    cookies: [],
+    body: Buffer.from(serialized, "utf8"),
+    isBase64: false,
+  });
+}
+
+export function binary(status, body, contentType) {
+  const headers = {};
+  if (contentType) {
+    headers["content-type"] = [String(contentType)];
+  }
+  return normalizeResponse({
+    status,
+    headers,
+    cookies: [],
+    body,
+    isBase64: true,
+  });
+}
+
+export class App {
+  constructor({ clock } = {}) {
+    this._router = new Router();
+    this._clock = clock ?? new RealClock();
+  }
+
+  handle(method, pattern, handler) {
+    this._router.add(method, pattern, handler);
+    return this;
+  }
+
+  get(pattern, handler) {
+    return this.handle("GET", pattern, handler);
+  }
+
+  post(pattern, handler) {
+    return this.handle("POST", pattern, handler);
+  }
+
+  put(pattern, handler) {
+    return this.handle("PUT", pattern, handler);
+  }
+
+  delete(pattern, handler) {
+    return this.handle("DELETE", pattern, handler);
+  }
+
+  async serve(request, ctx) {
+    let normalized;
+    try {
+      normalized = normalizeRequest(request);
+    } catch (err) {
+      return responseForError(err);
+    }
+
+    const { match, allowed } = this._router.match(normalized.method, normalized.path);
+    if (!match) {
+      if (allowed.length > 0) {
+        return errorResponse("app.method_not_allowed", "method not allowed", {
+          allow: [formatAllowHeader(allowed)],
+        });
+      }
+      return errorResponse("app.not_found", "not found");
+    }
+
+    const requestCtx = new Context({
+      request: normalized,
+      params: match.params,
+      clock: this._clock,
+      ctx,
+    });
+
+    try {
+      const out = await match.route.handler(requestCtx);
+      return normalizeResponse(out);
+    } catch (err) {
+      return responseForError(err);
+    }
+  }
+}
+
+export function createApp(options = {}) {
+  return new App(options);
+}
+
+export class TestEnv {
+  constructor({ now } = {}) {
+    this.clock = new ManualClock(now ?? new Date(0));
+  }
+
+  app(options = {}) {
+    return createApp({ ...options, clock: this.clock });
+  }
+
+  invoke(app, request, ctx) {
+    return app.serve(request, ctx);
+  }
+}
+
+export function createTestEnv(options = {}) {
+  return new TestEnv(options);
+}
+
+class Router {
+  constructor() {
+    this._routes = [];
+  }
+
+  add(method, pattern, handler) {
+    const normalizedMethod = normalizeMethod(method);
+    const normalizedPattern = normalizePath(pattern);
+    this._routes.push({
+      method: normalizedMethod,
+      pattern: normalizedPattern,
+      segments: splitPath(normalizedPattern),
+      handler,
+    });
+  }
+
+  match(method, path) {
+    const normalizedMethod = normalizeMethod(method);
+    const pathSegments = splitPath(normalizePath(path));
+
+    const allowed = [];
+    for (const route of this._routes) {
+      const params = matchPath(route.segments, pathSegments);
+      if (!params) {
+        continue;
+      }
+      allowed.push(route.method);
+      if (route.method === normalizedMethod) {
+        return { match: { route, params }, allowed };
+      }
+    }
+    return { match: null, allowed };
+  }
+}
+
+function normalizeMethod(method) {
+  return String(method ?? "").trim().toUpperCase();
+}
+
+function normalizePath(path) {
+  let value = String(path ?? "").trim();
+  if (!value) value = "/";
+  const idx = value.indexOf("?");
+  if (idx >= 0) value = value.slice(0, idx);
+  if (!value.startsWith("/")) value = `/${value}`;
+  if (!value) value = "/";
+  return value;
+}
+
+function splitPath(path) {
+  const value = normalizePath(path).replace(/^\//, "");
+  if (!value) return [];
+  return value.split("/");
+}
+
+function matchPath(patternSegments, pathSegments) {
+  if (patternSegments.length !== pathSegments.length) return null;
+
+  const params = {};
+  for (let i = 0; i < patternSegments.length; i += 1) {
+    const pattern = patternSegments[i];
+    const segment = pathSegments[i];
+    if (!segment) return null;
+
+    if (pattern.startsWith("{") && pattern.endsWith("}") && pattern.length > 2) {
+      const name = pattern.slice(1, -1);
+      params[name] = segment;
+      continue;
+    }
+    if (pattern !== segment) return null;
+  }
+  return params;
+}
+
+function canonicalizeHeaders(headers) {
+  const out = {};
+  if (!headers) return out;
+  const keys = Object.keys(headers).sort();
+  for (const key of keys) {
+    const lower = String(key).trim().toLowerCase();
+    if (!lower) continue;
+    const values = Array.isArray(headers[key]) ? headers[key] : [headers[key]];
+    if (!out[lower]) out[lower] = [];
+    out[lower].push(...values.map((v) => String(v)));
+  }
+  return out;
+}
+
+function cloneQuery(query) {
+  const out = {};
+  if (!query) return out;
+  for (const [key, values] of Object.entries(query)) {
+    out[key] = Array.isArray(values) ? [...values] : [String(values)];
+  }
+  return out;
+}
+
+function parseCookies(cookieHeaders) {
+  const out = {};
+  for (const header of cookieHeaders ?? []) {
+    for (const part of String(header).split(";")) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      const idx = trimmed.indexOf("=");
+      if (idx <= 0) continue;
+      const name = trimmed.slice(0, idx).trim();
+      if (!name) continue;
+      const value = trimmed.slice(idx + 1).trim();
+      out[name] = value;
+    }
+  }
+  return out;
+}
+
+function toBuffer(body) {
+  if (body === null || body === undefined) return Buffer.alloc(0);
+  if (Buffer.isBuffer(body)) return Buffer.from(body);
+  if (body instanceof Uint8Array) return Buffer.from(body);
+  if (typeof body === "string") return Buffer.from(body, "utf8");
+  throw new TypeError("body must be Uint8Array, Buffer, or string");
+}
+
+function normalizeRequest(request) {
+  const out = {};
+  out.method = normalizeMethod(request?.method);
+  out.path = normalizePath(request?.path);
+  out.query = cloneQuery(request?.query);
+  out.headers = canonicalizeHeaders(request?.headers);
+
+  const rawBody = toBuffer(request?.body);
+  out.isBase64 = Boolean(request?.isBase64);
+  if (out.isBase64) {
+    try {
+      out.body = Buffer.from(rawBody.toString("utf8"), "base64");
+    } catch {
+      throw new AppError("app.bad_request", "invalid base64");
+    }
+  } else {
+    out.body = rawBody;
+  }
+
+  out.cookies = parseCookies(out.headers.cookie);
+  return out;
+}
+
+function normalizeResponse(response) {
+  if (!response) {
+    return errorResponse("app.internal", "internal error");
+  }
+
+  const out = {};
+  out.status = response.status ?? 200;
+  out.headers = canonicalizeHeaders(response.headers);
+  out.cookies = Array.isArray(response.cookies) ? [...response.cookies] : [];
+  out.body = toBuffer(response.body);
+  out.isBase64 = Boolean(response.isBase64);
+  return out;
+}
+
+function hasJSONContentType(headers) {
+  for (const value of headers?.["content-type"] ?? []) {
+    const normalized = String(value).trim().toLowerCase();
+    if (normalized.startsWith("application/json")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function statusForErrorCode(code) {
+  switch (code) {
+    case "app.bad_request":
+    case "app.validation_failed":
+      return 400;
+    case "app.unauthorized":
+      return 401;
+    case "app.forbidden":
+      return 403;
+    case "app.not_found":
+      return 404;
+    case "app.method_not_allowed":
+      return 405;
+    case "app.conflict":
+      return 409;
+    case "app.too_large":
+      return 413;
+    case "app.rate_limited":
+      return 429;
+    case "app.overloaded":
+      return 503;
+    case "app.internal":
+      return 500;
+    default:
+      return 500;
+  }
+}
+
+function errorResponse(code, message, headers = {}) {
+  const outHeaders = { ...canonicalizeHeaders(headers) };
+  outHeaders["content-type"] = ["application/json; charset=utf-8"];
+
+  return normalizeResponse({
+    status: statusForErrorCode(code),
+    headers: outHeaders,
+    cookies: [],
+    body: Buffer.from(JSON.stringify({ error: { code, message } }), "utf8"),
+    isBase64: false,
+  });
+}
+
+function responseForError(err) {
+  if (err instanceof AppError) {
+    return errorResponse(err.code, err.message);
+  }
+  return errorResponse("app.internal", "internal error");
+}
+
+function formatAllowHeader(methods) {
+  const unique = new Set();
+  for (const m of methods ?? []) {
+    const normalized = normalizeMethod(m);
+    if (normalized) unique.add(normalized);
+  }
+  return [...unique].sort().join(", ");
+}


### PR DESCRIPTION
Implements the TypeScript runtime P0 core per the contract v0 fixtures.

- Adds TS runtime core (router + request/response normalization + portable error envelope): `ts/dist/index.js`.
- Adds public TS testkit (deterministic clock + local invocation): `createTestEnv`, `ManualClock`.
- Updates the TS contract runner to execute P0 fixtures against the real TS runtime (P1/P2 remain runner-internal for now).

Validation: `make rubric`
