### PR TITLE
feat(docs): add package knowledgebase contracts

### DIFF
--- a/cdk/docs/README.md
+++ b/cdk/docs/README.md
@@ -9,9 +9,10 @@
 - [Getting Started](./getting-started.md) — deploy a minimal API backed by an AppTheory Lambda.
 
 ### 📚 Core documentation
+- [Docs Contract](./_contract.yaml) — canonical CDK package knowledgebase scope: fixed ingestible, optional ingestible, and contract-only docs.
 - [API Reference](./api-reference.md) — construct inventory and key props.
 - [Core Patterns](./core-patterns.md) — safe defaults, domains/certs, alarms, and proxy routing.
-- [Development Guidelines](./development-guidelines.md) — jsii build flow and regeneration steps.
+- [Development Guidelines](./development-guidelines.md) — contract-only maintainer guidance for keeping the package docs set aligned.
 - [Testing Guide](./testing-guide.md) — how to run CDK tests and synth checks.
 - [Troubleshooting](./troubleshooting.md) — common synth/deploy failures.
 - [Migration Guide](./migration-guide.md) — moving from ad-hoc CDK stacks.
@@ -31,9 +32,16 @@
 - [Media CDN Pattern](./media-cdn.md) — S3 + CloudFront distribution for media subdomains (optional private media).
 
 ### 🤖 AI knowledge base (YAML triad)
+- Docs Contract: `cdk/docs/_contract.yaml`
 - Concepts: `cdk/docs/_concepts.yaml`
 - Patterns: `cdk/docs/_patterns.yaml`
 - Decisions: `cdk/docs/_decisions.yaml`
+
+## Knowledgebase Canonical Set
+
+- CDK package knowledgebases should ingest the `fixed_ingestible` set declared in `cdk/docs/_contract.yaml` as the canonical core.
+- `cdk/docs/_contract.yaml` and `cdk/docs/development-guidelines.md` are contract-only maintainer surfaces and should not be treated as user-facing knowledgebase content.
+- The guide pages linked above are sanctioned optional ingestible sources for infrastructure-specific KB scopes.
 
 ## What this package is
 

--- a/cdk/docs/_contract.yaml
+++ b/cdk/docs/_contract.yaml
@@ -1,0 +1,36 @@
+contract:
+  fixed_ingestible:
+    - cdk/docs/README.md
+    - cdk/docs/getting-started.md
+    - cdk/docs/api-reference.md
+    - cdk/docs/core-patterns.md
+    - cdk/docs/testing-guide.md
+    - cdk/docs/troubleshooting.md
+    - cdk/docs/migration-guide.md
+    - cdk/docs/_concepts.yaml
+    - cdk/docs/_patterns.yaml
+    - cdk/docs/_decisions.yaml
+  fixed_contract_only:
+    - cdk/docs/_contract.yaml
+    - cdk/docs/development-guidelines.md
+  sanctioned_optional_ingestible:
+    - cdk/docs/rest-api-router-streaming.md
+    - cdk/docs/mcp-server-agentcore.md
+    - cdk/docs/mcp-server-remote-mcp.md
+    - cdk/docs/mcp-protected-resource.md
+    - cdk/docs/sqs-queue-consumer.md
+    - cdk/docs/eventbridge-rule-target.md
+    - cdk/docs/s3-ingest.md
+    - cdk/docs/codebuild-job-runner.md
+    - cdk/docs/jobs-table.md
+    - cdk/docs/lambda-role.md
+    - cdk/docs/path-routed-frontend.md
+    - cdk/docs/media-cdn.md
+    - examples/cdk/import-pipeline/README.md
+  out_of_scope:
+    - docs/development/**
+    - docs/planning/**
+    - docs/archive/**
+    - gov-infra/planning/**
+    - gov-infra/evidence/**
+  contract_only_note: "contract-only surfaces are maintainer-only and not ingestible: cdk/docs/_contract.yaml, cdk/docs/development-guidelines.md"

--- a/cdk/docs/development-guidelines.md
+++ b/cdk/docs/development-guidelines.md
@@ -1,5 +1,17 @@
 # CDK Development Guidelines
 
+This guide is contract-only maintainer guidance. It defines how the CDK package docs contract is maintained and is not part of the ingestible user-facing knowledgebase surface.
+
+## Knowledgebase contract
+
+`cdk/docs/_contract.yaml` is the canonical declaration for CDK package knowledgebase scope.
+
+✅ CORRECT:
+- Treat `fixed_ingestible` as the mandatory CDK package knowledgebase core.
+- Treat `fixed_contract_only` as maintainer-only and never ingest it as user-facing KB content.
+- Add `sanctioned_optional_ingestible` only when the KB scope explicitly needs those specialized guides.
+- Keep `cdk/docs/README.md` and `cdk/docs/_contract.yaml` aligned whenever official package docs are added, retired, or reclassified.
+
 ## Project layout
 
 - Source (TypeScript): `cdk/*.ts`
@@ -25,4 +37,3 @@ From repo root:
 ./scripts/verify-cdk-go.sh
 ./scripts/verify-cdk-synth.sh
 ```
-

--- a/py/docs/README.md
+++ b/py/docs/README.md
@@ -9,20 +9,27 @@
 - [Getting Started](./getting-started.md) — install and run your first route locally.
 
 ### 📚 Core documentation
+- [Docs Contract](./_contract.yaml) — canonical Python package knowledgebase scope: fixed ingestible, optional ingestible, and contract-only docs.
 - [API Reference](./api-reference.md) — key exports and where to find the authoritative public surface.
 - [Core Patterns](./core-patterns.md) — routing, middleware, streaming, SSE, and error patterns.
-- [Development Guidelines](./development-guidelines.md) — lint/build steps and repo conventions.
+- [Development Guidelines](./development-guidelines.md) — contract-only maintainer guidance for keeping the package docs set aligned.
 - [Testing Guide](./testing-guide.md) — unit tests, contract tests, and repo gates.
 - [Troubleshooting](./troubleshooting.md) — common failures and fixes.
 - [Migration Guide](./migration-guide.md) — moving from raw handlers/frameworks.
 
 ### 🤖 AI knowledge base (YAML triad)
+- Docs Contract: `py/docs/_contract.yaml`
 - Concepts: `py/docs/_concepts.yaml`
 - Patterns: `py/docs/_patterns.yaml`
 - Decisions: `py/docs/_decisions.yaml`
+
+## Knowledgebase Canonical Set
+
+- Python package knowledgebases should ingest the `fixed_ingestible` set declared in `py/docs/_contract.yaml` as the canonical core.
+- `py/docs/_contract.yaml` and `py/docs/development-guidelines.md` are contract-only maintainer surfaces and should not be treated as user-facing knowledgebase content.
+- `api-snapshots/py.txt` and `py/README.md` are sanctioned optional sources when a knowledgebase needs export-level or package-root context.
 
 ## Contract note
 
 Portable behavior is defined by the fixture-backed contract:
 `docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
-

--- a/py/docs/_contract.yaml
+++ b/py/docs/_contract.yaml
@@ -1,0 +1,25 @@
+contract:
+  fixed_ingestible:
+    - py/docs/README.md
+    - py/docs/getting-started.md
+    - py/docs/api-reference.md
+    - py/docs/core-patterns.md
+    - py/docs/testing-guide.md
+    - py/docs/troubleshooting.md
+    - py/docs/migration-guide.md
+    - py/docs/_concepts.yaml
+    - py/docs/_patterns.yaml
+    - py/docs/_decisions.yaml
+  fixed_contract_only:
+    - py/docs/_contract.yaml
+    - py/docs/development-guidelines.md
+  sanctioned_optional_ingestible:
+    - api-snapshots/py.txt
+    - py/README.md
+  out_of_scope:
+    - docs/development/**
+    - docs/planning/**
+    - docs/archive/**
+    - gov-infra/planning/**
+    - gov-infra/evidence/**
+  contract_only_note: "contract-only surfaces are maintainer-only and not ingestible: py/docs/_contract.yaml, py/docs/development-guidelines.md"

--- a/py/docs/development-guidelines.md
+++ b/py/docs/development-guidelines.md
@@ -1,5 +1,17 @@
 # Python Development Guidelines
 
+This guide is contract-only maintainer guidance. It defines how the Python package docs contract is maintained and is not part of the ingestible user-facing knowledgebase surface.
+
+## Knowledgebase contract
+
+`py/docs/_contract.yaml` is the canonical declaration for Python package knowledgebase scope.
+
+✅ CORRECT:
+- Treat `fixed_ingestible` as the mandatory Python package knowledgebase core.
+- Treat `fixed_contract_only` as maintainer-only and never ingest it as user-facing KB content.
+- Add `sanctioned_optional_ingestible` only when the KB scope explicitly needs those specialized docs.
+- Keep `py/docs/README.md` and `py/docs/_contract.yaml` aligned whenever official package docs are added, retired, or reclassified.
+
 ## Project layout
 
 - Source: `py/src/apptheory/`
@@ -24,4 +36,3 @@ If you change exports, update snapshots and commit the results:
 ```bash
 ./scripts/update-api-snapshots.sh
 ```
-

--- a/scripts/verify-docs-standard.sh
+++ b/scripts/verify-docs-standard.sh
@@ -12,6 +12,7 @@ required_dirs=(
 
 required_files=(
   "README.md"
+  "_contract.yaml"
   "_concepts.yaml"
   "_patterns.yaml"
   "_decisions.yaml"
@@ -55,26 +56,21 @@ for d in "${required_dirs[@]}"; do
     fi
   fi
 
-  if [[ "${d}" == "docs" ]]; then
-    contract="${d}/_contract.yaml"
-    if [[ ! -f "${contract}" ]]; then
-      echo "FAIL: missing required docs contract file: ${contract}" >&2
-      fail=1
-    elif ! grep -q '^contract:' "${contract}"; then
-      echo "FAIL: ${contract} missing top-level 'contract:' key" >&2
-      fail=1
-    fi
+  contract="${d}/_contract.yaml"
+  if [[ -f "${contract}" ]] && ! grep -q '^contract:' "${contract}"; then
+    echo "FAIL: ${contract} missing top-level 'contract:' key" >&2
+    fail=1
+  fi
 
-    if [[ -f "${readme}" ]] && ! grep -q '\./_contract.yaml' "${readme}"; then
-      echo "FAIL: ${readme} missing link to docs contract" >&2
-      fail=1
-    fi
+  if [[ -f "${readme}" ]] && ! grep -q '\./_contract.yaml' "${readme}"; then
+    echo "FAIL: ${readme} missing link to docs contract" >&2
+    fail=1
+  fi
 
-    dev_guidelines="${d}/development-guidelines.md"
-    if [[ -f "${dev_guidelines}" ]] && ! grep -qi 'contract-only' "${dev_guidelines}"; then
-      echo "FAIL: ${dev_guidelines} must clearly state contract-only scope" >&2
-      fail=1
-    fi
+  dev_guidelines="${d}/development-guidelines.md"
+  if [[ -f "${dev_guidelines}" ]] && ! grep -qi 'contract-only' "${dev_guidelines}"; then
+    echo "FAIL: ${dev_guidelines} must clearly state contract-only scope" >&2
+    fail=1
   fi
 
   concepts="${d}/_concepts.yaml"

--- a/ts/docs/README.md
+++ b/ts/docs/README.md
@@ -9,17 +9,25 @@
 - [Getting Started](./getting-started.md) — install and run your first route locally.
 
 ### 📚 Core documentation
+- [Docs Contract](./_contract.yaml) — canonical TypeScript package knowledgebase scope: fixed ingestible, optional ingestible, and contract-only docs.
 - [API Reference](./api-reference.md) — key exports and where to find the authoritative type surface.
 - [Core Patterns](./core-patterns.md) — routing, middleware, streaming, SSE, and error patterns.
-- [Development Guidelines](./development-guidelines.md) — build/lint steps and how to keep `dist/` in sync.
+- [Development Guidelines](./development-guidelines.md) — contract-only maintainer guidance for keeping the package docs set aligned.
 - [Testing Guide](./testing-guide.md) — unit tests and contract parity checks.
 - [Troubleshooting](./troubleshooting.md) — common failures and fixes.
 - [Migration Guide](./migration-guide.md) — moving from raw Lambda handlers.
 
 ### 🤖 AI knowledge base (YAML triad)
+- Docs Contract: `ts/docs/_contract.yaml`
 - Concepts: `ts/docs/_concepts.yaml`
 - Patterns: `ts/docs/_patterns.yaml`
 - Decisions: `ts/docs/_decisions.yaml`
+
+## Knowledgebase Canonical Set
+
+- TypeScript package knowledgebases should ingest the `fixed_ingestible` set declared in `ts/docs/_contract.yaml` as the canonical core.
+- `ts/docs/_contract.yaml` and `ts/docs/development-guidelines.md` are contract-only maintainer surfaces and should not be treated as user-facing knowledgebase content.
+- `api-snapshots/ts.txt` and `ts/README.md` are sanctioned optional sources when a knowledgebase needs export-level or package-root context.
 
 ## What this package is
 
@@ -31,4 +39,3 @@ AppTheory TypeScript provides:
 
 Contract note: portable behavior is defined by the fixture-backed contract:
 `docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
-

--- a/ts/docs/_contract.yaml
+++ b/ts/docs/_contract.yaml
@@ -1,0 +1,25 @@
+contract:
+  fixed_ingestible:
+    - ts/docs/README.md
+    - ts/docs/getting-started.md
+    - ts/docs/api-reference.md
+    - ts/docs/core-patterns.md
+    - ts/docs/testing-guide.md
+    - ts/docs/troubleshooting.md
+    - ts/docs/migration-guide.md
+    - ts/docs/_concepts.yaml
+    - ts/docs/_patterns.yaml
+    - ts/docs/_decisions.yaml
+  fixed_contract_only:
+    - ts/docs/_contract.yaml
+    - ts/docs/development-guidelines.md
+  sanctioned_optional_ingestible:
+    - api-snapshots/ts.txt
+    - ts/README.md
+  out_of_scope:
+    - docs/development/**
+    - docs/planning/**
+    - docs/archive/**
+    - gov-infra/planning/**
+    - gov-infra/evidence/**
+  contract_only_note: "contract-only surfaces are maintainer-only and not ingestible: ts/docs/_contract.yaml, ts/docs/development-guidelines.md"

--- a/ts/docs/development-guidelines.md
+++ b/ts/docs/development-guidelines.md
@@ -1,5 +1,17 @@
 # TypeScript Development Guidelines
 
+This guide is contract-only maintainer guidance. It defines how the TypeScript package docs contract is maintained and is not part of the ingestible user-facing knowledgebase surface.
+
+## Knowledgebase contract
+
+`ts/docs/_contract.yaml` is the canonical declaration for TypeScript package knowledgebase scope.
+
+✅ CORRECT:
+- Treat `fixed_ingestible` as the mandatory TypeScript package knowledgebase core.
+- Treat `fixed_contract_only` as maintainer-only and never ingest it as user-facing KB content.
+- Add `sanctioned_optional_ingestible` only when the KB scope explicitly needs those specialized docs.
+- Keep `ts/docs/README.md` and `ts/docs/_contract.yaml` aligned whenever official package docs are added, retired, or reclassified.
+
 ## Project layout
 
 - Source: `ts/src/`
@@ -24,4 +36,3 @@ If you change exports, update snapshots and commit the results:
 ```bash
 ./scripts/update-api-snapshots.sh
 ```
-


### PR DESCRIPTION
## Summary
- add explicit `_contract.yaml` files for `ts/docs`, `py/docs`, and `cdk/docs`
- wire each package docs index to its contract and mark development guidelines as contract-only maintainer guidance
- extend `scripts/verify-docs-standard.sh` so package docs contracts are enforced alongside the repo-level contract

## Testing
- `bash ./scripts/verify-docs-standard.sh`
