### PR TITLE
fix(ci): run CI on staging pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - staging
       - main
       - premain
 

--- a/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
+++ b/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
@@ -33,6 +33,13 @@ Important: release automation is driven by **Conventional Commits**. Commits typ
 and will advance the release line; `chore:` commits may be ignored by release-please. If a change must ship, prefer `fix(<scope>): ...`
 or `feat(<scope>): ...` (this matches TableTheory’s release flow expectations).
 
+## Troubleshooting
+
+- If a prerelease/release PR was merged but no new `vX.Y.Z-rc...` (or `vX.Y.Z`) tag exists, check the corresponding GitHub Actions run:
+  `Prerelease (premain)` or `Release (main)`.
+- The release workflows may delete failed *draft* releases/tags to avoid leaving broken remnants; after fixing the underlying build/gate,
+  re-run the workflow (or merge the next release-please PR) to cut a new RC/release.
+
 ## Branch/version invariants (enforced)
 
 AppTheory follows the TableTheory invariant set so prereleases cannot get “stuck” on an old semver track:

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -11,6 +11,7 @@ failures=0
 
 required_files=(
   "docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md"
+  ".github/workflows/ci.yml"
   ".github/workflows/prerelease.yml"
   ".github/workflows/prerelease-pr.yml"
   ".github/workflows/release.yml"
@@ -28,6 +29,26 @@ for f in "${required_files[@]}"; do
     failures=$((failures + 1))
   fi
 done
+
+if [[ -f ".github/workflows/ci.yml" ]]; then
+  # Staging is the integration branch in the documented TableTheory-style flow; it must run CI on merge.
+  grep -Eq 'branches:' ".github/workflows/ci.yml" || {
+    echo "branch-release: ci workflow must define push branches"
+    failures=$((failures + 1))
+  }
+  grep -Eq '^\s*-\s*staging\s*$' ".github/workflows/ci.yml" || {
+    echo "branch-release: ci workflow must run on staging pushes"
+    failures=$((failures + 1))
+  }
+  grep -Eq '^\s*-\s*premain\s*$' ".github/workflows/ci.yml" || {
+    echo "branch-release: ci workflow must run on premain pushes"
+    failures=$((failures + 1))
+  }
+  grep -Eq '^\s*-\s*main\s*$' ".github/workflows/ci.yml" || {
+    echo "branch-release: ci workflow must run on main pushes"
+    failures=$((failures + 1))
+  }
+fi
 
 if [[ -f ".github/workflows/prerelease.yml" ]]; then
   grep -Eq 'branches:.*premain' ".github/workflows/prerelease.yml" || {
@@ -229,4 +250,3 @@ if [[ "${failures}" -ne 0 ]]; then
 fi
 
 echo "branch-release: PASS"
-


### PR DESCRIPTION
Runs CI on staging merges (required for staged promotion workflow), enforces via branch-release supply-chain verifier, and documents release troubleshooting.

Demo plan:
1) Merge this into staging.
2) Create PR staging -> premain to trigger next RC release-please PR.