### PR TITLE
fix(ci): support X.Y.Z-rc prerelease versions

### DIFF
--- a/scripts/render-release-notes.sh
+++ b/scripts/render-release-notes.sh
@@ -12,7 +12,11 @@ fi
 version="${tag#v}"
 python_version="${version}"
 if [[ "${python_version}" == *"-rc."* ]]; then
+  # `X.Y.Z-rc.N` -> `X.Y.ZrcN` (PEP 440 normalized wheel/sdist version)
   python_version="${python_version/-rc./rc}"
+elif [[ "${python_version}" == *"-rc" ]]; then
+  # `X.Y.Z-rc` -> `X.Y.Zrc0` (TableTheory pattern)
+  python_version="${python_version/-rc/rc0}"
 fi
 
 repo="theory-cloud/AppTheory"

--- a/scripts/verify-cdk-python-build.sh
+++ b/scripts/verify-cdk-python-build.sh
@@ -6,7 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 expected_version="$(./scripts/read-version.sh)"
 expected_py_version="${expected_version}"
 if [[ "${expected_py_version}" == *"-rc."* ]]; then
+  # `X.Y.Z-rc.N` -> `X.Y.ZrcN` (PEP 440 normalized wheel/sdist version)
   expected_py_version="${expected_py_version/-rc./rc}"
+elif [[ "${expected_py_version}" == *"-rc" ]]; then
+  # `X.Y.Z-rc` -> `X.Y.Zrc0` (TableTheory pattern)
+  expected_py_version="${expected_py_version/-rc/rc0}"
 fi
 
 epoch="${SOURCE_DATE_EPOCH:-}"

--- a/scripts/verify-python-build.sh
+++ b/scripts/verify-python-build.sh
@@ -6,7 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 expected_version="$(./scripts/read-version.sh)"
 expected_py_version="${expected_version}"
 if [[ "${expected_py_version}" == *"-rc."* ]]; then
+  # `X.Y.Z-rc.N` -> `X.Y.ZrcN` (PEP 440 normalized wheel/sdist version)
   expected_py_version="${expected_py_version/-rc./rc}"
+elif [[ "${expected_py_version}" == *"-rc" ]]; then
+  # `X.Y.Z-rc` -> `X.Y.Zrc0` (TableTheory pattern)
+  expected_py_version="${expected_py_version/-rc/rc0}"
 fi
 
 epoch="${SOURCE_DATE_EPOCH:-}"

--- a/scripts/verify-version-alignment.sh
+++ b/scripts/verify-version-alignment.sh
@@ -16,8 +16,8 @@ if [[ -z "${expected_version}" ]]; then
   exit 1
 fi
 
-if [[ ! "${expected_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-  echo "version-alignment: FAIL (VERSION '${expected_version}' must match X.Y.Z or X.Y.Z-rc.N)"
+if [[ ! "${expected_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?$ ]]; then
+  echo "version-alignment: FAIL (VERSION '${expected_version}' must match X.Y.Z, X.Y.Z-rc, or X.Y.Z-rc.N)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Align prerelease version handling with TableTheory.
- Allow `X.Y.Z-rc` (no numeric suffix) across CI version alignment.
- Normalize expected Python artifact filenames to `X.Y.Zrc0` / `X.Y.ZrcN`.

## Why
`premain` now has `0.4.2-rc` (release-please first RC on a new track). Our CI assumed only `-rc.N`, causing `staging → premain` sync PRs to fail.

## Test plan
- CI