### PR TITLE
fix(ci): repair release-pr workflow yaml

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -36,35 +36,35 @@ jobs:
 
           release_as="$(
             python3 - <<'PY'
-import json
-from pathlib import Path
+          import json
+          from pathlib import Path
 
 
-def parse_base(v: str) -> tuple[int, int, int]:
-    v = v.strip()
-    if v.startswith("v"):
-        v = v[1:]
-    v = v.split("+", 1)[0]
-    base = v.split("-", 1)[0]
-    parts = base.split(".")
-    if len(parts) != 3:
-        raise ValueError(f"invalid semver base: {v}")
-    return (int(parts[0]), int(parts[1]), int(parts[2]))
+          def parse_base(v: str) -> tuple[int, int, int]:
+              v = v.strip()
+              if v.startswith("v"):
+                  v = v[1:]
+              v = v.split("+", 1)[0]
+              base = v.split("-", 1)[0]
+              parts = base.split(".")
+              if len(parts) != 3:
+                  raise ValueError(f"invalid semver base: {v}")
+              return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
-stable = json.loads(Path(".release-please-manifest.json").read_text(encoding="utf-8")).get(".", "")
-premain = json.loads(Path(".release-please-manifest.premain.json").read_text(encoding="utf-8")).get(".", "")
+          stable = json.loads(Path(".release-please-manifest.json").read_text(encoding="utf-8")).get(".", "")
+          premain = json.loads(Path(".release-please-manifest.premain.json").read_text(encoding="utf-8")).get(".", "")
 
-if not stable or not premain:
-    raise SystemExit("")
+          if not stable or not premain:
+              raise SystemExit("")
 
-premain_base = premain.split("+", 1)[0].split("-", 1)[0]
+          premain_base = premain.split("+", 1)[0].split("-", 1)[0]
 
-# If premain is already on a higher major/minor/patch line (e.g., 0.5.0-rc.1),
-# force the stable Release PR to promote that baseline (e.g., 0.5.0).
-if parse_base(premain_base) > parse_base(stable):
-    print(premain_base)
-PY
+          # If premain is already on a higher major/minor/patch line (e.g., 0.5.0-rc.1),
+          # force the stable Release PR to promote that baseline (e.g., 0.5.0).
+          if parse_base(premain_base) > parse_base(stable):
+              print(premain_base)
+          PY
           )"
 
           echo "release_as=${release_as}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Fixes invalid YAML in `.github/workflows/release-pr.yml` by indenting the embedded Python heredoc.

Why:
- GitHub Actions was reporting "This run likely failed because of a workflow file issue" on pushes to non-main branches.
- Once valid, the workflow should only run on `main` (as configured) and can generate stable release-please PRs.