### PR TITLE
fix(contract-tests): deflake streaming headers fixture

### DIFF
--- a/contract-tests/runners/go/apptheory_p0.go
+++ b/contract-tests/runners/go/apptheory_p0.go
@@ -349,7 +349,10 @@ var builtInAppTheoryHandlers = map[string]apptheory.Handler{
 			IsBase64: false,
 		}
 
-		ch := make(chan apptheory.StreamChunk, 2)
+		// Use an unbuffered channel so the first send blocks until the runtime starts
+		// consuming the stream. This prevents a race where the goroutine mutates
+		// headers/cookies before the response is normalized (flake in CI).
+		ch := make(chan apptheory.StreamChunk)
 		resp.BodyStream = ch
 		go func() {
 			defer close(ch)


### PR DESCRIPTION
Deflakes contract test fixture 'm14.streaming.headers_finalized_after_first_chunk' by making the first stream send block until the runtime consumes it, preventing concurrent header/cookie mutation before response normalization.