### PR TITLE
fix: follow-ups from review (issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ Non-goals (near-term):
 - **P1:** request-id, tenant extraction, auth hooks, CORS, size/time guardrails, middleware ordering
 - **P2 (default):** P1 + observability hooks + rate limiting / load shedding policy hooks
 
+## Security & production notes
+
+- CSRF protection and secure cookie flags are application concerns; set `Secure`/`HttpOnly`/`SameSite` explicitly in `Set-Cookie`.
+- Request IDs can be supplied via `x-request-id`; validate/override if your threat model requires it.
+- Retries/backoff for event sources are handled by AWS trigger settings (retry policies, DLQs/redrive), not by the runtime.
+
 ## Go runtime (P2 default)
 
 The Go runtime implements the fixture-backed contract across P0/P1/P2 tiers (default: P2).
+
+Notes:
+
+- Header names are case-insensitive, but `Request.Headers` / `Response.Headers` keys are canonicalized to lowercase.
+- If two routes are equally specific, the router prefers earlier registration order.
 
 Minimal local invocation:
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -794,6 +794,8 @@ func (*client) PostToConnection(context.Context, string, []byte) error
 
 ## github.com/theory-cloud/apptheory/runtime
 
+const RateLimitDecisionKey = "rate_limit_decision"
+
 const TierP0 Tier = "p0"
 
 const TierP1 Tier = "p1"
@@ -937,12 +939,27 @@ type PolicyHook func(*Context) (*PolicyDecision, error)
 
 type RandomIDGenerator struct{}
 
+type RateLimitConfig struct {
+	Limiter limited.RateLimiter
+
+	FailClosed bool
+
+	ExtractIdentifier func(*Context) string
+	ExtractResource   func(*Context) string
+	ExtractOperation  func(*Context) string
+
+	OnError     func(*Context, error)
+	OnSuccess   func(*Context, *limited.LimitDecision)
+	OnRateLimit func(*Context, *limited.LimitDecision)
+}
+
 type RealClock struct{}
 
 type Request struct {
-	Method   string
-	Path     string
-	Query    map[string][]string
+	Method string
+	Path   string
+	Query  map[string][]string
+
 	Headers  map[string][]string
 	Cookies  map[string]string
 	Body     []byte
@@ -950,8 +967,10 @@ type Request struct {
 }
 
 type Response struct {
-	Status     int
-	Headers    map[string][]string
+	Status int
+
+	Headers map[string][]string
+
 	Cookies    []string
 	Body       []byte
 	BodyReader io.Reader
@@ -1053,6 +1072,8 @@ func New(...Option) *App
 
 func OriginURL(map[string][]string) string
 
+func RateLimitMiddleware(RateLimitConfig) Middleware
+
 func RequireAuth() RouteOption
 
 func SSEResponse(int, ...SSEEvent) (*Response, error)
@@ -1108,6 +1129,10 @@ func (*App) HandleLambda(context.Context, json.RawMessage) (any, error)
 func (*App) IsLambda() bool
 
 func (*App) Kinesis(string, KinesisHandler) *App
+
+func (*App) Options(string, Handler, ...RouteOption) *App
+
+func (*App) Patch(string, Handler, ...RouteOption) *App
 
 func (*App) Post(string, Handler, ...RouteOption) *App
 

--- a/cdk/.jsii
+++ b/cdk/.jsii
@@ -8476,7 +8476,7 @@
   },
   "name": "@theory-cloud/apptheory-cdk",
   "readme": {
-    "markdown": "# AppTheory CDK Constructs\n\nTS-first `jsii` constructs for deploying AppTheory apps with consistent defaults across Go/TypeScript/Python.\n\nStatus: early; start with a small “top 20%” set and grow based on real usage.\n\n## Constructs\n\n- `AppTheoryHttpApi` — HTTP API (APIGWv2) + Lambda proxy routes (`/` and `/{proxy+}`).\n- `AppTheoryRestApi` — API Gateway REST API v1 + Lambda proxy routes (supports streaming per-method).\n- `AppTheoryFunction` — Lambda wrapper with AppTheory-friendly defaults.\n- `AppTheoryFunctionAlarms` — baseline CloudWatch alarms for a Lambda function.\n- `AppTheoryQueueProcessor` — SQS queue + consumer wiring.\n- `AppTheoryEventBridgeHandler` — EventBridge schedule/rule + Lambda target wiring.\n- `AppTheoryDynamoDBStreamMapping` — DynamoDB Streams event source mapping + permissions.\n\n## Development\n\n```bash\ncd cdk\nnpm ci\nnpm test\n```\n"
+    "markdown": "# AppTheory CDK Constructs\n\nTS-first `jsii` constructs for deploying AppTheory apps with consistent defaults across Go/TypeScript/Python.\n\nStatus: early; start with a small “top 20%” set and grow based on real usage.\n\n## Constructs\n\n- `AppTheoryHttpApi` — HTTP API (APIGWv2) + Lambda proxy routes (`/` and `/{proxy+}`).\n- `AppTheoryRestApi` — API Gateway REST API v1 + Lambda proxy routes (supports streaming per-method).\n- `AppTheoryFunction` — Lambda wrapper with AppTheory-friendly defaults.\n- `AppTheoryFunctionAlarms` — baseline CloudWatch alarms for a Lambda function.\n- `AppTheoryQueueProcessor` — SQS queue + consumer wiring.\n- `AppTheoryEventBridgeHandler` — EventBridge schedule/rule + Lambda target wiring.\n- `AppTheoryDynamoDBStreamMapping` — DynamoDB Streams event source mapping + permissions.\n\n## Minimal example\n\n```ts\nimport { Stack } from \"aws-cdk-lib\";\nimport * as lambda from \"aws-cdk-lib/aws-lambda\";\nimport { AppTheoryHttpApi } from \"@theory-cloud/apptheory-cdk\";\n\nconst stack = new Stack();\nconst fn = new lambda.Function(stack, \"Handler\", {\n  runtime: lambda.Runtime.NODEJS_24_X,\n  handler: \"index.handler\",\n  code: lambda.Code.fromAsset(\"dist\"),\n});\n\nnew AppTheoryHttpApi(stack, \"Api\", { handler: fn, apiName: \"my-api\" });\n```\n\n## Development\n\n```bash\ncd cdk\nnpm ci\nnpm test\n```\n"
   },
   "repository": {
     "directory": "cdk",
@@ -12214,5 +12214,5 @@
     }
   },
   "version": "0.2.0-rc.2",
-  "fingerprint": "h35YNrxq21Yb9AH8rJ70mI/FCqP9Wu1z4zHAMr0gkBU="
+  "fingerprint": "AjryqkvCdsRZclfSmGgKANCSvTpQE9beqXocJ8Hym0Y="
 }

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -14,6 +14,23 @@ Status: early; start with a small “top 20%” set and grow based on real usage
 - `AppTheoryEventBridgeHandler` — EventBridge schedule/rule + Lambda target wiring.
 - `AppTheoryDynamoDBStreamMapping` — DynamoDB Streams event source mapping + permissions.
 
+## Minimal example
+
+```ts
+import { Stack } from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { AppTheoryHttpApi } from "@theory-cloud/apptheory-cdk";
+
+const stack = new Stack();
+const fn = new lambda.Function(stack, "Handler", {
+  runtime: lambda.Runtime.NODEJS_24_X,
+  handler: "index.handler",
+  code: lambda.Code.fromAsset("dist"),
+});
+
+new AppTheoryHttpApi(stack, "Api", { handler: fn, apiName: "my-api" });
+```
+
 ## Development
 
 ```bash

--- a/py/README.md
+++ b/py/README.md
@@ -9,6 +9,8 @@ The portable runtime behavior is defined by the fixture-backed contract:
 
 To force the P0 core (minimal surface area), pass `tier="p0"` when creating the app.
 
+Note: header names are case-insensitive, but response headers are emitted with lowercase keys.
+
 ```py
 from apptheory import Request, create_test_env, text
 

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -185,6 +185,12 @@ class App:
     def put(self, pattern: str, handler: Handler) -> App:
         return self.handle("PUT", pattern, handler)
 
+    def patch(self, pattern: str, handler: Handler) -> App:
+        return self.handle("PATCH", pattern, handler)
+
+    def options(self, pattern: str, handler: Handler) -> App:
+        return self.handle("OPTIONS", pattern, handler)
+
     def delete(self, pattern: str, handler: Handler) -> App:
         return self.handle("DELETE", pattern, handler)
 

--- a/runtime/rate_limit_middleware.go
+++ b/runtime/rate_limit_middleware.go
@@ -1,0 +1,157 @@
+package apptheory
+
+import (
+	"context"
+	"strings"
+
+	"github.com/theory-cloud/apptheory/pkg/limited"
+)
+
+// RateLimitDecisionKey is the Context key used by RateLimitMiddleware to store the last LimitDecision.
+const RateLimitDecisionKey = "rate_limit_decision"
+
+type RateLimitConfig struct {
+	// Limiter is required. If nil, RateLimitMiddleware is a no-op.
+	Limiter limited.RateLimiter
+
+	// FailClosed controls behavior when the limiter returns an error.
+	// If false (default), requests proceed on limiter errors.
+	FailClosed bool
+
+	ExtractIdentifier func(ctx *Context) string
+	ExtractResource   func(ctx *Context) string
+	ExtractOperation  func(ctx *Context) string
+
+	OnError     func(ctx *Context, err error)
+	OnSuccess   func(ctx *Context, decision *limited.LimitDecision)
+	OnRateLimit func(ctx *Context, decision *limited.LimitDecision)
+}
+
+func RateLimitMiddleware(config RateLimitConfig) Middleware {
+	cfg := normalizeRateLimitConfig(config)
+
+	return func(next Handler) Handler {
+		if next == nil || cfg.Limiter == nil {
+			return next
+		}
+
+		return func(ctx *Context) (*Response, error) {
+			key := limited.RateLimitKey{
+				Identifier: cfg.ExtractIdentifier(ctx),
+				Resource:   cfg.ExtractResource(ctx),
+				Operation:  cfg.ExtractOperation(ctx),
+				Metadata: map[string]string{
+					"method": ctx.Request.Method,
+					"path":   ctx.Request.Path,
+					"tenant": ctx.TenantID,
+				},
+			}
+
+			decision, err := checkRateLimit(ctx.Context(), cfg.Limiter, key)
+			if err != nil {
+				if cfg.OnError != nil {
+					cfg.OnError(ctx, err)
+				}
+				if !cfg.FailClosed {
+					return next(ctx)
+				}
+				return nil, &AppError{Code: errorCodeInternal, Message: errorMessageInternal}
+			}
+
+			ctx.Set(RateLimitDecisionKey, decision)
+
+			if decision != nil && !decision.Allowed {
+				if cfg.OnRateLimit != nil {
+					cfg.OnRateLimit(ctx, decision)
+				}
+				return nil, &AppError{Code: errorCodeRateLimited, Message: errorMessageRateLimited}
+			}
+
+			if cfg.OnSuccess != nil {
+				cfg.OnSuccess(ctx, decision)
+			}
+
+			return next(ctx)
+		}
+	}
+}
+
+func normalizeRateLimitConfig(in RateLimitConfig) RateLimitConfig {
+	cfg := in
+
+	if cfg.ExtractIdentifier == nil {
+		cfg.ExtractIdentifier = defaultRateLimitIdentifier
+	}
+	if cfg.ExtractResource == nil {
+		cfg.ExtractResource = defaultRateLimitResource
+	}
+	if cfg.ExtractOperation == nil {
+		cfg.ExtractOperation = defaultRateLimitOperation
+	}
+
+	return cfg
+}
+
+func checkRateLimit(ctx context.Context, limiter limited.RateLimiter, key limited.RateLimitKey) (*limited.LimitDecision, error) {
+	if limiter == nil {
+		return &limited.LimitDecision{Allowed: true}, nil
+	}
+
+	if atomic, ok := limiter.(limited.AtomicRateLimiter); ok {
+		return atomic.CheckAndIncrement(ctx, key)
+	}
+
+	decision, err := limiter.CheckLimit(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if decision != nil && decision.Allowed {
+		if err := limiter.RecordRequest(ctx, key); err != nil {
+			_ = err
+		}
+	}
+
+	return decision, nil
+}
+
+func defaultRateLimitIdentifier(ctx *Context) string {
+	if ctx == nil {
+		return "anonymous"
+	}
+
+	if apiKey := firstHeaderValue(ctx.Request.Headers, "x-api-key"); apiKey != "" {
+		return apiKey
+	}
+
+	auth := firstHeaderValue(ctx.Request.Headers, "authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		if token := strings.TrimSpace(strings.TrimPrefix(auth, "Bearer ")); token != "" {
+			return token
+		}
+	}
+
+	if id := strings.TrimSpace(ctx.AuthIdentity); id != "" {
+		return id
+	}
+
+	if tenant := strings.TrimSpace(ctx.TenantID); tenant != "" {
+		return tenant
+	}
+
+	return "anonymous"
+}
+
+func defaultRateLimitResource(ctx *Context) string {
+	if ctx == nil {
+		return "/"
+	}
+	return ctx.Request.Path
+}
+
+func defaultRateLimitOperation(ctx *Context) string {
+	if ctx == nil {
+		return ""
+	}
+	return ctx.Request.Method
+}

--- a/runtime/rate_limit_middleware_test.go
+++ b/runtime/rate_limit_middleware_test.go
@@ -1,0 +1,99 @@
+package apptheory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/theory-cloud/apptheory/pkg/limited"
+)
+
+type stubRateLimiter struct {
+	decision *limited.LimitDecision
+	err      error
+
+	recordCalls int
+}
+
+func (s *stubRateLimiter) CheckLimit(_ context.Context, _ limited.RateLimitKey) (*limited.LimitDecision, error) {
+	return s.decision, s.err
+}
+
+func (s *stubRateLimiter) RecordRequest(_ context.Context, _ limited.RateLimitKey) error {
+	s.recordCalls++
+	return nil
+}
+
+func (s *stubRateLimiter) GetUsage(_ context.Context, _ limited.RateLimitKey) (*limited.UsageStats, error) {
+	return nil, nil
+}
+
+func TestRateLimitMiddleware_AllowsAndStoresDecision(t *testing.T) {
+	resetsAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &stubRateLimiter{
+		decision: &limited.LimitDecision{Allowed: true, CurrentCount: 0, Limit: 10, ResetsAt: resetsAt},
+	}
+
+	app := New(WithTier(TierP0))
+	app.Use(RateLimitMiddleware(RateLimitConfig{Limiter: limiter}))
+
+	called := false
+	app.Get("/ok", func(ctx *Context) (*Response, error) {
+		called = true
+		if got := ctx.Get(RateLimitDecisionKey); got == nil {
+			t.Fatalf("expected decision in context, got nil")
+		}
+		return Text(200, "ok"), nil
+	})
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/ok"})
+	if resp.Status != 200 {
+		t.Fatalf("expected status 200, got %d", resp.Status)
+	}
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+	if limiter.recordCalls != 1 {
+		t.Fatalf("expected RecordRequest to be called once, got %d", limiter.recordCalls)
+	}
+}
+
+func TestRateLimitMiddleware_RateLimited(t *testing.T) {
+	limiter := &stubRateLimiter{
+		decision: &limited.LimitDecision{Allowed: false, CurrentCount: 10, Limit: 10, ResetsAt: time.Now()},
+	}
+
+	app := New(WithTier(TierP0))
+	app.Use(RateLimitMiddleware(RateLimitConfig{Limiter: limiter}))
+
+	app.Get("/nope", func(_ *Context) (*Response, error) {
+		t.Fatalf("handler should not be called when rate limited")
+		return nil, nil
+	})
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/nope"})
+	if resp.Status != 429 {
+		t.Fatalf("expected status 429, got %d", resp.Status)
+	}
+}
+
+func TestRateLimitMiddleware_FailOpenOnLimiterError(t *testing.T) {
+	limiter := &stubRateLimiter{decision: nil, err: context.DeadlineExceeded}
+
+	app := New(WithTier(TierP0))
+	app.Use(RateLimitMiddleware(RateLimitConfig{Limiter: limiter}))
+
+	called := false
+	app.Get("/ok", func(_ *Context) (*Response, error) {
+		called = true
+		return Text(200, "ok"), nil
+	})
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/ok"})
+	if resp.Status != 200 {
+		t.Fatalf("expected status 200, got %d", resp.Status)
+	}
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+}

--- a/runtime/request.go
+++ b/runtime/request.go
@@ -8,9 +8,11 @@ import (
 
 // Request is the canonical HTTP request model used by the AppTheory runtime.
 type Request struct {
-	Method   string
-	Path     string
-	Query    map[string][]string
+	Method string
+	Path   string
+	Query  map[string][]string
+	// Headers are canonicalized to lowercase keys during request normalization.
+	// Treat header names as case-insensitive and prefer lowercase when accessing values.
 	Headers  map[string][]string
 	Cookies  map[string]string
 	Body     []byte

--- a/runtime/response.go
+++ b/runtime/response.go
@@ -7,8 +7,12 @@ import (
 
 // Response is the canonical HTTP response model returned by AppTheory handlers.
 type Response struct {
-	Status     int
-	Headers    map[string][]string
+	Status int
+	// Headers are canonicalized to lowercase keys during response normalization.
+	// Treat header names as case-insensitive and prefer lowercase when accessing values.
+	Headers map[string][]string
+	// Cookies contains raw Set-Cookie header values. If you also provide a "set-cookie"
+	// header in Headers, normalization merges it into Cookies.
 	Cookies    []string
 	Body       []byte
 	BodyReader io.Reader

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -266,6 +266,7 @@ func routeMoreSpecific(a, b route) bool {
 	if len(a.Segments) != len(b.Segments) {
 		return len(a.Segments) > len(b.Segments)
 	}
+	// If two routes are equally specific, prefer earlier registration order.
 	return a.order < b.order
 }
 

--- a/runtime/serve.go
+++ b/runtime/serve.go
@@ -37,6 +37,14 @@ func (a *App) Put(pattern string, handler Handler, opts ...RouteOption) *App {
 	return a.Handle("PUT", pattern, handler, opts...)
 }
 
+func (a *App) Patch(pattern string, handler Handler, opts ...RouteOption) *App {
+	return a.Handle("PATCH", pattern, handler, opts...)
+}
+
+func (a *App) Options(pattern string, handler Handler, opts ...RouteOption) *App {
+	return a.Handle("OPTIONS", pattern, handler, opts...)
+}
+
 func (a *App) Delete(pattern string, handler Handler, opts ...RouteOption) *App {
 	return a.Handle("DELETE", pattern, handler, opts...)
 }

--- a/ts/README.md
+++ b/ts/README.md
@@ -9,6 +9,8 @@ The portable runtime behavior is defined by the fixture-backed contract:
 
 To force the P0 core (minimal surface area), pass `tier: "p0"` when creating the app.
 
+Note: header names are case-insensitive, but response headers are emitted with lowercase keys.
+
 ```ts
 import { createTestEnv, text } from "@theory-cloud/apptheory";
 

--- a/ts/dist/app.d.ts
+++ b/ts/dist/app.d.ts
@@ -93,6 +93,8 @@ export declare class App {
     get(pattern: string, handler: Handler): this;
     post(pattern: string, handler: Handler): this;
     put(pattern: string, handler: Handler): this;
+    patch(pattern: string, handler: Handler): this;
+    options(pattern: string, handler: Handler): this;
     delete(pattern: string, handler: Handler): this;
     use(middleware: Middleware): this;
     useEvents(middleware: EventMiddleware): this;

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -73,6 +73,12 @@ export class App {
     put(pattern, handler) {
         return this.handle("PUT", pattern, handler);
     }
+    patch(pattern, handler) {
+        return this.handle("PATCH", pattern, handler);
+    }
+    options(pattern, handler) {
+        return this.handle("OPTIONS", pattern, handler);
+    }
     delete(pattern, handler) {
         return this.handle("DELETE", pattern, handler);
     }

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -271,6 +271,14 @@ export class App {
     return this.handle("PUT", pattern, handler);
   }
 
+  patch(pattern: string, handler: Handler): this {
+    return this.handle("PATCH", pattern, handler);
+  }
+
+  options(pattern: string, handler: Handler): this {
+    return this.handle("OPTIONS", pattern, handler);
+  }
+
   delete(pattern: string, handler: Handler): this {
     return this.handle("DELETE", pattern, handler);
   }


### PR DESCRIPTION
Fixes theory-cloud/AppTheory#22

Changes:
- Add PATCH/OPTIONS route helpers in Go/TS/Py.
- Clarify header canonicalization + router tie-break behavior.
- Add Go `RateLimitMiddleware` that integrates `pkg/limited`.
- Add a minimal CDK usage example.

Verification:
- `make rubric`