### PR TITLE
fix(go-lint): unblock prerelease build

### DIFF
--- a/scripts/tools/api_snapshots/go/main.go
+++ b/scripts/tools/api_snapshots/go/main.go
@@ -36,7 +36,15 @@ type exportDecl struct {
 	Decl string
 }
 
-const unknownReceiverType = "(unknown)"
+const (
+	exportKindConst  = "const"
+	exportKindVar    = "var"
+	exportKindType   = "type"
+	exportKindFunc   = "func"
+	exportKindMethod = "method"
+
+	unknownReceiverType = "(unknown)"
+)
 
 func main() {
 	if err := run(); err != nil {
@@ -255,7 +263,7 @@ func collectTypeSpecExports(fset *token.FileSet, d *ast.GenDecl) []exportDecl {
 			continue
 		}
 		exports = append(exports, exportDecl{
-			Kind: "type",
+			Kind: exportKindType,
 			Name: ts.Name.Name,
 			Decl: formatTypeSpec(fset, ts),
 		})
@@ -291,11 +299,11 @@ func dedupeExports(exports []exportDecl) []exportDecl {
 
 func sortExports(exports []exportDecl) {
 	kindOrder := map[string]int{
-		"const":  1,
-		"var":    2,
-		"type":   3,
-		"func":   4,
-		"method": 5,
+		exportKindConst:  1,
+		exportKindVar:    2,
+		exportKindType:   3,
+		exportKindFunc:   4,
+		exportKindMethod: 5,
 	}
 	sort.Slice(exports, func(i, j int) bool {
 		ki, kj := kindOrder[exports[i].Kind], kindOrder[exports[j].Kind]
@@ -342,9 +350,9 @@ func normalizeFieldList(list *ast.FieldList) *ast.FieldList {
 
 func funcDeclKind(d *ast.FuncDecl) string {
 	if d.Recv == nil {
-		return "func"
+		return exportKindFunc
 	}
-	return "method"
+	return exportKindMethod
 }
 
 func funcDeclName(d *ast.FuncDecl) string {
@@ -413,9 +421,9 @@ func formatValueSpecExports(fset *token.FileSet, tok token.Token, vs *ast.ValueS
 		return nil
 	}
 
-	kind := "var"
+	kind := exportKindVar
 	if tok == token.CONST {
-		kind = "const"
+		kind = exportKindConst
 	}
 
 	if len(vs.Names) == 1 {

--- a/scripts/tools/api_snapshots/go/main_test.go
+++ b/scripts/tools/api_snapshots/go/main_test.go
@@ -49,7 +49,7 @@ func TestNormalizeFieldList(t *testing.T) {
 
 func TestFuncDeclKindAndName(t *testing.T) {
 	fn := &ast.FuncDecl{Name: ast.NewIdent("Foo"), Type: &ast.FuncType{}}
-	if got := funcDeclKind(fn); got != "func" {
+	if got := funcDeclKind(fn); got != exportKindFunc {
 		t.Fatalf("expected kind func, got %q", got)
 	}
 	if got := funcDeclName(fn); got != "Foo" {
@@ -65,7 +65,7 @@ func TestFuncDeclKindAndName(t *testing.T) {
 			},
 		},
 	}
-	if got := funcDeclKind(m); got != "method" {
+	if got := funcDeclKind(m); got != exportKindMethod {
 		t.Fatalf("expected kind method, got %q", got)
 	}
 	if got := funcDeclName(m); got != "*T.Meth" {
@@ -85,7 +85,7 @@ func TestFormatValueSpecExports(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("expected 1 export, got %d", len(out))
 	}
-	if out[0].Kind != "const" || out[0].Name != "Foo" {
+	if out[0].Kind != exportKindConst || out[0].Name != "Foo" {
 		t.Fatalf("unexpected export: %#v", out[0])
 	}
 	if !strings.HasPrefix(out[0].Decl, "const Foo") {
@@ -104,7 +104,7 @@ func TestFormatValueSpecExports(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("expected 1 export, got %d", len(out))
 	}
-	if out[0].Kind != "var" || out[0].Name != "Foo" {
+	if out[0].Kind != exportKindVar || out[0].Name != "Foo" {
 		t.Fatalf("unexpected export: %#v", out[0])
 	}
 

--- a/scripts/tools/api_snapshots/go/run_additional_test.go
+++ b/scripts/tools/api_snapshots/go/run_additional_test.go
@@ -104,7 +104,7 @@ func TestCollectDeclExports_CoversValueSpecAndUnexportedFunc(t *testing.T) {
 		},
 	}
 	exports := collectGenDeclExports(fset, g)
-	if len(exports) != 1 || exports[0].Kind != "var" || exports[0].Name != "Foo" {
+	if len(exports) != 1 || exports[0].Kind != exportKindVar || exports[0].Name != "Foo" {
 		t.Fatalf("unexpected exports: %#v", exports)
 	}
 
@@ -115,11 +115,11 @@ func TestCollectDeclExports_CoversValueSpecAndUnexportedFunc(t *testing.T) {
 
 func TestSortExports_OrdersKindThenNameThenDecl(t *testing.T) {
 	exports := []exportDecl{
-		{Kind: "func", Name: "B", Decl: "func B()"},
-		{Kind: "type", Name: "A", Decl: "type A struct{}"},
-		{Kind: "var", Name: "Z", Decl: "var Z = 1"},
-		{Kind: "const", Name: "Y", Decl: "const Y = 1"},
-		{Kind: "func", Name: "A", Decl: "func A()"},
+		{Kind: exportKindFunc, Name: "B", Decl: "func B()"},
+		{Kind: exportKindType, Name: "A", Decl: "type A struct{}"},
+		{Kind: exportKindVar, Name: "Z", Decl: "var Z = 1"},
+		{Kind: exportKindConst, Name: "Y", Decl: "const Y = 1"},
+		{Kind: exportKindFunc, Name: "A", Decl: "func A()"},
 	}
 	sortExports(exports)
 


### PR DESCRIPTION
Fixes golangci-lint goconst failure that broke the premain prerelease workflow (run 21566899364).

Changes:
- Introduce export kind constants in scripts/tools/api_snapshots/go and use them across code/tests.

Validation:
- make rubric