### PR TITLE
fix(ci): make jsii-pacmak compatible with -rc tags

### DIFF
--- a/scripts/verify-cdk-python-build.sh
+++ b/scripts/verify-cdk-python-build.sh
@@ -43,6 +43,44 @@ trap cleanup EXIT
 
 cp -a cdk "${tmp_dir}/cdk"
 
+jsii_version="${expected_version}"
+# jsii-pacmak requires prerelease labels to be followed by an integer for Python
+# mapping (e.g., `0.4.2-rc.0`, not `0.4.2-rc`).
+if [[ "${jsii_version}" =~ -rc$ ]]; then
+  jsii_version="${jsii_version}.0"
+fi
+
+TMP_CDK_DIR="${tmp_dir}/cdk" JSII_VERSION="${jsii_version}" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["TMP_CDK_DIR"])
+version = os.environ["JSII_VERSION"]
+
+# Patch the copied CDK package versions for jsii-pacmak compatibility.
+package_json = root / "package.json"
+if package_json.exists():
+  data = json.loads(package_json.read_text(encoding="utf-8"))
+  data["version"] = version
+  package_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+package_lock = root / "package-lock.json"
+if package_lock.exists():
+  data = json.loads(package_lock.read_text(encoding="utf-8"))
+  data["version"] = version
+  packages = data.get("packages", {})
+  if isinstance(packages, dict) and "" in packages and isinstance(packages[""], dict):
+    packages[""]["version"] = version
+  package_lock.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+jsii = root / ".jsii"
+if jsii.exists():
+  data = json.loads(jsii.read_text(encoding="utf-8"))
+  data["version"] = version
+  jsii.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+
 TMP_CDK_DIR="${tmp_dir}/cdk" python3 - <<'PY'
 import os
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Fix CDK Python packaging when VERSION is `X.Y.Z-rc` (no numeric suffix).

## Why
When premain is on a first-RC tag like `0.4.2-rc`, jsii-pacmak fails to translate the prerelease identifier to Python because it requires `rc.<number>`.

This change patches the *copied* CDK package version to `X.Y.Z-rc.0` inside the deterministic build sandbox before running jsii-pacmak.

## Test plan
- CI