### PR TITLE
chore(cdk-go): gofmt generated bindings

### DIFF
--- a/cdk-go/apptheorycdk/ApiBypassConfig.go
+++ b/cdk-go/apptheorycdk/ApiBypassConfig.go
@@ -15,4 +15,3 @@ type ApiBypassConfig struct {
 	// Optional origin request policy override.
 	OriginRequestPolicy awscloudfront.IOriginRequestPolicy `field:"optional" json:"originRequestPolicy" yaml:"originRequestPolicy"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryLambdaRole.go
+++ b/cdk-go/apptheorycdk/AppTheoryLambdaRole.go
@@ -19,19 +19,19 @@ import (
 // - Escape hatch for additional inline policy statements.
 //
 // Example:
-//   const role = new AppTheoryLambdaRole(this, 'LambdaRole', {
-//     roleName: 'my-lambda-role',
-//     enableXRay: true,
-//     environmentEncryptionKeys: [envKey],
-//     applicationKmsKeys: [dataKey],
-//     additionalStatements: [
-//       new iam.PolicyStatement({
-//         actions: ['s3:GetObject'],
-//         resources: ['arn:aws:s3:::my-bucket/*'],
-//       }),
-//     ],
-//   });
 //
+//	const role = new AppTheoryLambdaRole(this, 'LambdaRole', {
+//	  roleName: 'my-lambda-role',
+//	  enableXRay: true,
+//	  environmentEncryptionKeys: [envKey],
+//	  applicationKmsKeys: [dataKey],
+//	  additionalStatements: [
+//	    new iam.PolicyStatement({
+//	      actions: ['s3:GetObject'],
+//	      resources: ['arn:aws:s3:::my-bucket/*'],
+//	    }),
+//	  ],
+//	});
 type AppTheoryLambdaRole interface {
 	constructs.Construct
 	// The tree node.
@@ -102,7 +102,6 @@ func (j *jsiiProxy_AppTheoryLambdaRole) RoleName() *string {
 	)
 	return returns
 }
-
 
 func NewAppTheoryLambdaRole(scope constructs.Construct, id *string, props *AppTheoryLambdaRoleProps) AppTheoryLambdaRole {
 	_init_.Initialize()
@@ -237,4 +236,3 @@ func (a *jsiiProxy_AppTheoryLambdaRole) ToString() *string {
 
 	return returns
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryLambdaRoleProps.go
+++ b/cdk-go/apptheorycdk/AppTheoryLambdaRoleProps.go
@@ -32,4 +32,3 @@ type AppTheoryLambdaRoleProps struct {
 	// Tags to apply to the IAM role.
 	Tags *map[string]*string `field:"optional" json:"tags" yaml:"tags"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryLambdaRole__checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryLambdaRole__checks.go
@@ -66,4 +66,3 @@ func validateNewAppTheoryLambdaRoleParameters(scope constructs.Construct, id *st
 
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryLambdaRole__no_checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryLambdaRole__no_checks.go
@@ -27,4 +27,3 @@ func validateAppTheoryLambdaRole_IsConstructParameters(x interface{}) error {
 func validateNewAppTheoryLambdaRoleParameters(scope constructs.Construct, id *string, props *AppTheoryLambdaRoleProps) error {
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryMediaCdn.go
+++ b/cdk-go/apptheorycdk/AppTheoryMediaCdn.go
@@ -119,7 +119,6 @@ func (j *jsiiProxy_AppTheoryMediaCdn) PublicKey() awscloudfront.PublicKey {
 	return returns
 }
 
-
 func NewAppTheoryMediaCdn(scope constructs.Construct, id *string, props *AppTheoryMediaCdnProps) AppTheoryMediaCdn {
 	_init_.Initialize()
 
@@ -194,4 +193,3 @@ func (a *jsiiProxy_AppTheoryMediaCdn) ToString() *string {
 
 	return returns
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryMediaCdnProps.go
+++ b/cdk-go/apptheorycdk/AppTheoryMediaCdnProps.go
@@ -62,4 +62,3 @@ type AppTheoryMediaCdnProps struct {
 	// Optional web ACL ID for AWS WAF integration.
 	WebAclId *string `field:"optional" json:"webAclId" yaml:"webAclId"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryMediaCdn__checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryMediaCdn__checks.go
@@ -36,4 +36,3 @@ func validateNewAppTheoryMediaCdnParameters(scope constructs.Construct, id *stri
 
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryMediaCdn__no_checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryMediaCdn__no_checks.go
@@ -11,4 +11,3 @@ func validateAppTheoryMediaCdn_IsConstructParameters(x interface{}) error {
 func validateNewAppTheoryMediaCdnParameters(scope constructs.Construct, id *string, props *AppTheoryMediaCdnProps) error {
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontend.go
+++ b/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontend.go
@@ -91,7 +91,6 @@ func (j *jsiiProxy_AppTheoryPathRoutedFrontend) SpaRewriteFunction() awscloudfro
 	return returns
 }
 
-
 func NewAppTheoryPathRoutedFrontend(scope constructs.Construct, id *string, props *AppTheoryPathRoutedFrontendProps) AppTheoryPathRoutedFrontend {
 	_init_.Initialize()
 
@@ -166,4 +165,3 @@ func (a *jsiiProxy_AppTheoryPathRoutedFrontend) ToString() *string {
 
 	return returns
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontendProps.go
+++ b/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontendProps.go
@@ -50,4 +50,3 @@ type AppTheoryPathRoutedFrontendProps struct {
 	// Optional web ACL ID for AWS WAF integration.
 	WebAclId *string `field:"optional" json:"webAclId" yaml:"webAclId"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontend__checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontend__checks.go
@@ -36,4 +36,3 @@ func validateNewAppTheoryPathRoutedFrontendParameters(scope constructs.Construct
 
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontend__no_checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryPathRoutedFrontend__no_checks.go
@@ -11,4 +11,3 @@ func validateAppTheoryPathRoutedFrontend_IsConstructParameters(x interface{}) er
 func validateNewAppTheoryPathRoutedFrontendParameters(scope constructs.Construct, id *string, props *AppTheoryPathRoutedFrontendProps) error {
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueue.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueue.go
@@ -17,13 +17,13 @@ import (
 // with AppTheoryQueueConsumer for Lambda integration.
 //
 // Example:
-//   // Queue with custom DLQ configuration
-//   const queue = new AppTheoryQueue(stack, 'Queue', {
-//     queueName: 'my-queue',
-//     maxReceiveCount: 5,
-//     dlqRetentionPeriod: Duration.days(14),
-//   });
 //
+//	// Queue with custom DLQ configuration
+//	const queue = new AppTheoryQueue(stack, 'Queue', {
+//	  queueName: 'my-queue',
+//	  maxReceiveCount: 5,
+//	  dlqRetentionPeriod: Duration.days(14),
+//	});
 type AppTheoryQueue interface {
 	constructs.Construct
 	// The Dead Letter Queue, if enabled.
@@ -112,7 +112,6 @@ func (j *jsiiProxy_AppTheoryQueue) QueueUrl() *string {
 	)
 	return returns
 }
-
 
 func NewAppTheoryQueue(scope constructs.Construct, id *string, props *AppTheoryQueueProps) AppTheoryQueue {
 	_init_.Initialize()
@@ -221,4 +220,3 @@ func (a *jsiiProxy_AppTheoryQueue) ToString() *string {
 
 	return returns
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueueConsumer.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueueConsumer.go
@@ -16,16 +16,16 @@ import (
 // with full control over batching, concurrency, and failure reporting.
 //
 // Example:
-//   // Consumer with full configuration
-//   new AppTheoryQueueConsumer(stack, 'Consumer', {
-//     queue: myQueue.queue,
-//     consumer: myFunction,
-//     batchSize: 100,
-//     maxBatchingWindow: Duration.seconds(10),
-//     reportBatchItemFailures: true,
-//     maxConcurrency: 50,
-//   });
 //
+//	// Consumer with full configuration
+//	new AppTheoryQueueConsumer(stack, 'Consumer', {
+//	  queue: myQueue.queue,
+//	  consumer: myFunction,
+//	  batchSize: 100,
+//	  maxBatchingWindow: Duration.seconds(10),
+//	  reportBatchItemFailures: true,
+//	  maxConcurrency: 50,
+//	});
 type AppTheoryQueueConsumer interface {
 	constructs.Construct
 	// The consumer Lambda function.
@@ -88,7 +88,6 @@ func (j *jsiiProxy_AppTheoryQueueConsumer) Queue() awssqs.IQueue {
 	)
 	return returns
 }
-
 
 func NewAppTheoryQueueConsumer(scope constructs.Construct, id *string, props *AppTheoryQueueConsumerProps) AppTheoryQueueConsumer {
 	_init_.Initialize()
@@ -172,4 +171,3 @@ func (a *jsiiProxy_AppTheoryQueueConsumer) ToString() *string {
 
 	return returns
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueueConsumerProps.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueueConsumerProps.go
@@ -45,4 +45,3 @@ type AppTheoryQueueConsumerProps struct {
 	//
 	ReportBatchItemFailures *bool `field:"optional" json:"reportBatchItemFailures" yaml:"reportBatchItemFailures"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueueConsumer__checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueueConsumer__checks.go
@@ -36,4 +36,3 @@ func validateNewAppTheoryQueueConsumerParameters(scope constructs.Construct, id 
 
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueueConsumer__no_checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueueConsumer__no_checks.go
@@ -11,4 +11,3 @@ func validateAppTheoryQueueConsumer_IsConstructParameters(x interface{}) error {
 func validateNewAppTheoryQueueConsumerParameters(scope constructs.Construct, id *string, props *AppTheoryQueueConsumerProps) error {
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueueProps.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueueProps.go
@@ -61,4 +61,3 @@ type AppTheoryQueueProps struct {
 	//
 	VisibilityTimeout awscdk.Duration `field:"optional" json:"visibilityTimeout" yaml:"visibilityTimeout"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueue__checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueue__checks.go
@@ -58,4 +58,3 @@ func validateNewAppTheoryQueueParameters(scope constructs.Construct, id *string,
 
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryQueue__no_checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryQueue__no_checks.go
@@ -23,4 +23,3 @@ func validateAppTheoryQueue_IsConstructParameters(x interface{}) error {
 func validateNewAppTheoryQueueParameters(scope constructs.Construct, id *string, props *AppTheoryQueueProps) error {
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouter.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouter.go
@@ -21,16 +21,16 @@ import (
 // - Custom domain wiring with optional Route53 record.
 //
 // Example:
-//   const router = new AppTheoryRestApiRouter(this, 'Router', {
-//     apiName: 'my-api',
-//     stage: { stageName: 'prod', accessLogging: true, detailedMetrics: true },
-//     cors: true,
-//   });
 //
-//   router.addLambdaIntegration('/sse', ['GET'], sseFn, { streaming: true });
-//   router.addLambdaIntegration('/api/graphql', ['POST'], graphqlFn);
-//   router.addLambdaIntegration('/{proxy+}', ['ANY'], apiFn);
+//	const router = new AppTheoryRestApiRouter(this, 'Router', {
+//	  apiName: 'my-api',
+//	  stage: { stageName: 'prod', accessLogging: true, detailedMetrics: true },
+//	  cors: true,
+//	});
 //
+//	router.addLambdaIntegration('/sse', ['GET'], sseFn, { streaming: true });
+//	router.addLambdaIntegration('/api/graphql', ['POST'], graphqlFn);
+//	router.addLambdaIntegration('/{proxy+}', ['ANY'], apiFn);
 type AppTheoryRestApiRouter interface {
 	constructs.Construct
 	// The access log group (if access logging is enabled).
@@ -128,7 +128,6 @@ func (j *jsiiProxy_AppTheoryRestApiRouter) Stage() awsapigateway.Stage {
 	return returns
 }
 
-
 func NewAppTheoryRestApiRouter(scope constructs.Construct, id *string, props *AppTheoryRestApiRouterProps) AppTheoryRestApiRouter {
 	_init_.Initialize()
 
@@ -214,4 +213,3 @@ func (a *jsiiProxy_AppTheoryRestApiRouter) ToString() *string {
 
 	return returns
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouterCorsOptions.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouterCorsOptions.go
@@ -27,4 +27,3 @@ type AppTheoryRestApiRouterCorsOptions struct {
 	//
 	MaxAge awscdk.Duration `field:"optional" json:"maxAge" yaml:"maxAge"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouterDomainOptions.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouterDomainOptions.go
@@ -37,4 +37,3 @@ type AppTheoryRestApiRouterDomainOptions struct {
 	//
 	SecurityPolicy awsapigateway.SecurityPolicy `field:"optional" json:"securityPolicy" yaml:"securityPolicy"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouterIntegrationOptions.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouterIntegrationOptions.go
@@ -30,4 +30,3 @@ type AppTheoryRestApiRouterIntegrationOptions struct {
 	// For non-streaming routes, defaults to 29 seconds.
 	Timeout awscdk.Duration `field:"optional" json:"timeout" yaml:"timeout"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouterProps.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouterProps.go
@@ -50,4 +50,3 @@ type AppTheoryRestApiRouterProps struct {
 	// Stage configuration.
 	Stage *AppTheoryRestApiRouterStageOptions `field:"optional" json:"stage" yaml:"stage"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouterStageOptions.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouterStageOptions.go
@@ -41,4 +41,3 @@ type AppTheoryRestApiRouterStageOptions struct {
 	//
 	ThrottlingRateLimit *float64 `field:"optional" json:"throttlingRateLimit" yaml:"throttlingRateLimit"`
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouter__checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouter__checks.go
@@ -54,4 +54,3 @@ func validateNewAppTheoryRestApiRouterParameters(scope constructs.Construct, id 
 
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/AppTheoryRestApiRouter__no_checks.go
+++ b/cdk-go/apptheorycdk/AppTheoryRestApiRouter__no_checks.go
@@ -15,4 +15,3 @@ func validateAppTheoryRestApiRouter_IsConstructParameters(x interface{}) error {
 func validateNewAppTheoryRestApiRouterParameters(scope constructs.Construct, id *string, props *AppTheoryRestApiRouterProps) error {
 	return nil
 }
-

--- a/cdk-go/apptheorycdk/MediaCdnDomainConfig.go
+++ b/cdk-go/apptheorycdk/MediaCdnDomainConfig.go
@@ -20,4 +20,3 @@ type MediaCdnDomainConfig struct {
 	// When provided, an A record alias will be created for the domain.
 	HostedZone awsroute53.IHostedZone `field:"optional" json:"hostedZone" yaml:"hostedZone"`
 }
-

--- a/cdk-go/apptheorycdk/PathRoutedFrontendDomainConfig.go
+++ b/cdk-go/apptheorycdk/PathRoutedFrontendDomainConfig.go
@@ -20,4 +20,3 @@ type PathRoutedFrontendDomainConfig struct {
 	// When provided, an A record alias will be created for the domain.
 	HostedZone awsroute53.IHostedZone `field:"optional" json:"hostedZone" yaml:"hostedZone"`
 }
-

--- a/cdk-go/apptheorycdk/PrivateMediaConfig.go
+++ b/cdk-go/apptheorycdk/PrivateMediaConfig.go
@@ -25,4 +25,3 @@ type PrivateMediaConfig struct {
 	// Only used if keyGroup is not provided.
 	PublicKeyPem *string `field:"optional" json:"publicKeyPem" yaml:"publicKeyPem"`
 }
-

--- a/cdk-go/apptheorycdk/SpaOriginConfig.go
+++ b/cdk-go/apptheorycdk/SpaOriginConfig.go
@@ -16,4 +16,3 @@ type SpaOriginConfig struct {
 	// Defaults to CACHING_OPTIMIZED.
 	CachePolicy awscloudfront.ICachePolicy `field:"optional" json:"cachePolicy" yaml:"cachePolicy"`
 }
-


### PR DESCRIPTION
CI for staging→premain promotion is failing fmt-check due to non-gofmt'd generated Go bindings.\n\nThis PR applies gofmt to the generated files under cdk-go/apptheorycdk/.