### PR TITLE
docs(agentcore): add MCP/AgentCore deployment guide

### DIFF
--- a/cdk/docs/README.md
+++ b/cdk/docs/README.md
@@ -18,6 +18,7 @@
 
 ### 🧭 Guides (copy/paste patterns)
 - [REST API v1 Router + Streaming](./rest-api-router-streaming.md) — multi-Lambda REST API v1 + full response streaming parity.
+- [MCP Server for Bedrock AgentCore](./mcp-server-agentcore.md) — deploy `POST /mcp` (HTTP API v2) for AgentCore tool calls.
 - [SQS Queue + Consumer Patterns](./sqs-queue-consumer.md) — queue-only, queue+consumer, and processor patterns (DLQs + partial batch failures).
 - [Lambda Role Helper](./lambda-role.md) — Lambda execution roles (baseline + X-Ray + KMS + custom statements).
 - [CloudFront Path-Routed Frontend Distribution](./path-routed-frontend.md) — multi-SPA routing behind one stage domain.

--- a/cdk/docs/_concepts.yaml
+++ b/cdk/docs/_concepts.yaml
@@ -14,3 +14,13 @@ concepts:
       - aws_cdk_v2
       - node_24
 
+  mcp_server_agentcore:
+    type: construct
+    purpose: "Provision an HTTP API `POST /mcp` endpoint for MCP / Bedrock AgentCore tool calls."
+    provides:
+      - http_api_v2_route
+      - optional_session_table
+      - optional_custom_domain
+      - optional_stage_logging_throttling
+    related_docs:
+      - cdk/docs/mcp-server-agentcore.md

--- a/cdk/docs/api-reference.md
+++ b/cdk/docs/api-reference.md
@@ -10,6 +10,7 @@ AppTheory CDK exports constructs such as:
 - `AppTheoryFunction` (Lambda wrapper defaults)
 - `AppTheoryFunctionAlarms` (baseline alarms)
 - `AppTheoryHttpApi` (API Gateway v2 HTTP API + proxy routes)
+- `AppTheoryMcpServer` (API Gateway v2 HTTP API `POST /mcp` for MCP / Bedrock AgentCore)
 - `AppTheoryRestApi` (API Gateway REST API v1 + single-Lambda proxy routes)
 - `AppTheoryRestApiRouter` (API Gateway REST API v1 + multi-Lambda routing + full streaming parity)
 - `AppTheoryWebSocketApi` (WebSocket API + routes/permissions; optional connection table + stage access logging)

--- a/cdk/docs/mcp-server-agentcore.md
+++ b/cdk/docs/mcp-server-agentcore.md
@@ -1,0 +1,185 @@
+# MCP Server for Bedrock AgentCore
+
+This guide shows how to deploy an **MCP (Model Context Protocol)** endpoint for **Bedrock AgentCore** using **AppTheory CDK**.
+
+The construct you want is:
+
+- `AppTheoryMcpServer` — provisions an API Gateway v2 **HTTP API** with `POST /mcp` routed to your Lambda handler.
+
+It also supports:
+
+- Optional DynamoDB session table (TTL + permissions + env vars)
+- Optional custom domain + Route53 CNAME
+- Optional stage options (name, access logs, throttling)
+
+If you’re looking for the Go runtime implementation (tools + handler), see `docs/agentcore-mcp.md`.
+
+---
+
+## Minimal TypeScript stack
+
+```ts
+import * as cdk from "aws-cdk-lib";
+import { Duration } from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+import { AppTheoryMcpServer } from "@theory-cloud/apptheory-cdk";
+
+export class AgentCoreMcpStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const handler = new lambda.Function(this, "McpHandler", {
+      runtime: lambda.Runtime.PROVIDED_AL2023,
+      handler: "bootstrap",
+      code: lambda.Code.fromAsset("dist/mcp-handler"), // your Go build output
+      memorySize: 1024,
+      timeout: Duration.seconds(30),
+    });
+
+    const mcp = new AppTheoryMcpServer(this, "McpServer", {
+      handler,
+    });
+
+    new cdk.CfnOutput(this, "McpEndpoint", { value: mcp.endpoint });
+  }
+}
+```
+
+This deploys:
+
+- HTTP API Gateway v2
+- `POST /mcp` route → your Lambda
+- Output `mcp.endpoint` (this is the URL you configure in AgentCore)
+
+---
+
+## Minimal Python stack
+
+```py
+from aws_cdk import (
+    CfnOutput,
+    Duration,
+    Stack,
+)
+from aws_cdk import aws_lambda as _lambda
+from constructs import Construct
+
+from apptheory_cdk import AppTheoryMcpServer
+
+
+class AgentCoreMcpStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        handler = _lambda.Function(
+            self,
+            "McpHandler",
+            runtime=_lambda.Runtime.PROVIDED_AL2023,
+            handler="bootstrap",
+            code=_lambda.Code.from_asset("dist/mcp-handler"),
+            memory_size=1024,
+            timeout=Duration.seconds(30),
+        )
+
+        mcp = AppTheoryMcpServer(self, "McpServer", handler=handler)
+        CfnOutput(self, "McpEndpoint", value=mcp.endpoint)
+```
+
+---
+
+## Sessions (optional DynamoDB table)
+
+To enable a DynamoDB session table:
+
+```ts
+const mcp = new AppTheoryMcpServer(this, "McpServer", {
+  handler,
+  enableSessionTable: true,
+  sessionTtlMinutes: 60,
+});
+```
+
+What you get:
+
+- A DynamoDB table with:
+  - Partition key: `sessionId` (string)
+  - TTL attribute: `expiresAt`
+- Read/write permissions granted to your Lambda
+- Lambda env vars:
+  - `MCP_SESSION_TABLE` (table name)
+  - `MCP_SESSION_TTL_MINUTES` (TTL minutes)
+
+Important:
+
+- The **CDK construct does not automatically switch your runtime to DynamoDB-backed sessions**.
+- In Go, choose the Dynamo session store explicitly (see `docs/agentcore-mcp.md`).
+
+---
+
+## Custom domain (optional)
+
+AppTheory is a framework — your platform can (and often should) apply a custom domain.
+
+```ts
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as route53 from "aws-cdk-lib/aws-route53";
+
+const zone = route53.HostedZone.fromLookup(this, "Zone", { domainName: "example.com" });
+const cert = acm.Certificate.fromCertificateArn(this, "Cert", "arn:aws:acm:...");
+
+const mcp = new AppTheoryMcpServer(this, "McpServer", {
+  handler,
+  domain: {
+    domainName: "mcp.example.com",
+    certificate: cert,
+    hostedZone: zone, // creates a CNAME automatically
+  },
+});
+
+// With a custom domain, the endpoint is always:
+// https://mcp.example.com/mcp
+```
+
+Notes:
+
+- Provide either `certificate` or `certificateArn`.
+- If you omit `hostedZone`, the domain is created but DNS is not (bring your own record management).
+
+---
+
+## Stage options (logging + throttling)
+
+`AppTheoryMcpServer` defaults to the `$default` stage.
+
+To create an explicit stage and enable access logs / throttling:
+
+```ts
+const mcp = new AppTheoryMcpServer(this, "McpServer", {
+  handler,
+  stage: {
+    stageName: "prod",
+    accessLogging: true,
+    throttlingRateLimit: 50,
+    throttlingBurstLimit: 100,
+  },
+});
+```
+
+When you’re using the execute-api hostname (no custom domain), non-`$default` stages include the stage path:
+
+- `https://{apiId}.execute-api.{region}.amazonaws.com/prod/mcp`
+
+When you’re using a custom domain, the construct maps the stage to the domain root:
+
+- `https://mcp.example.com/mcp`
+
+---
+
+## Security note
+
+This construct wires a public HTTP endpoint by default. Secure it intentionally:
+
+- Enforce auth in your Lambda (shared secret header, JWT verification, etc.), and/or
+- Extend the API configuration in your own construct if you require authorizers/WAF/private networking.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 ### 📚 Core documentation
 - [API Reference](./api-reference.md) — public surfaces + where to find the authoritative snapshots.
 - [Core Patterns](./core-patterns.md) — canonical patterns (and anti-patterns) for routing, middleware, streaming, and errors.
+- [Bedrock AgentCore (MCP Gateway)](./agentcore-mcp.md) — deploy an MCP tool server for AgentCore (Go runtime + CDK).
 - [Development Guidelines](./development-guidelines.md) — repo conventions, version alignment, and regeneration steps.
 - [Testing Guide](./testing-guide.md) — unit tests, contract tests, and rubric verification.
 - [Troubleshooting](./troubleshooting.md) — common symptoms → verified fixes.

--- a/docs/_concepts.yaml
+++ b/docs/_concepts.yaml
@@ -86,3 +86,18 @@ concepts:
       - lambda_defaults
     configuration:
       - cdk/
+
+  mcp_gateway:
+    type: component
+    purpose: "Expose MCP (Model Context Protocol) over HTTP for Bedrock AgentCore tool integrations."
+    provides:
+      - jsonrpc_2_0_methods
+      - tools_registry
+      - session_management
+      - optional_sse_progress_streaming
+    configuration:
+      - runtime/mcp/
+      - cdk/lib/mcp-server.ts
+    docs:
+      - docs/agentcore-mcp.md
+      - cdk/docs/mcp-server-agentcore.md

--- a/docs/agentcore-mcp.md
+++ b/docs/agentcore-mcp.md
@@ -1,0 +1,303 @@
+# Bedrock AgentCore + AppTheory (MCP Gateway)
+
+This guide explains how to expose an **MCP (Model Context Protocol)** server from an AppTheory Lambda so **Bedrock AgentCore** can call your tools.
+
+AppTheory provides two building blocks:
+
+- **Runtime (Go):** `github.com/theory-cloud/apptheory/runtime/mcp` — an MCP JSON-RPC handler (`initialize`, `tools/list`, `tools/call`), tool registry, sessions, and optional SSE progress streaming.
+- **CDK (TypeScript/Python):** `AppTheoryMcpServer` — an API Gateway v2 HTTP API with `POST /mcp` → Lambda, optional session table, optional custom domain, and optional stage logging/throttling.
+
+If you’re trying to answer “what do I deploy and what code do I write?”, start with **Quick Start** below.
+
+---
+
+## What you deploy (high level)
+
+```
+Bedrock AgentCore  ──HTTP POST /mcp──>  API Gateway (HTTP API)  ──>  Lambda (Go)
+                                                              └──>  AppTheory route POST /mcp
+                                                                   └──> MCP server (tools registry)
+```
+
+Key details:
+
+- The MCP endpoint is **`POST /mcp`**.
+- The payload is **JSON-RPC 2.0** (`jsonrpc: "2.0"`) with an `id`, `method`, and optional `params`.
+- Session state is tracked via the **`mcp-session-id`** header (server issues one if you don’t send it).
+- MCP errors are returned as JSON-RPC errors (HTTP status is still `200`).
+
+---
+
+## Quick start (Go runtime)
+
+Deploy an HTTP API with `POST /mcp` and point AgentCore at the resulting `/mcp` URL.
+
+```go
+package main
+
+import (
+  "context"
+  "encoding/json"
+  "fmt"
+  "os"
+
+  "github.com/aws/aws-lambda-go/events"
+  "github.com/aws/aws-lambda-go/lambda"
+
+  apptheory "github.com/theory-cloud/apptheory/runtime"
+  "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+func serviceVersion() string {
+  if v := os.Getenv("SERVICE_VERSION"); v != "" {
+    return v
+  }
+  return "dev"
+}
+
+func main() {
+  srv := mcp.NewServer("my-agentcore-tools", serviceVersion())
+
+  // Example tool: echo
+  if err := srv.Registry().RegisterTool(mcp.ToolDef{
+    Name:        "echo",
+    Description: "Echo back the provided message.",
+    InputSchema: json.RawMessage(`{
+      "type": "object",
+      "properties": { "message": { "type": "string" } },
+      "required": ["message"]
+    }`),
+  }, func(ctx context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
+    var in struct {
+      Message string `json:"message"`
+    }
+    if err := json.Unmarshal(args, &in); err != nil {
+      return nil, fmt.Errorf("invalid args: %w", err)
+    }
+    return &mcp.ToolResult{
+      Content: []mcp.ContentBlock{{Type: "text", Text: in.Message}},
+    }, nil
+  }); err != nil {
+    panic(err)
+  }
+
+  app := apptheory.New()
+  app.Post("/mcp", srv.Handler())
+
+  lambda.Start(func(ctx context.Context, ev events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+    return app.ServeAPIGatewayV2(ctx, ev), nil
+  })
+}
+```
+
+---
+
+## Deploy with AppTheory CDK (`AppTheoryMcpServer`)
+
+Use the CDK construct to provision the HTTP API + `POST /mcp` route + optional session table and domain.
+
+See: `cdk/docs/mcp-server-agentcore.md`.
+
+---
+
+## MCP protocol surface (what AgentCore calls)
+
+AppTheory’s MCP server implements these JSON-RPC methods:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+
+### Example: initialize
+
+```bash
+curl -sS -i \
+  -X POST "https://YOUR_ENDPOINT/mcp" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+```
+
+- The response includes a `mcp-session-id` header.
+- Send that header on subsequent calls to keep a session.
+
+### Example: list tools
+
+```bash
+curl -sS \
+  -X POST "https://YOUR_ENDPOINT/mcp" \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: ${MCP_SESSION_ID}" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+### Example: call a tool
+
+```bash
+curl -sS \
+  -X POST "https://YOUR_ENDPOINT/mcp" \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: ${MCP_SESSION_ID}" \
+  -d '{
+    "jsonrpc":"2.0",
+    "id":3,
+    "method":"tools/call",
+    "params":{
+      "name":"echo",
+      "arguments":{"message":"hello"}
+    }
+  }'
+```
+
+---
+
+## Sessions (stateless HTTP with a session header)
+
+MCP calls are plain HTTP requests. AppTheory adds a lightweight session mechanism:
+
+- Clients send **`mcp-session-id`**.
+- If missing/unknown/expired, the server issues a new session ID and returns it in the response headers.
+- TTL is controlled by `MCP_SESSION_TTL_MINUTES` (default: `60` minutes).
+
+### Persistence options
+
+By default, sessions are stored in-memory (fine for local/dev; not shared across cold starts).
+
+For persistent session storage, use the DynamoDB-backed store:
+
+```go
+import (
+  "os"
+
+  "github.com/theory-cloud/tabletheory"
+  "github.com/theory-cloud/tabletheory/pkg/session"
+  "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+func buildMcpServerWithDynamoSessions() (*mcp.Server, error) {
+  db, err := tabletheory.NewBasic(session.Config{
+    Region: os.Getenv("AWS_REGION"),
+  })
+  if err != nil {
+    return nil, err
+  }
+
+  srv := mcp.NewServer("my-agentcore-tools", "dev",
+    mcp.WithSessionStore(mcp.NewDynamoSessionStore(db)),
+  )
+
+  // Register your tools on srv.Registry() as usual...
+  return srv, nil
+}
+```
+
+Notes:
+
+- If you deploy the CDK `enableSessionTable` option, the construct sets `MCP_SESSION_TABLE` and grants read/write permissions.
+- Your code still needs to choose the Dynamo-backed store (`NewDynamoSessionStore`) to actually persist sessions.
+
+---
+
+## Streaming progress (SSE) for long-running tools
+
+If the client sets `Accept: text/event-stream` on a `tools/call`, AppTheory formats the response as SSE:
+
+- `event: progress` for intermediate events emitted by your tool
+- `event: message` for the final JSON-RPC response
+
+### Implement a streaming tool
+
+```go
+_ = srv.Registry().RegisterStreamingTool(mcp.ToolDef{
+  Name:        "long_task",
+  Description: "Example long-running task with progress events.",
+  InputSchema: json.RawMessage(`{"type":"object","properties":{"steps":{"type":"integer"}}}`),
+}, func(ctx context.Context, args json.RawMessage, emit func(mcp.SSEEvent)) (*mcp.ToolResult, error) {
+  // Emit progress events whenever you want.
+  emit(mcp.SSEEvent{Data: map[string]any{"status": "started"}})
+
+  // ... do work ...
+
+  emit(mcp.SSEEvent{Data: map[string]any{"status": "done"}})
+  return &mcp.ToolResult{Content: []mcp.ContentBlock{{Type: "text", Text: "ok"}}}, nil
+})
+```
+
+### Call it with SSE
+
+```bash
+curl -N \
+  -X POST "https://YOUR_ENDPOINT/mcp" \
+  -H 'content-type: application/json' \
+  -H 'accept: text/event-stream' \
+  -H "mcp-session-id: ${MCP_SESSION_ID}" \
+  -d '{
+    "jsonrpc":"2.0",
+    "id":4,
+    "method":"tools/call",
+    "params":{"name":"long_task","arguments":{"steps":3}}
+  }'
+```
+
+---
+
+## Security checklist (don’t ship an open tool endpoint)
+
+`AppTheoryMcpServer` creates a public HTTP endpoint by default. You should intentionally secure it.
+
+Common approaches:
+
+- **Enforce auth in your handler** (e.g., require a shared secret header or JWT verification).
+- **Put the endpoint on a custom domain** and front it with CloudFront/WAF (if that matches your platform).
+- **Use a private network path** if your AgentCore integration supports it.
+
+AppTheory is a framework — if you need a different domain/auth story, wire it the way your platform requires.
+
+---
+
+## Testing locally (no AWS required)
+
+Use the deterministic MCP test client:
+
+```go
+import (
+  "context"
+  "testing"
+
+  mcptest "github.com/theory-cloud/apptheory/testkit/mcp"
+  "github.com/theory-cloud/apptheory/testkit"
+)
+
+func TestMcpServer(t *testing.T) {
+  env := testkit.New()
+  client := mcptest.NewClient(buildMcpServer(), env)
+
+  _, _ = client.Initialize(context.Background())
+
+  tools, _ := client.ListTools(context.Background())
+  mcptest.AssertHasTools(t, tools, "echo")
+
+  out, _ := client.CallTool(context.Background(), "echo", map[string]any{"message": "hi"})
+  _ = out
+}
+```
+
+---
+
+## Troubleshooting
+
+### 404 / “not found”
+
+- Ensure the deployed route is **`POST /mcp`**.
+- If you’re not using a custom domain and your stage name is not `$default`, the URL is:
+  - `https://{apiId}.execute-api.{region}.amazonaws.com/{stageName}/mcp`
+
+### JSON-RPC “Parse error” / “Invalid request”
+
+- `jsonrpc` must be `"2.0"`.
+- `id` is required.
+- `method` must be one of `initialize`, `tools/list`, `tools/call`.
+
+### “tool not found”
+
+- Confirm the tool is registered on `srv.Registry()`.
+- Confirm the `params.name` matches exactly.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -107,3 +107,13 @@ AppTheory includes a DynamoDB-backed rate limiter with portable semantics:
 
 Use it when you need **cross-instance** rate limiting (DynamoDB is the coordination layer). The portable response
 contract uses `app.rate_limited` with deterministic `Retry-After` when known.
+
+## MCP server (Bedrock AgentCore)
+
+AppTheory includes an MCP (Model Context Protocol) server implementation intended for **Bedrock AgentCore** tool integrations.
+
+- Go runtime package: `runtime/mcp` (JSON-RPC methods: `initialize`, `tools/list`, `tools/call`)
+- Go test helpers: `testkit/mcp` (deterministic in-process MCP client)
+- CDK construct (jsii): `AppTheoryMcpServer` (HTTP API v2 `POST /mcp` → Lambda, optional session table + custom domain)
+
+Guide: `docs/agentcore-mcp.md` and `cdk/docs/mcp-server-agentcore.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,5 +58,5 @@ Use the adapter entrypoints on `*apptheory.App`:
 
 Next:
 - See package-specific docs for full examples: `ts/docs/README.md`, `py/docs/README.md`, `cdk/docs/README.md`.
+- If you’re integrating with Bedrock AgentCore, start here: `docs/agentcore-mcp.md`.
 - If you’re migrating from Lift, start at `docs/migration/from-lift.md`.
-


### PR DESCRIPTION
Adds comprehensive documentation for using Bedrock AgentCore with AppTheory's MCP gateway.

- New end-to-end guide: docs/agentcore-mcp.md (runtime + protocol + sessions + SSE + testing)
- New CDK guide: cdk/docs/mcp-server-agentcore.md (AppTheoryMcpServer, session table, custom domain, stage options)
- Linked from docs/README.md and cdk/docs/README.md and referenced in API docs

Validation:
- scripts/verify-docs-standard.sh (PASS)