### PR TITLE
fix: address issue #20 (TS batch fail-closed, strict base64, ts pack rebuild)

### DIFF
--- a/contract-tests/fixtures/m1/dynamodb-stream-unrecognized-table-fails-closed.json
+++ b/contract-tests/fixtures/m1/dynamodb-stream-unrecognized-table-fails-closed.json
@@ -1,0 +1,46 @@
+{
+  "id": "m1.dynamodb_stream.unrecognized_table_fails_closed",
+  "tier": "m1",
+  "name": "DynamoDB Streams: unrecognized table fails closed (all records returned as failures)",
+  "setup": {
+    "dynamodb": [
+      { "table": "TableA", "handler": "ddb_noop" }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "dynamodb_streams",
+      "event": {
+        "Records": [
+          {
+            "eventID": "evt-1",
+            "eventName": "MODIFY",
+            "eventVersion": "1.1",
+            "eventSource": "aws:dynamodb",
+            "awsRegion": "us-east-1",
+            "dynamodb": { "SequenceNumber": "1", "SizeBytes": 1, "StreamViewType": "NEW_AND_OLD_IMAGES" },
+            "eventSourceARN": "arn:aws:dynamodb:us-east-1:000000000000:table/TableMissing/stream/2020-01-01T00:00:00.000"
+          },
+          {
+            "eventID": "evt-2",
+            "eventName": "MODIFY",
+            "eventVersion": "1.1",
+            "eventSource": "aws:dynamodb",
+            "awsRegion": "us-east-1",
+            "dynamodb": { "SequenceNumber": "2", "SizeBytes": 1, "StreamViewType": "NEW_AND_OLD_IMAGES" },
+            "eventSourceARN": "arn:aws:dynamodb:us-east-1:000000000000:table/TableMissing/stream/2020-01-01T00:00:00.000"
+          }
+        ]
+      }
+    }
+  },
+  "expect": {
+    "output_json": {
+      "batchItemFailures": [
+        { "itemIdentifier": "evt-1" },
+        { "itemIdentifier": "evt-2" }
+      ]
+    }
+  }
+}
+

--- a/contract-tests/fixtures/m1/kinesis-unrecognized-stream-fails-closed.json
+++ b/contract-tests/fixtures/m1/kinesis-unrecognized-stream-fails-closed.json
@@ -1,0 +1,56 @@
+{
+  "id": "m1.kinesis.unrecognized_stream_fails_closed",
+  "tier": "m1",
+  "name": "Kinesis: unrecognized stream fails closed (all records returned as failures)",
+  "setup": {
+    "kinesis": [
+      { "stream": "stream-a", "handler": "kinesis_noop" }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "kinesis",
+      "event": {
+        "Records": [
+          {
+            "eventID": "kin-1",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/stream-missing",
+            "eventVersion": "1.0",
+            "awsRegion": "us-east-1",
+            "kinesis": {
+              "partitionKey": "pk-1",
+              "sequenceNumber": "1",
+              "kinesisSchemaVersion": "1.0",
+              "data": "b2s="
+            }
+          },
+          {
+            "eventID": "kin-2",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/stream-missing",
+            "eventVersion": "1.0",
+            "awsRegion": "us-east-1",
+            "kinesis": {
+              "partitionKey": "pk-2",
+              "sequenceNumber": "2",
+              "kinesisSchemaVersion": "1.0",
+              "data": "b2s="
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expect": {
+    "output_json": {
+      "batchItemFailures": [
+        { "itemIdentifier": "kin-1" },
+        { "itemIdentifier": "kin-2" }
+      ]
+    }
+  }
+}
+

--- a/contract-tests/fixtures/m1/sqs-unrecognized-queue-fails-closed.json
+++ b/contract-tests/fixtures/m1/sqs-unrecognized-queue-fails-closed.json
@@ -1,0 +1,50 @@
+{
+  "id": "m1.sqs.unrecognized_queue_fails_closed",
+  "tier": "m1",
+  "name": "SQS: unrecognized queue fails closed (all records returned as failures)",
+  "setup": {
+    "sqs": [
+      { "queue": "queue-a", "handler": "sqs_noop" }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "sqs",
+      "event": {
+        "Records": [
+          {
+            "messageId": "msg-1",
+            "receiptHandle": "rh-1",
+            "body": "ok",
+            "attributes": {},
+            "messageAttributes": {},
+            "md5OfBody": "",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:us-east-1:000000000000:queue-missing",
+            "awsRegion": "us-east-1"
+          },
+          {
+            "messageId": "msg-2",
+            "receiptHandle": "rh-2",
+            "body": "ok",
+            "attributes": {},
+            "messageAttributes": {},
+            "md5OfBody": "",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:us-east-1:000000000000:queue-missing",
+            "awsRegion": "us-east-1"
+          }
+        ]
+      }
+    }
+  },
+  "expect": {
+    "output_json": {
+      "batchItemFailures": [
+        { "itemIdentifier": "msg-1" },
+        { "itemIdentifier": "msg-2" }
+      ]
+    }
+  }
+}
+

--- a/contract-tests/fixtures/m3/apigw-proxy-invalid-base64-request.json
+++ b/contract-tests/fixtures/m3/apigw-proxy-invalid-base64-request.json
@@ -1,0 +1,34 @@
+{
+  "id": "m3.apigw_proxy.invalid_base64_request_body",
+  "tier": "m3",
+  "name": "APIGW REST API v1: invalid base64 request body maps to app.bad_request",
+  "setup": {
+    "routes": [{ "method": "POST", "path": "/echo", "handler": "echo_request" }]
+  },
+  "input": {
+    "aws_event": {
+      "source": "apigw_proxy",
+      "event": {
+        "path": "/echo",
+        "httpMethod": "POST",
+        "headers": { "content-type": "application/octet-stream" },
+        "multiValueHeaders": {},
+        "queryStringParameters": {},
+        "multiValueQueryStringParameters": {},
+        "requestContext": { "requestId": "req-1", "path": "/echo", "httpMethod": "POST" },
+        "body": "AAE",
+        "isBase64Encoded": true
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 400,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": { "error": { "code": "app.bad_request", "message": "invalid base64" } },
+      "is_base64": false
+    }
+  }
+}
+

--- a/runtime/request.go
+++ b/runtime/request.go
@@ -2,7 +2,6 @@ package apptheory
 
 import (
 	"encoding/base64"
-	"fmt"
 	"sort"
 	"strings"
 )
@@ -29,7 +28,7 @@ func normalizeRequest(in Request) (Request, error) {
 	if in.IsBase64 {
 		decoded, err := base64.StdEncoding.DecodeString(string(in.Body))
 		if err != nil {
-			return Request{}, &AppError{Code: errorCodeBadRequest, Message: fmt.Sprintf("invalid base64: %v", err)}
+			return Request{}, &AppError{Code: errorCodeBadRequest, Message: "invalid base64"}
 		}
 		out.Body = decoded
 	} else {

--- a/scripts/verify-ts-pack.sh
+++ b/scripts/verify-ts-pack.sh
@@ -3,6 +3,23 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "ts-pack: BLOCKED (node not found)" >&2
+  exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "ts-pack: BLOCKED (npm not found)" >&2
+  exit 1
+fi
+if [[ ! -d "ts" ]]; then
+  echo "ts-pack: FAIL (missing ts/)" >&2
+  exit 1
+fi
+if [[ ! -f "ts/package-lock.json" ]]; then
+  echo "ts-pack: FAIL (missing ts/package-lock.json)" >&2
+  exit 1
+fi
+
 expected_version="$(./scripts/read-version.sh)"
 expected_tgz="theory-cloud-apptheory-${expected_version}.tgz"
 
@@ -18,15 +35,34 @@ dist_dir="$(pwd)/dist"
 
 cp -a ts "${tmp_ts_dir}"
 
+rm -rf "${tmp_ts_dir}/node_modules"
+rm -rf "${tmp_ts_dir}/dist"
+
+(cd "${tmp_ts_dir}" && npm ci >/dev/null)
+(cd "${tmp_ts_dir}" && npm run build >/dev/null)
+
 if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
   TMP_TS_DIR="${tmp_ts_dir}" python3 - <<'PY'
 import os
 from pathlib import Path
 
 epoch = int(os.environ["SOURCE_DATE_EPOCH"])
-for file_path in Path(os.environ["TMP_TS_DIR"]).rglob("*"):
-  if file_path.is_file():
-    os.utime(file_path, (epoch, epoch))
+root = Path(os.environ["TMP_TS_DIR"])
+
+targets = [
+  root / "LICENSE",
+  root / "README.md",
+  root / "package.json",
+]
+
+dist = root / "dist"
+if dist.is_dir():
+  for p in dist.rglob("*"):
+    targets.append(p)
+
+for p in targets:
+  if p.exists():
+    os.utime(p, (epoch, epoch))
 PY
 fi
 

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -491,7 +491,11 @@ export class App {
         const records = Array.isArray(event?.Records) ? event.Records : [];
         const handler = this._sqsHandlerForEvent(event);
         if (!handler) {
-            return { batchItemFailures: [] };
+            const failures = records
+                .map((r) => String(r?.messageId ?? "").trim())
+                .filter(Boolean)
+                .map((id) => ({ itemIdentifier: id }));
+            return { batchItemFailures: failures };
         }
         const eventCtx = this._eventContext(ctx);
         let failures = [];
@@ -530,7 +534,11 @@ export class App {
         const records = Array.isArray(event?.Records) ? event.Records : [];
         const handler = this._kinesisHandlerForEvent(event);
         if (!handler) {
-            return { batchItemFailures: [] };
+            const failures = records
+                .map((r) => String(r?.eventID ?? "").trim())
+                .filter(Boolean)
+                .map((id) => ({ itemIdentifier: id }));
+            return { batchItemFailures: failures };
         }
         const eventCtx = this._eventContext(ctx);
         let failures = [];
@@ -642,7 +650,11 @@ export class App {
         const records = Array.isArray(event?.Records) ? event.Records : [];
         const handler = this._dynamoDBHandlerForEvent(event);
         if (!handler) {
-            return { batchItemFailures: [] };
+            const failures = records
+                .map((r) => String(r?.eventID ?? "").trim())
+                .filter(Boolean)
+                .map((id) => ({ itemIdentifier: id }));
+            return { batchItemFailures: failures };
         }
         const eventCtx = this._eventContext(ctx);
         let failures = [];

--- a/ts/dist/internal/request.js
+++ b/ts/dist/internal/request.js
@@ -1,6 +1,25 @@
 import { Buffer } from "node:buffer";
 import { AppError } from "../errors.js";
 import { canonicalizeHeaders, cloneQuery, normalizeMethod, normalizePath, parseCookies, toBuffer, } from "./http.js";
+function isValidBase64String(value) {
+    if (value.length === 0)
+        return true;
+    if (value.length % 4 !== 0)
+        return false;
+    if (/[^A-Za-z0-9+/=]/.test(value))
+        return false;
+    const firstPad = value.indexOf("=");
+    if (firstPad === -1)
+        return true;
+    const padLen = value.length - firstPad;
+    if (padLen > 2)
+        return false;
+    for (let i = firstPad; i < value.length; i += 1) {
+        if (value[i] !== "=")
+            return false;
+    }
+    return true;
+}
 export function normalizeRequest(request) {
     const method = normalizeMethod(request.method);
     const path = normalizePath(request.path);
@@ -10,12 +29,11 @@ export function normalizeRequest(request) {
     const isBase64 = Boolean(request.isBase64);
     let body;
     if (isBase64) {
-        try {
-            body = Buffer.from(rawBody.toString("utf8"), "base64");
-        }
-        catch {
+        const asString = rawBody.toString("utf8");
+        if (!isValidBase64String(asString)) {
             throw new AppError("app.bad_request", "invalid base64");
         }
+        body = Buffer.from(asString, "base64");
     }
     else {
         body = rawBody;

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -828,7 +828,11 @@ export class App {
     const records = Array.isArray(event?.Records) ? event.Records : [];
     const handler = this._sqsHandlerForEvent(event);
     if (!handler) {
-      return { batchItemFailures: [] };
+      const failures = records
+        .map((r) => String(r?.messageId ?? "").trim())
+        .filter(Boolean)
+        .map((id) => ({ itemIdentifier: id }));
+      return { batchItemFailures: failures };
     }
 
     const eventCtx = this._eventContext(ctx);
@@ -873,7 +877,11 @@ export class App {
     const records = Array.isArray(event?.Records) ? event.Records : [];
     const handler = this._kinesisHandlerForEvent(event);
     if (!handler) {
-      return { batchItemFailures: [] };
+      const failures = records
+        .map((r) => String(r?.eventID ?? "").trim())
+        .filter(Boolean)
+        .map((id) => ({ itemIdentifier: id }));
+      return { batchItemFailures: failures };
     }
 
     const eventCtx = this._eventContext(ctx);
@@ -1006,7 +1014,11 @@ export class App {
     const records = Array.isArray(event?.Records) ? event.Records : [];
     const handler = this._dynamoDBHandlerForEvent(event);
     if (!handler) {
-      return { batchItemFailures: [] };
+      const failures = records
+        .map((r) => String(r?.eventID ?? "").trim())
+        .filter(Boolean)
+        .map((id) => ({ itemIdentifier: id }));
+      return { batchItemFailures: failures };
     }
 
     const eventCtx = this._eventContext(ctx);

--- a/ts/src/internal/request.ts
+++ b/ts/src/internal/request.ts
@@ -22,6 +22,22 @@ export interface NormalizedRequest {
   isBase64: boolean;
 }
 
+function isValidBase64String(value: string): boolean {
+  if (value.length === 0) return true;
+  if (value.length % 4 !== 0) return false;
+  if (/[^A-Za-z0-9+/=]/.test(value)) return false;
+
+  const firstPad = value.indexOf("=");
+  if (firstPad === -1) return true;
+
+  const padLen = value.length - firstPad;
+  if (padLen > 2) return false;
+  for (let i = firstPad; i < value.length; i += 1) {
+    if (value[i] !== "=") return false;
+  }
+  return true;
+}
+
 export function normalizeRequest(request: Request): NormalizedRequest {
   const method = normalizeMethod(request.method);
   const path = normalizePath(request.path);
@@ -32,11 +48,11 @@ export function normalizeRequest(request: Request): NormalizedRequest {
   const isBase64 = Boolean(request.isBase64);
   let body: Buffer;
   if (isBase64) {
-    try {
-      body = Buffer.from(rawBody.toString("utf8"), "base64");
-    } catch {
+    const asString = rawBody.toString("utf8");
+    if (!isValidBase64String(asString)) {
       throw new AppError("app.bad_request", "invalid base64");
     }
+    body = Buffer.from(asString, "base64");
   } else {
     body = rawBody;
   }


### PR DESCRIPTION
Fixes theory-cloud/AppTheory#20.

- TS: fail-closed for unrecognized SQS/Kinesis/DynamoDB batch sources.
- TS: strict base64 validation for request decoding.
- Go: standardize invalid base64 message.
- Contract tests: add fixtures for unrecognized batch sources + invalid base64.
- Release safety: ts-pack: PASS (theory-cloud-apptheory-0.2.0-rc.2.tgz) rebuilds TS before packing.

Verified: version-alignment: PASS (0.2.0-rc.2)
fmt-check: PASS
0 issues.
go-lint: PASS
ts-lint: PASS
All checks passed!
20 files already formatted
python-lint: PASS
ok  	github.com/theory-cloud/apptheory/cmd/lift-migrate	(cached)
ok  	github.com/theory-cloud/apptheory/contract-tests/runners/go	(cached)
ok  	github.com/theory-cloud/apptheory/examples/cdk/multilang/handlers/go	(cached)
ok  	github.com/theory-cloud/apptheory/examples/migration/rate-limited-http	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/limited	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/limited/middleware	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/naming	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/observability	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/observability/zap	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/sanitization	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/services	(cached)
ok  	github.com/theory-cloud/apptheory/pkg/streamer	(cached)
ok  	github.com/theory-cloud/apptheory/runtime	(cached)
ok  	github.com/theory-cloud/apptheory/scripts/tools/api_snapshots/go	(cached)
ok  	github.com/theory-cloud/apptheory/testkit	(cached)
go: PASS
ts-pack: PASS (theory-cloud-apptheory-0.2.0-rc.2.tgz)
python-build: PASS (0.2.0-rc.2)
cdk-constructs: PASS
cdk-ts-pack: PASS (theory-cloud-apptheory-cdk-0.2.0-rc.2.tgz)
cdk-python-build: PASS (0.2.0-rc.2)
cdk-go: PASS
cdk-synth: PASS
api-snapshots: PASS
contract-tests(go): PASS (74 fixtures)
contract-tests(ts): PASS (74 fixtures)
contract-tests(py): PASS (74 fixtures)
contract-tests: PASS
examples/testkit/ts.mjs: PASS
examples/testkit/ts-streaming.mjs: PASS
examples/testkit/py.py: PASS
examples: PASS
rubric: PASS (2026-01-22).