### PR TITLE
fix(ci): skip branch version sync outside git repo

### DIFF
--- a/scripts/verify-branch-version-sync.sh
+++ b/scripts/verify-branch-version-sync.sh
@@ -8,6 +8,12 @@ set -euo pipefail
 # - `premain` cuts prereleases using `.release-please-manifest.premain.json`
 # If `premain` doesn't regularly back-merge `main`, prereleases can get stuck on an old major/minor track.
 
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  # `scripts/verify-builds.sh` runs rubric in git-less working copies; this verifier needs git metadata.
+  echo "branch-version-sync: SKIP (not a git repository)"
+  exit 0
+fi
+
 git_fetch_retry() {
   local remote="$1"
   shift


### PR DESCRIPTION
## Summary
- `scripts/verify-branch-version-sync.sh` now skips when the checkout is not a git repository.

## Why
`CI → Verify deterministic builds` runs the rubric in git-less working copies. Our new branch/version sync verifier requires git metadata (fetching `origin/main`), so it fails in that environment and breaks the deterministic build check.

## Test plan
- CI