### PR TITLE
M6: Python runtime P0 core

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -2,3 +2,19 @@
 
 This folder contains the Python SDK/runtime for AppTheory.
 
+The portable runtime behavior is defined by the fixture-backed contract:
+`docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
+
+## Minimal local invocation (P0)
+
+```py
+from apptheory import Request, create_test_env, text
+
+env = create_test_env()
+app = env.app()
+
+app.get("/ping", lambda ctx: text(200, "pong"))
+
+resp = env.invoke(app, Request(method="GET", path="/ping"))
+assert resp.status == 200
+```

--- a/py/src/apptheory/__init__.py
+++ b/py/src/apptheory/__init__.py
@@ -2,8 +2,28 @@
 
 from __future__ import annotations
 
+from apptheory.app import App, create_app
+from apptheory.clock import Clock, ManualClock, RealClock
+from apptheory.context import Context
+from apptheory.errors import AppError
+from apptheory.request import Request
+from apptheory.response import Response, binary, json, text
+from apptheory.testkit import TestEnv, create_test_env
 
-class App:
-    def __init__(self) -> None:
-        return
+__all__ = [
+    "App",
+    "AppError",
+    "Clock",
+    "Context",
+    "ManualClock",
+    "RealClock",
+    "Request",
+    "Response",
+    "TestEnv",
+    "binary",
+    "create_app",
+    "create_test_env",
+    "json",
+    "text",
+]
 

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from apptheory.clock import Clock, RealClock
+from apptheory.context import Context
+from apptheory.errors import AppError, error_response, response_for_error
+from apptheory.request import Request, normalize_request
+from apptheory.response import Response, normalize_response
+from apptheory.router import Router
+
+Handler = Callable[[Context], Response]
+
+
+@dataclass(slots=True)
+class App:
+    _router: Router
+    _clock: Clock
+
+    def __init__(self, *, clock: Clock | None = None) -> None:
+        self._router = Router()
+        self._clock = clock or RealClock()
+
+    def handle(self, method: str, pattern: str, handler: Handler) -> App:
+        self._router.add(method, pattern, handler)
+        return self
+
+    def get(self, pattern: str, handler: Handler) -> App:
+        return self.handle("GET", pattern, handler)
+
+    def post(self, pattern: str, handler: Handler) -> App:
+        return self.handle("POST", pattern, handler)
+
+    def put(self, pattern: str, handler: Handler) -> App:
+        return self.handle("PUT", pattern, handler)
+
+    def delete(self, pattern: str, handler: Handler) -> App:
+        return self.handle("DELETE", pattern, handler)
+
+    def serve(self, request: Request, ctx: Any | None = None) -> Response:
+        try:
+            normalized = normalize_request(request)
+        except Exception as exc:  # noqa: BLE001
+            return response_for_error(exc)
+
+        match, allowed = self._router.match(normalized.method, normalized.path)
+        if match is None:
+            if allowed:
+                return error_response(
+                    "app.method_not_allowed",
+                    "method not allowed",
+                    headers={"allow": [self._router.format_allow_header(allowed)]},
+                )
+            return error_response("app.not_found", "not found")
+
+        request_ctx = Context(request=normalized, params=match.params, clock=self._clock, ctx=ctx)
+
+        try:
+            resp = match.handler(request_ctx)
+        except AppError as exc:
+            return error_response(exc.code, exc.message)
+        except Exception:  # noqa: BLE001
+            return error_response("app.internal", "internal error")
+
+        return normalize_response(resp)
+
+
+def create_app(*, clock: Clock | None = None) -> App:
+    return App(clock=clock)
+

--- a/py/src/apptheory/clock.py
+++ b/py/src/apptheory/clock.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Clock(Protocol):
+    def now(self) -> dt.datetime: ...
+
+
+@dataclass(slots=True)
+class RealClock:
+    def now(self) -> dt.datetime:
+        return dt.datetime.now(tz=dt.UTC)
+
+
+@dataclass(slots=True)
+class ManualClock:
+    _now: dt.datetime
+
+    def __init__(self, now: dt.datetime | None = None) -> None:
+        self._now = now or dt.datetime.fromtimestamp(0, tz=dt.UTC)
+
+    def now(self) -> dt.datetime:
+        return self._now
+
+    def set(self, now: dt.datetime) -> None:
+        self._now = now
+
+    def advance(self, delta: dt.timedelta) -> dt.datetime:
+        self._now = self._now + delta
+        return self._now
+

--- a/py/src/apptheory/context.py
+++ b/py/src/apptheory/context.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json as jsonlib
+from dataclasses import dataclass
+from typing import Any
+
+from apptheory.clock import Clock, RealClock
+from apptheory.errors import AppError
+from apptheory.request import Request
+
+
+@dataclass(slots=True)
+class Context:
+    request: Request
+    params: dict[str, str]
+    clock: Clock
+    ctx: Any | None
+
+    def __init__(
+        self,
+        *,
+        request: Request,
+        params: dict[str, str] | None = None,
+        clock: Clock | None = None,
+        ctx: Any | None = None,
+    ) -> None:
+        self.request = request
+        self.params = params or {}
+        self.clock = clock or RealClock()
+        self.ctx = ctx
+
+    def now(self):
+        return self.clock.now()
+
+    def param(self, name: str) -> str:
+        return self.params.get(name, "")
+
+    def json_value(self) -> Any:
+        if not _has_json_content_type(self.request.headers):
+            raise AppError("app.bad_request", "invalid json")
+        if not self.request.body:
+            return None
+        try:
+            return jsonlib.loads(self.request.body.decode("utf-8"))
+        except Exception:  # noqa: BLE001
+            raise AppError("app.bad_request", "invalid json") from None
+
+
+def _has_json_content_type(headers: dict[str, list[str]]) -> bool:
+    for value in headers.get("content-type", []):
+        v = str(value).strip().lower()
+        if v.startswith("application/json"):
+            return True
+    return False
+

--- a/py/src/apptheory/errors.py
+++ b/py/src/apptheory/errors.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from apptheory.response import Response, normalize_response
+
+
+@dataclass(slots=True)
+class AppError(Exception):
+    code: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}"
+
+
+def status_for_error_code(code: str) -> int:
+    match code:
+        case "app.bad_request" | "app.validation_failed":
+            return 400
+        case "app.unauthorized":
+            return 401
+        case "app.forbidden":
+            return 403
+        case "app.not_found":
+            return 404
+        case "app.method_not_allowed":
+            return 405
+        case "app.conflict":
+            return 409
+        case "app.too_large":
+            return 413
+        case "app.rate_limited":
+            return 429
+        case "app.overloaded":
+            return 503
+        case "app.internal":
+            return 500
+        case _:
+            return 500
+
+
+def error_response(code: str, message: str, *, headers: dict[str, Any] | None = None) -> Response:
+    headers_out: dict[str, Any] = dict(headers or {})
+    headers_out["content-type"] = ["application/json; charset=utf-8"]
+
+    body = json.dumps(
+        {"error": {"code": code, "message": message}},
+        ensure_ascii=False,
+        sort_keys=True,
+    ).encode("utf-8")
+
+    return normalize_response(
+        Response(
+            status=status_for_error_code(code),
+            headers=headers_out,
+            cookies=[],
+            body=body,
+            is_base64=False,
+        )
+    )
+
+
+def response_for_error(exc: Exception) -> Response:
+    if isinstance(exc, AppError):
+        return error_response(exc.code, exc.message)
+    return error_response("app.internal", "internal error")
+

--- a/py/src/apptheory/request.py
+++ b/py/src/apptheory/request.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+
+from apptheory.errors import AppError
+from apptheory.util import canonicalize_headers, clone_query, normalize_path, parse_cookies, to_bytes
+
+
+@dataclass(slots=True)
+class Request:
+    method: str
+    path: str
+    query: dict[str, list[str]] = field(default_factory=dict)
+    headers: dict[str, object] = field(default_factory=dict)
+    cookies: dict[str, str] = field(default_factory=dict)
+    body: object = b""
+    is_base64: bool = False
+
+
+def normalize_request(req: Request) -> Request:
+    method = str(req.method or "").strip().upper()
+    path = normalize_path(req.path)
+    query = clone_query(req.query)
+    headers = canonicalize_headers(req.headers)
+
+    body = to_bytes(req.body)
+    is_base64 = bool(req.is_base64)
+    if is_base64:
+        try:
+            body = base64.b64decode(body, validate=True)
+        except Exception:  # noqa: BLE001
+            raise AppError("app.bad_request", "invalid base64") from None
+
+    cookies = parse_cookies(headers.get("cookie", []))
+
+    return Request(
+        method=method,
+        path=path,
+        query=query,
+        headers=headers,
+        cookies=cookies,
+        body=body,
+        is_base64=is_base64,
+    )

--- a/py/src/apptheory/response.py
+++ b/py/src/apptheory/response.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json as jsonlib
+from dataclasses import dataclass
+from typing import Any
+
+from apptheory.util import canonicalize_headers, to_bytes
+
+
+@dataclass(slots=True)
+class Response:
+    status: int
+    headers: dict[str, Any]
+    cookies: list[str]
+    body: bytes
+    is_base64: bool
+
+
+def text(status: int, body: str) -> Response:
+    return normalize_response(
+        Response(
+            status=status,
+            headers={"content-type": ["text/plain; charset=utf-8"]},
+            cookies=[],
+            body=str(body).encode("utf-8"),
+            is_base64=False,
+        )
+    )
+
+
+def json(status: int, value: Any) -> Response:
+    body = jsonlib.dumps(value, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return normalize_response(
+        Response(
+            status=status,
+            headers={"content-type": ["application/json; charset=utf-8"]},
+            cookies=[],
+            body=body,
+            is_base64=False,
+        )
+    )
+
+
+def binary(status: int, body: Any, content_type: str | None = None) -> Response:
+    headers: dict[str, Any] = {}
+    if content_type:
+        headers["content-type"] = [str(content_type)]
+    return normalize_response(
+        Response(
+            status=status,
+            headers=headers,
+            cookies=[],
+            body=to_bytes(body),
+            is_base64=True,
+        )
+    )
+
+
+def normalize_response(resp: Response) -> Response:
+    status = int(resp.status or 200)
+    headers = canonicalize_headers(resp.headers)
+    cookies = [str(c) for c in (resp.cookies or [])]
+    body = to_bytes(resp.body)
+    return Response(
+        status=status,
+        headers=headers,
+        cookies=cookies,
+        body=body,
+        is_base64=bool(resp.is_base64),
+    )

--- a/py/src/apptheory/router.py
+++ b/py/src/apptheory/router.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from apptheory.util import normalize_path
+
+
+@dataclass(slots=True)
+class Match:
+    handler: object
+    params: dict[str, str]
+
+
+@dataclass(slots=True)
+class _Route:
+    method: str
+    pattern: str
+    segments: list[str]
+    handler: object
+
+
+class Router:
+    def __init__(self) -> None:
+        self._routes: list[_Route] = []
+
+    def add(self, method: str, pattern: str, handler: object) -> None:
+        method_value = str(method or "").strip().upper()
+        pattern_value = normalize_path(pattern)
+        self._routes.append(
+            _Route(
+                method=method_value,
+                pattern=pattern_value,
+                segments=_split_path(pattern_value),
+                handler=handler,
+            )
+        )
+
+    def match(self, method: str, path: str) -> tuple[Match | None, list[str]]:
+        method_value = str(method or "").strip().upper()
+        path_segments = _split_path(normalize_path(path))
+
+        allowed: list[str] = []
+        for route in self._routes:
+            params = _match_path(route.segments, path_segments)
+            if params is None:
+                continue
+            allowed.append(route.method)
+            if route.method == method_value:
+                return Match(handler=route.handler, params=params), allowed
+
+        return None, allowed
+
+    @staticmethod
+    def format_allow_header(methods: list[str]) -> str:
+        unique = {str(m or "").strip().upper() for m in methods if str(m or "").strip()}
+        return ", ".join(sorted(unique))
+
+
+def _split_path(path: str) -> list[str]:
+    value = normalize_path(path).lstrip("/")
+    if not value:
+        return []
+    return value.split("/")
+
+
+def _match_path(pattern_segments: list[str], path_segments: list[str]) -> dict[str, str] | None:
+    if len(pattern_segments) != len(path_segments):
+        return None
+
+    params: dict[str, str] = {}
+    for pattern, segment in zip(pattern_segments, path_segments, strict=False):
+        if not segment:
+            return None
+        if pattern.startswith("{") and pattern.endswith("}") and len(pattern) > 2:
+            params[pattern[1:-1]] = segment
+            continue
+        if pattern != segment:
+            return None
+
+    return params

--- a/py/src/apptheory/testkit.py
+++ b/py/src/apptheory/testkit.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from apptheory.app import App, create_app
+from apptheory.clock import ManualClock
+from apptheory.request import Request
+from apptheory.response import Response
+
+
+@dataclass(slots=True)
+class TestEnv:
+    clock: ManualClock
+
+    def __init__(self, *, now: dt.datetime | None = None) -> None:
+        self.clock = ManualClock(now or dt.datetime.fromtimestamp(0, tz=dt.UTC))
+
+    def app(self) -> App:
+        return create_app(clock=self.clock)
+
+    def invoke(self, app: App, request: Request) -> Response:
+        return app.serve(request)
+
+
+def create_test_env(*, now: dt.datetime | None = None) -> TestEnv:
+    return TestEnv(now=now)
+

--- a/py/src/apptheory/util.py
+++ b/py/src/apptheory/util.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_path(path: str) -> str:
+    value = str(path or "").strip()
+    if not value:
+        return "/"
+    if "?" in value:
+        value = value.split("?", 1)[0]
+    if not value.startswith("/"):
+        value = "/" + value
+    return value or "/"
+
+
+def canonicalize_headers(headers: dict[str, Any] | None) -> dict[str, list[str]]:
+    if not headers:
+        return {}
+    out: dict[str, list[str]] = {}
+    for key in sorted(headers.keys()):
+        lower = str(key).strip().lower()
+        if not lower:
+            continue
+        value = headers[key]
+        values = value if isinstance(value, list) else [value]
+        out.setdefault(lower, []).extend([str(v) for v in values])
+    return out
+
+
+def clone_query(query: dict[str, Any] | None) -> dict[str, list[str]]:
+    if not query:
+        return {}
+    out: dict[str, list[str]] = {}
+    for key, value in query.items():
+        if isinstance(value, list):
+            out[key] = [str(v) for v in value]
+        else:
+            out[key] = [str(value)]
+    return out
+
+
+def parse_cookies(cookie_headers: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for header in cookie_headers:
+        for part in str(header).split(";"):
+            trimmed = part.strip()
+            if not trimmed:
+                continue
+            if "=" not in trimmed:
+                continue
+            name, value = trimmed.split("=", 1)
+            name = name.strip()
+            if not name:
+                continue
+            out[name] = value.strip()
+    return out
+
+
+def to_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return bytes(value)
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, memoryview):
+        return value.tobytes()
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    raise TypeError("body must be bytes-like or str")
+


### PR DESCRIPTION
Implements the Python runtime P0 core per the contract v0 fixtures.

- Adds Python runtime core (router + request/response normalization + portable error envelope): `py/src/apptheory/*`.
- Adds public Python testkit (deterministic clock + local invocation): `apptheory.testkit`.
- Updates the Python contract runner to execute P0 fixtures against the real Python runtime (P1/P2 remain runner-internal for now).

Validation: `make rubric`
