### PR TITLE
docs: expand AppSync and MCP coverage

### DIFF
--- a/docs/agentcore-mcp.md
+++ b/docs/agentcore-mcp.md
@@ -26,6 +26,7 @@ Key details:
 - The MCP endpoint is **`POST /mcp`**.
 - The payload is **JSON-RPC 2.0** (`jsonrpc: "2.0"`) with an `id`, `method`, and optional `params`.
 - Session state is tracked via the **`Mcp-Session-Id`** header (issued on the `initialize` response).
+- Follow-up calls should also send **`MCP-Protocol-Version`** matching the negotiated `initialize` result.
 - MCP errors are returned as JSON-RPC errors (HTTP status is still `200`).
 
 ---
@@ -118,11 +119,12 @@ AgentCore typically uses only the tools surface. AppTheory also supports additio
 curl -sS -i \
   -X POST "https://YOUR_ENDPOINT/mcp" \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"agentcore","version":"unknown"}}}'
 ```
 
 - The response includes a `mcp-session-id` header.
 - Send that header on subsequent calls to keep a session.
+- Send `mcp-protocol-version` on subsequent calls as well.
 
 ### Example: list tools
 
@@ -131,6 +133,7 @@ curl -sS \
   -X POST "https://YOUR_ENDPOINT/mcp" \
   -H 'content-type: application/json' \
   -H "mcp-session-id: ${MCP_SESSION_ID}" \
+  -H 'mcp-protocol-version: 2025-11-25' \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 ```
 
@@ -141,6 +144,7 @@ curl -sS \
   -X POST "https://YOUR_ENDPOINT/mcp" \
   -H 'content-type: application/json' \
   -H "mcp-session-id: ${MCP_SESSION_ID}" \
+  -H 'mcp-protocol-version: 2025-11-25' \
   -d '{
     "jsonrpc":"2.0",
     "id":3,
@@ -158,8 +162,10 @@ curl -sS \
 
 MCP calls are plain HTTP requests. AppTheory adds a lightweight session mechanism:
 
-- Clients send **`mcp-session-id`**.
-- If missing/unknown/expired, the server issues a new session ID and returns it in the response headers.
+- `initialize` issues **`mcp-session-id`**.
+- After initialization, clients must send **`mcp-session-id`** on follow-up requests.
+- Missing session headers fail with `400`.
+- Unknown or expired sessions fail with `404`.
 - TTL is controlled by `MCP_SESSION_TTL_MINUTES` (default: `60` minutes).
 
 ### Persistence options
@@ -205,8 +211,9 @@ Notes:
 
 If the client sets `Accept: text/event-stream` on a `tools/call`, AppTheory formats the response as SSE:
 
-- `event: progress` for intermediate events emitted by your tool
-- `event: message` for the final JSON-RPC response
+- every SSE frame is `event: message`
+- intermediate progress is emitted as JSON-RPC `notifications/progress`
+- the final frame is the JSON-RPC response to the original `tools/call`
 
 Important adapter note:
 
@@ -240,6 +247,7 @@ curl -N \
   -H 'content-type: application/json' \
   -H 'accept: text/event-stream' \
   -H "mcp-session-id: ${MCP_SESSION_ID}" \
+  -H 'mcp-protocol-version: 2025-11-25' \
   -d '{
     "jsonrpc":"2.0",
     "id":4,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,10 +106,32 @@ AppTheory supports the standard AWS direct Lambda resolver event shape in all th
   - Go: `AppSyncResolverEvent`, `AppSyncResolverInfo`, `AppSyncResolverRequest`
   - TypeScript: `AppSyncResolverEvent`, `AppSyncResolverInfo`, `AppSyncResolverRequest`
   - Python: `AppSyncResolverEvent`, `AppSyncResolverInfo`, `AppSyncResolverRequest`
+- Core event fields:
+  - `arguments`: top-level resolver arguments; adapted into the JSON request body
+  - `info.fieldName` + `info.parentTypeName`: determine the AppTheory route and method
+  - `info.variables`: preserved on the typed context and raw event
+  - `info.selectionSetList` + `info.selectionSetGraphQL`: preserved on the exported event types and available on the raw event for selection-set-aware handlers
+  - `request.headers`: forwarded to the synthesized request
+  - `identity`, `source`, `prev`, and `stash`: preserved on the typed context and portable metadata keys
 - Typed context:
   - Go: `ctx.AsAppSync()`
   - TypeScript: `ctx.asAppSync()`
   - Python: `ctx.as_appsync()`
+- Portable context metadata keys:
+
+| Key | Meaning |
+| --- | --- |
+| `apptheory.trigger_type` | Constant `"appsync"` |
+| `apptheory.appsync.field_name` | GraphQL field name |
+| `apptheory.appsync.parent_type_name` | GraphQL parent type |
+| `apptheory.appsync.arguments` | Top-level resolver arguments |
+| `apptheory.appsync.identity` | Resolver identity payload |
+| `apptheory.appsync.source` | Parent/source object |
+| `apptheory.appsync.variables` | GraphQL variables |
+| `apptheory.appsync.prev` | Previous resolver result |
+| `apptheory.appsync.stash` | Resolver stash map |
+| `apptheory.appsync.request_headers` | Forwarded AppSync request headers |
+| `apptheory.appsync.raw_event` | Full resolver event |
 - Request adaptation:
   - `Mutation -> POST /fieldName`
   - `Query -> GET /fieldName`
@@ -118,12 +140,14 @@ AppTheory supports the standard AWS direct Lambda resolver event shape in all th
   - `request.headers` are forwarded and `content-type: application/json` is synthesized when absent
 - Response behavior:
   - JSON bodies project back to native resolver payloads
-  - `text/*` bodies project to UTF-8 strings
   - empty bodies project to `null`
+  - any other non-empty body projects to a UTF-8 string
   - binary and streaming bodies fail closed with deterministic AppSync system errors
 - Error behavior:
   - handler failures return Lift-compatible AppSync error objects with `pay_theory_error`, `error_message`,
     `error_type`, `error_data`, and `error_info`
+  - portable AppTheory/AppError payloads include `error_data.status_code` and may include `request_id`, `trace_id`,
+    `timestamp`, plus `error_info.code`, `trigger_type`, `method`, `path`, and optional `details`
 
 Recipe:
 
@@ -191,8 +215,12 @@ Known configuration keys surfaced by canonical docs:
 
 AppTheory includes Go runtime support for MCP and OAuth-adjacent remote-MCP flows:
 
-- `runtime/mcp`: JSON-RPC server methods, registries, and session support
-- `testkit/mcp`: deterministic in-process MCP test helpers
+- `runtime/mcp`: Streamable HTTP `POST/GET/DELETE /mcp`, protocol negotiation, origin validation, sessions, resumable
+  SSE, and the MCP request surface (`initialize`, `ping`, `tools/*`, `resources/*`, `prompts/*`, plus accepted
+  `notifications/initialized` / `notifications/cancelled`)
+- `testkit/mcp`: deterministic in-process MCP client helpers (`NewClient`, `Initialize`, `ListTools`, `CallTool`,
+  `ListResources`, `ReadResource`, `ListPrompts`, `GetPrompt`, `RawStream`, `ResumeStream`) plus JSON-RPC request
+  builders and assertions
 - `runtime/oauth`: protected-resource metadata, challenges, DCR, PKCE, and token-store helpers
 - `testkit/oauth`: end-to-end OAuth flow helpers for remote MCP tests
 

--- a/docs/cdk/mcp-protected-resource.md
+++ b/docs/cdk/mcp-protected-resource.md
@@ -1,25 +1,48 @@
-# MCP Protected Resource Metadata
+# MCP Protected Resource Metadata (OAuth) - RFC9728
 
-Use `AppTheoryMcpProtectedResource` to add the OAuth protected-resource metadata endpoint required for Claude Remote
-MCP discovery.
+Claude Remote MCP requires an OAuth protected-resource metadata endpoint for discovery.
 
-## What it adds
+This guide covers `AppTheoryMcpProtectedResource`, which adds:
 
 - `GET /.well-known/oauth-protected-resource`
 
-Clients expect this after a `401 Unauthorized` response that includes a `WWW-Authenticate: Bearer` challenge with
-`resource_metadata=...`.
+## What Claude expects
 
-## Minimal example
+When calling your MCP server without a token, Claude expects:
+
+- `401 Unauthorized`
+- `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"`
+
+Claude then fetches the metadata endpoint and expects JSON like:
+
+```json
+{
+  "resource": "https://mcp.example.com/mcp",
+  "authorization_servers": ["https://auth.example.com"]
+}
+```
+
+## TypeScript example
 
 ```ts
+import { Stack } from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import {
   AppTheoryMcpProtectedResource,
   AppTheoryRemoteMcpServer,
 } from "@theory-cloud/apptheory-cdk";
 
+const stack = new Stack();
+
+const handler = new lambda.Function(stack, "McpHandler", {
+  runtime: lambda.Runtime.PROVIDED_AL2023,
+  handler: "bootstrap",
+  code: lambda.Code.fromAsset("dist"),
+});
+
 const mcp = new AppTheoryRemoteMcpServer(stack, "RemoteMcp", {
   handler,
+  apiName: "remote-mcp",
 });
 
 new AppTheoryMcpProtectedResource(stack, "ProtectedResource", {
@@ -29,5 +52,10 @@ new AppTheoryMcpProtectedResource(stack, "ProtectedResource", {
 });
 ```
 
-This construct only adds the metadata endpoint. Your MCP Lambda still needs to enforce bearer auth and emit the
-challenge on unauthorized requests.
+## Important notes
+
+- this construct only adds the metadata endpoint
+- your MCP Lambda still needs to enforce `Authorization: Bearer ...` and emit the `WWW-Authenticate` challenge on
+  `401`
+- the `resource` value should match the actual `/mcp` URL the client uses, including any custom domain or base path
+- for API Gateway REST APIs, `/.well-known/...` sits under the same stage or base path as your `/mcp` route

--- a/docs/cdk/mcp-server-agentcore.md
+++ b/docs/cdk/mcp-server-agentcore.md
@@ -1,15 +1,32 @@
 # MCP Server for Bedrock AgentCore
 
-Use `AppTheoryMcpServer` when you need a canonical AppTheory CDK deployment for Bedrock AgentCore tool calls.
+This guide shows how to deploy an MCP endpoint for Bedrock AgentCore using AppTheory CDK.
 
-## What it provisions
+The construct you want is:
 
-- API Gateway HTTP API v2
-- `POST /mcp` routed to your Lambda handler
-- optional DynamoDB session table
-- optional custom domain and stage controls
+- `AppTheoryMcpServer` - provisions an API Gateway v2 HTTP API with `POST /mcp` routed to your Lambda handler
 
-If you need true response streaming for Remote MCP, use `AppTheoryRemoteMcpServer` instead.
+It also supports:
+
+- optional DynamoDB session table (TTL + permissions + env vars)
+- optional custom domain + Route53 CNAME
+- optional stage options (name, access logs, throttling)
+
+If you're looking for the Go runtime implementation (tools + handler), see `docs/agentcore-mcp.md`.
+
+Note on SSE progress streaming:
+
+- this construct uses HTTP API v2, so many deployments will buffer responses and not deliver incremental SSE progress
+- if you require true response streaming, use an API Gateway REST API v1 streaming pattern
+- for Claude Remote MCP, use `AppTheoryRemoteMcpServer` instead
+
+Related docs:
+
+- `docs/agentcore-mcp.md`
+- `docs/cdk/mcp-server-remote-mcp.md`
+- `docs/cdk/rest-api-router-streaming.md`
+
+---
 
 ## Minimal TypeScript stack
 
@@ -17,11 +34,13 @@ If you need true response streaming for Remote MCP, use `AppTheoryRemoteMcpServe
 import * as cdk from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
 import { AppTheoryMcpServer } from "@theory-cloud/apptheory-cdk";
 
 export class AgentCoreMcpStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
 
     const handler = new lambda.Function(this, "McpHandler", {
       runtime: lambda.Runtime.PROVIDED_AL2023,
@@ -31,19 +50,146 @@ export class AgentCoreMcpStack extends cdk.Stack {
       timeout: Duration.seconds(30),
     });
 
-    new AppTheoryMcpServer(this, "McpServer", { handler });
+    const mcp = new AppTheoryMcpServer(this, "McpServer", {
+      handler,
+    });
+
+    new cdk.CfnOutput(this, "McpEndpoint", { value: mcp.endpoint });
   }
 }
 ```
 
-## Session table option
+This deploys:
+
+- HTTP API Gateway v2
+- `POST /mcp` route -> your Lambda
+- output `mcp.endpoint` (the URL you configure in AgentCore)
+
+---
+
+## Minimal Python stack
+
+```py
+from aws_cdk import (
+    CfnOutput,
+    Duration,
+    Stack,
+)
+from aws_cdk import aws_lambda as _lambda
+from constructs import Construct
+
+from apptheory_cdk import AppTheoryMcpServer
+
+
+class AgentCoreMcpStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        handler = _lambda.Function(
+            self,
+            "McpHandler",
+            runtime=_lambda.Runtime.PROVIDED_AL2023,
+            handler="bootstrap",
+            code=_lambda.Code.from_asset("dist/mcp-handler"),
+            memory_size=1024,
+            timeout=Duration.seconds(30),
+        )
+
+        mcp = AppTheoryMcpServer(self, "McpServer", handler=handler)
+        CfnOutput(self, "McpEndpoint", value=mcp.endpoint)
+```
+
+---
+
+## Sessions (optional DynamoDB table)
+
+To enable a DynamoDB session table:
 
 ```ts
-new AppTheoryMcpServer(this, "McpServer", {
+const mcp = new AppTheoryMcpServer(this, "McpServer", {
   handler,
   enableSessionTable: true,
   sessionTtlMinutes: 60,
 });
 ```
 
-This grants table access to the Lambda and sets `MCP_SESSION_TABLE` plus `MCP_SESSION_TTL_MINUTES`.
+What you get:
+
+- a DynamoDB table with:
+  - partition key: `sessionId` (string)
+  - TTL attribute: `expiresAt`
+- read/write permissions granted to your Lambda
+- Lambda env vars:
+  - `MCP_SESSION_TABLE`
+  - `MCP_SESSION_TTL_MINUTES`
+
+Important:
+
+- the CDK construct does not automatically switch your runtime to DynamoDB-backed sessions
+- in Go, choose the Dynamo session store explicitly (see `docs/agentcore-mcp.md`)
+
+---
+
+## Custom domain (optional)
+
+AppTheory is a framework, so your platform can apply a custom domain when it makes sense.
+
+```ts
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as route53 from "aws-cdk-lib/aws-route53";
+
+const zone = route53.HostedZone.fromLookup(this, "Zone", { domainName: "example.com" });
+const cert = acm.Certificate.fromCertificateArn(this, "Cert", "arn:aws:acm:...");
+
+const mcp = new AppTheoryMcpServer(this, "McpServer", {
+  handler,
+  domain: {
+    domainName: "mcp.example.com",
+    certificate: cert,
+    hostedZone: zone,
+  },
+});
+```
+
+Notes:
+
+- provide either `certificate` or `certificateArn`
+- if you omit `hostedZone`, the domain is created but DNS is not
+- with a custom domain, the endpoint is always `https://mcp.example.com/mcp`
+
+---
+
+## Stage options (logging + throttling)
+
+`AppTheoryMcpServer` defaults to the `$default` stage.
+
+To create an explicit stage and enable access logs or throttling:
+
+```ts
+const mcp = new AppTheoryMcpServer(this, "McpServer", {
+  handler,
+  stage: {
+    stageName: "prod",
+    accessLogging: true,
+    throttlingRateLimit: 50,
+    throttlingBurstLimit: 100,
+  },
+});
+```
+
+When you're using the execute-api hostname and a non-`$default` stage, the stage path is part of the URL:
+
+- `https://{apiId}.execute-api.{region}.amazonaws.com/prod/mcp`
+
+When you're using a custom domain, the construct maps the stage to the domain root:
+
+- `https://mcp.example.com/mcp`
+
+---
+
+## Security note
+
+This construct wires a public HTTP endpoint by default. Secure it intentionally:
+
+- enforce auth in your Lambda (shared secret header, JWT verification, etc.)
+- add surrounding platform controls if you need them (custom domains, WAF, private networking, authorizers)

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -1,25 +1,33 @@
-# Claude Remote MCP + Streaming
+# Claude Remote MCP (Streamable HTTP) - REST API v1 + Streaming
 
-Use `AppTheoryRemoteMcpServer` when you need an AppTheory CDK deployment for Remote MCP with incremental SSE
-streaming.
+This guide covers `AppTheoryRemoteMcpServer`, the recommended CDK construct for Claude Custom Connectors using Remote
+MCP with MCP Streamable HTTP.
 
 ## Why this construct exists
 
-Claude Remote MCP requires real incremental streaming. On AWS that means:
+Claude Remote MCP requires real incremental streaming for tool calls. On AWS that means:
 
 - API Gateway REST API v1, not HTTP API v2
 - Lambda response streaming
 
-`AppTheoryRemoteMcpServer` provisions `/mcp` routes that fit that deployment shape.
+`AppTheoryRemoteMcpServer` provisions a REST API and configures `/mcp` correctly for that deployment shape.
 
 ## What it provisions
 
-- `POST /mcp`
-- `GET /mcp`
-- `DELETE /mcp`
-- optional DynamoDB session and stream tables
+- API Gateway REST API v1
+- `/mcp` routes:
+  - `POST /mcp` (streaming enabled)
+  - `GET /mcp` (streaming enabled; used for `Last-Event-ID` replay and session listeners)
+  - `DELETE /mcp`
+- optional DynamoDB tables:
+  - session table (matches `runtime/mcp/session_dynamo.go` schema)
+  - stream/event table (infra only unless the app wires a concrete `StreamStore`)
 
-## Minimal example
+If you are using OAuth for Claude connectors, also add:
+
+- `GET /.well-known/oauth-protected-resource`
+
+## TypeScript example
 
 ```ts
 import { Stack } from "aws-cdk-lib";
@@ -30,6 +38,7 @@ import {
 } from "@theory-cloud/apptheory-cdk";
 
 const stack = new Stack();
+
 const handler = new lambda.Function(stack, "McpHandler", {
   runtime: lambda.Runtime.PROVIDED_AL2023,
   handler: "bootstrap",
@@ -38,8 +47,11 @@ const handler = new lambda.Function(stack, "McpHandler", {
 
 const mcp = new AppTheoryRemoteMcpServer(stack, "RemoteMcp", {
   handler,
+  apiName: "remote-mcp",
   enableSessionTable: true,
   sessionTtlMinutes: 120,
+  // enableStreamTable: true,
+  // streamTtlMinutes: 120,
 });
 
 new AppTheoryMcpProtectedResource(stack, "ProtectedResource", {
@@ -49,6 +61,48 @@ new AppTheoryMcpProtectedResource(stack, "ProtectedResource", {
 });
 ```
 
-## Keepalive guidance
+## Session and stream tables
 
-Expect SSE disconnects. Prefer resumable streams, `Last-Event-ID`, and periodic progress events for long-running work.
+Session table behavior:
+
+- partition key: `sessionId`
+- TTL attribute: `expiresAt`
+- Lambda env vars:
+  - `MCP_SESSION_TABLE`
+  - `MCP_SESSION_TTL_MINUTES`
+
+Stream table behavior:
+
+- partition key: `sessionId`
+- sort key: `eventId`
+- TTL attribute: `expiresAt`
+- Lambda env vars:
+  - `MCP_STREAM_TABLE`
+  - `MCP_STREAM_TTL_MINUTES`
+
+Important caveat:
+
+- the built-in runtime currently ships `MemoryStreamStore`
+- `enableStreamTable` only provisions storage and injects env vars
+- durable replay requires application code to provide a matching persistent `StreamStore` via `mcp.WithStreamStore(...)`
+
+## Keepalive, replay, and origin guidance
+
+For SSE connections, expect disconnects. Prefer:
+
+- resumable streams (`Last-Event-ID`) + replay from an event log
+- periodic progress updates during long-running work
+- `GET /mcp` without `Last-Event-ID` as a keepalive listener path
+
+If your clients send an `Origin` header, remember that the default runtime allowlist is Claude-oriented:
+
+- `https://claude.ai`
+- `https://claude.com`
+
+Use `mcp.WithOriginValidator(...)` when you need other browser origins.
+
+## Related docs
+
+- `docs/mcp.md`
+- `docs/remote-mcp.md`
+- `docs/cdk/mcp-protected-resource.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,6 +146,8 @@ single-Lambda entrypoint can continue to use `HandleLambda`, `handleLambda`, or 
 Additional repo guide outside the current KT ingest set:
 
 - [Bedrock AgentCore MCP](./agentcore-mcp.md)
+- [Claude Remote MCP](./remote-mcp.md)
+- [MCP Method Surface](./mcp.md)
 
 Package-local quick starts still exist under `ts/docs/` and `py/docs/`, but the canonical cross-language guidance
 starts in `docs/`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,30 +1,62 @@
 # MCP (Model Context Protocol) Server (Go runtime)
 
-This document describes AppTheory’s **MCP server implementation** (`github.com/theory-cloud/apptheory/runtime/mcp`) — the JSON-RPC method surface, registries, payload shapes, sessions, and streaming behavior.
+This document describes AppTheory's MCP server implementation (`github.com/theory-cloud/apptheory/runtime/mcp`) for
+the Go runtime: transport behavior, JSON-RPC surface, registries, sessions, streaming, and test helpers.
 
-If you’re specifically integrating with **Bedrock AgentCore**, start with `docs/agentcore-mcp.md` (it focuses on what to deploy and how AgentCore calls tools).
+If you're specifically integrating with Bedrock AgentCore, start with `docs/agentcore-mcp.md`.
 
 For the Claude-first Remote MCP deployment guide, see:
+
 - `docs/remote-mcp.md`
 
 OAuth helper surfaces used by Remote MCP deployments and Autheory are in:
+
 - `github.com/theory-cloud/apptheory/runtime/oauth`
 
 ---
 
 ## Transport + endpoint
 
-AppTheory’s MCP server implements **MCP Streamable HTTP** on a single endpoint path:
+AppTheory implements MCP Streamable HTTP on a single path:
 
-- `POST /mcp`
-- `GET /mcp` (resume/replay via `Last-Event-ID`)
-- `DELETE /mcp` (terminate session)
+- `POST /mcp`: JSON-RPC requests, notifications, and client responses
+- `GET /mcp`: resumable SSE replay via `Last-Event-ID`, or a keepalive listener when `Last-Event-ID` is absent
+- `DELETE /mcp`: session termination
 
-- Request body: JSON-RPC `{ "jsonrpc": "2.0", "id": ..., "method": "...", "params": { ... } }`
-- Session header: `Mcp-Session-Id` (issued by the server on `initialize`)
-- Protocol header: `MCP-Protocol-Version` (required after initialization)
+Header names are case-insensitive on the wire. The examples in this doc use lowercase HTTP headers.
 
-It is not a stdio transport — you mount it on AppTheory routes:
+- Session header: `mcp-session-id`
+- Protocol header: `mcp-protocol-version`
+- Resume header: `last-event-id`
+
+Important transport behavior:
+
+- `initialize` is the only request that creates a session and returns `mcp-session-id`
+- subsequent `POST /mcp`, `GET /mcp`, and `DELETE /mcp` calls require `mcp-session-id`
+- missing session header returns `400`
+- unknown or expired sessions return `404`
+- `mcp-protocol-version` is optional after initialization; when present it must be supported and must match the
+  session's negotiated protocol version
+- JSON-RPC success and error payloads return HTTP `200`; transport-level failures such as missing sessions, bad
+  protocol headers, rejected origins, or missing replay events return HTTP `4xx` / `5xx`
+
+Supported protocol versions negotiated on `initialize`:
+
+- `2025-11-25` (latest)
+- `2025-06-18`
+- `2025-03-26` (legacy compatibility / batch mode)
+
+If the client requests an unsupported protocol version during `initialize`, AppTheory counter-proposes the latest
+supported version instead of failing the request.
+
+If a request includes an `Origin` header, AppTheory validates it fail-closed. The default allowlist is:
+
+- `https://claude.ai`
+- `https://claude.com`
+
+Use `mcp.WithOriginValidator(...)` to replace that policy for other browser-based callers.
+
+Mounting the handler is still just normal AppTheory routing:
 
 ```go
 srv := mcp.NewServer("my-mcp-server", "dev")
@@ -36,15 +68,14 @@ app.Get("/mcp", h)
 app.Delete("/mcp", h)
 ```
 
-Supported protocol versions (negotiated on `initialize`): `2025-11-25` (latest), `2025-06-18`, `2025-03-26` (legacy).
-
 ---
 
-## Supported JSON-RPC methods
+## Supported JSON-RPC surface
 
-AppTheory currently dispatches these MCP JSON-RPC methods:
+AppTheory currently dispatches these MCP request methods:
 
 - `initialize`
+- `ping`
 - `tools/list`
 - `tools/call`
 - `resources/list`
@@ -52,16 +83,27 @@ AppTheory currently dispatches these MCP JSON-RPC methods:
 - `prompts/list`
 - `prompts/get`
 
+Accepted notification methods:
+
+- `notifications/initialized`
+- `notifications/cancelled`
+
+Other transport notes:
+
+- posted client responses are accepted for Streamable HTTP compliance and return `202 Accepted` with no body
+- notifications also return `202 Accepted` with no body
+- JSON-RPC batch requests are only supported for legacy `2025-03-26` callers
+
 ### Capabilities advertisement (`initialize`)
 
 The `initialize` result always advertises `tools`.
 
-It advertises `resources` and `prompts` **only when something is registered**:
+It advertises `resources` and `prompts` only when something is registered:
 
-- if `srv.Resources().Len() > 0` → `"resources": {}`
-- if `srv.Prompts().Len() > 0` → `"prompts": {}`
+- if `srv.Resources().Len() > 0` -> `"resources": {}`
+- if `srv.Prompts().Len() > 0` -> `"prompts": {}`
 
-This keeps “tools-only” clients stable while still exposing the full MCP surface when you opt in.
+This keeps tools-only clients stable while still exposing the broader MCP surface when you opt in.
 
 ---
 
@@ -89,31 +131,41 @@ _ = srv.Registry().RegisterTool(mcp.ToolDef{
 })
 ```
 
-### Tool results: `ContentBlock` shapes
+`ToolDef` exposes more than the minimal name + schema shape:
 
-Tool results return `content: []ContentBlock` where each content block is one of:
+- required: `Name`, `InputSchema`
+- optional: `Title`, `Description`, `OutputSchema`
+- optional annotations: `Title`, `ReadOnlyHint`, `DestructiveHint`, `IdempotentHint`, `OpenWorldHint`
+- optional icons: `Src`, `MimeType`, `Sizes`, `Theme`
+- optional execution metadata: `TaskSupport` (`"forbidden"`, `"optional"`, `"required"`)
 
-- **Text**: `{ "type": "text", "text": "..." }`
-- **Image**: `{ "type": "image", "data": "<base64>", "mimeType": "image/png" }`
-- **Audio**: `{ "type": "audio", "data": "<base64>", "mimeType": "audio/wav" }`
-- **Resource link**: `{ "type": "resource_link", "uri": "file://...", "name": "..." }`
-- **Embedded resource**:
-  `{ "type": "resource", "resource": { "uri": "file://...", "text": "..." } }`
+### Tool results
 
-If you want to include structured output in addition to the `content` blocks, set:
+`ToolResult` supports:
 
-- `ToolResult.StructuredContent` (encoded into `structuredContent`)
+- `Content`: ordered `[]ContentBlock`
+- `StructuredContent`: serialized as `structuredContent`
+- `IsError`: serialized as `isError`
+
+`ContentBlock` shapes:
+
+- text: `{ "type": "text", "text": "..." }`
+- image: `{ "type": "image", "data": "<base64>", "mimeType": "image/png" }`
+- audio: `{ "type": "audio", "data": "<base64>", "mimeType": "audio/wav" }`
+- resource link:
+  `{ "type": "resource_link", "uri": "file://...", "name": "...", "title": "...", "description": "...", "size": 123 }`
+- embedded resource:
+  `{ "type": "resource", "resource": { "uri": "file://...", "text": "...", "mimeType": "text/plain" } }`
 
 ### Streaming tool progress (SSE)
 
-If the client includes `Accept: text/event-stream` on a `tools/call`, AppTheory may format the response as SSE:
+If the client includes `Accept: text/event-stream` on `tools/call`, AppTheory may respond as SSE:
 
-- Every server message is delivered as an SSE event:
-  - `event: message`
-  - `data: <single JSON-RPC message>`
-- Progress is delivered as JSON-RPC notifications:
-  - `method: "notifications/progress"`
-  - correlated via `params._meta.progressToken` from the original request
+- every SSE frame is `event: message`
+- the frame `data:` is always a single JSON-RPC message
+- progress is emitted as JSON-RPC `notifications/progress`
+- the progress notification is correlated with `params._meta.progressToken` from the original `tools/call`
+- `progressToken` may be a string or an integer
 
 Register a streaming tool with `RegisterStreamingTool`:
 
@@ -132,24 +184,25 @@ _ = srv.Registry().RegisterStreamingTool(mcp.ToolDef{
 
 Important deployment note:
 
-- **True incremental SSE streaming requires a response-streaming adapter**.
-  AppTheory’s `SSEStreamResponse` is supported by the API Gateway **REST API v1** adapter (`ServeAPIGatewayProxy` via `HandleLambda`).
-  If you’re behind an adapter that buffers (common with HTTP API v2), clients may receive progress only after completion.
+- true incremental SSE delivery requires a response-streaming adapter
+- AppTheory's `SSEStreamResponse` is supported by the API Gateway REST API v1 adapter (`ServeAPIGatewayProxy` via
+  `HandleLambda`)
+- if you're behind an adapter that buffers responses, clients may receive progress only after completion
 
-### Resumability (GET + `Last-Event-ID`)
+### Resumability
 
-For streaming tool calls, the server includes `id: <id>` on SSE events.
+For streaming tool calls, AppTheory assigns SSE event ids and persists them in the active `StreamStore`.
 
-If the client disconnects, it can resume by calling:
-
-- `GET /mcp` with `Last-Event-ID: <id>`
-- plus the same `Mcp-Session-Id` (and usually `MCP-Protocol-Version`)
+- `GET /mcp` with `last-event-id: <id>` resumes or replays that stream
+- clients must reuse the same `mcp-session-id`
+- `GET /mcp` without `last-event-id` opens a session listener that stays alive with keepalive comments so reconnecting
+  clients do not hit immediate EOF loops
 
 ---
 
 ## Resources
 
-Resources are “things the server can read” by URI.
+Resources are URI-addressable things the server can read.
 
 Register resources on the resource registry:
 
@@ -165,22 +218,28 @@ _ = srv.Resources().RegisterResource(mcp.ResourceDef{
 })
 ```
 
-Handlers return one or more `ResourceContent` items:
+`ResourceDef` fields:
 
-- Text content: `{ "uri": "...", "text": "..." }`
-- Binary content: `{ "uri": "...", "blob": "<base64>" }`
-- Optional: `mimeType`
+- required: `URI`, `Name`
+- optional: `Title`, `Description`, `MimeType`, `Size`
+
+`ResourceContent` fields:
+
+- required: `URI`
+- optional: `MimeType`
+- exactly one of `Text` or `Blob`
+- `Blob` is expected to be base64-encoded content
 
 Supported methods:
 
-- `resources/list` → `{ "resources": []ResourceDef }`
-- `resources/read` → `{ "contents": []ResourceContent }`
+- `resources/list` -> `{ "resources": []ResourceDef }`
+- `resources/read` -> `{ "contents": []ResourceContent }`
 
 ---
 
 ## Prompts
 
-Prompts are named templates that return a sequence of messages for the client/LLM.
+Prompts are named templates that return a sequence of messages for the client or LLM.
 
 Register prompts on the prompt registry:
 
@@ -202,30 +261,56 @@ _ = srv.Prompts().RegisterPrompt(mcp.PromptDef{
 })
 ```
 
+`PromptDef` fields:
+
+- `Name`, `Title`, `Description`
+- `Arguments` as `[]PromptArgument`
+
+`PromptArgument` fields:
+
+- `Name`
+- optional `Title`, `Description`
+- optional `Required`
+
+`PromptResult` fields:
+
+- optional `Description`
+- required `Messages`
+
 Supported methods:
 
-- `prompts/list` → `{ "prompts": []PromptDef }`
-- `prompts/get` → `PromptResult` (`{ "description": "...", "messages": [...] }`)
+- `prompts/list` -> `{ "prompts": []PromptDef }`
+- `prompts/get` -> `PromptResult`
 
 ---
 
-## Sessions
+## Sessions + persistence
 
-Sessions are tracked via the `Mcp-Session-Id` HTTP header:
+Sessions are tracked with the `mcp-session-id` header.
 
-- The server issues a session id on the **`initialize`** HTTP response.
-- After initialization, clients must send:
-  - `Mcp-Session-Id: ...`
-  - `MCP-Protocol-Version: 2025-06-18` (or `2025-03-26` for legacy/batch compatibility)
-- TTL is controlled by `MCP_SESSION_TTL_MINUTES` (default: `60`).
+- `initialize` creates the session and returns `mcp-session-id` on the HTTP response
+- session TTL is controlled by `MCP_SESSION_TTL_MINUTES` (default `60`)
+- session TTL is refreshed on access (sliding window)
+- `notifications/initialized` persists an `"initialized": "true"` marker in the session data
+- `DELETE /mcp` returns `202 Accepted` and deletes the session plus best-effort stream state for that session
 
-The default store is in-memory. For persistent storage across cold starts, use the Dynamo-backed store (see `docs/agentcore-mcp.md`).
+Persistence options:
+
+- default session store: in-memory
+- persistent sessions: `mcp.WithSessionStore(mcp.NewDynamoSessionStore(db))`
+- default Dynamo table name: `MCP_SESSION_TABLE` when set, otherwise `mcp-sessions`
+
+Stream persistence note:
+
+- the built-in runtime ships `MemoryStreamStore`
+- durable replay across cold starts requires your own `StreamStore` wired with `mcp.WithStreamStore(...)`
+- the CDK Remote MCP stream table is infrastructure only until the application provides a matching `StreamStore`
 
 ---
 
 ## Local testing (no AWS required)
 
-Use the deterministic testkit client in `testkit/mcp`:
+Use the deterministic `testkit/mcp` client for in-process tests:
 
 ```go
 env := testkit.New()
@@ -237,6 +322,34 @@ tools, _ := client.ListTools(context.Background())
 _ = tools
 ```
 
-For Streamable HTTP SSE streaming, use:
-- `Client.RawStream(...)` (POST stream)
-- `Client.ResumeStream(...)` (GET replay/resume with `Last-Event-ID`)
+High-level helpers on `Client`:
+
+- `Initialize`
+- `ListTools`
+- `CallTool`
+- `ListResources`
+- `ReadResource`
+- `ListPrompts`
+- `GetPrompt`
+- `Raw`
+- `RawStream`
+- `ResumeStream`
+
+Low-level JSON-RPC request builders:
+
+- `InitializeRequest`
+- `ListToolsRequest`
+- `CallToolRequest`
+- `ListResourcesRequest`
+- `ReadResourceRequest`
+- `ListPromptsRequest`
+- `GetPromptRequest`
+
+SSE helpers and assertions:
+
+- `Stream.Next`
+- `Stream.ReadAll`
+- `ReadSSEMessage`
+- `AssertError`
+- `AssertHasTools`
+- `AssertToolResult`

--- a/docs/migration/appsync-lambda-resolvers.md
+++ b/docs/migration/appsync-lambda-resolvers.md
@@ -45,6 +45,26 @@ Resolver metadata stays available on the request context:
 The typed AppSync context exposes field name, parent type name, arguments, identity, source, variables, stash, prev,
 request headers, and the raw event.
 
+Selection-set-aware handlers can read the preserved raw event data directly:
+
+- Go: `ctx.AsAppSync().RawEvent.Info.SelectionSetList`, `SelectionSetGraphQL`
+- TypeScript: `ctx.asAppSync()?.rawEvent.info.selectionSetList`, `selectionSetGraphQL`
+- Python: `ctx.as_appsync().raw_event["info"]["selectionSetList"]`, `selectionSetGraphQL`
+
+Portable metadata keys are also populated on the generic request context:
+
+- `apptheory.trigger_type`
+- `apptheory.appsync.field_name`
+- `apptheory.appsync.parent_type_name`
+- `apptheory.appsync.arguments`
+- `apptheory.appsync.identity`
+- `apptheory.appsync.source`
+- `apptheory.appsync.variables`
+- `apptheory.appsync.prev`
+- `apptheory.appsync.stash`
+- `apptheory.appsync.request_headers`
+- `apptheory.appsync.raw_event`
+
 ## Minimal shape
 
 Given a GraphQL field like `Query.getThing`, register the matching AppTheory route as `GET /getThing`.
@@ -143,8 +163,8 @@ def handler(event: AppSyncResolverEvent, ctx: Any) -> Any:
 Successful AppSync handlers return resolver payloads, not API Gateway-style envelopes:
 
 - JSON bodies project to native resolver values
-- `text/*` bodies project to strings
 - empty bodies project to `null`
+- any other non-empty body projects to a UTF-8 string
 
 Handler failures return Lift-compatible AppSync error objects:
 
@@ -153,6 +173,12 @@ Handler failures return Lift-compatible AppSync error objects:
 - `error_type`
 - `error_data`
 - `error_info`
+
+Portable AppTheory/AppError values also carry deterministic metadata:
+
+- `error_data.status_code`
+- optional `error_data.request_id`, `trace_id`, `timestamp`
+- `error_info.code`, `trigger_type`, `method`, `path`, and optional `details`
 
 Binary and streaming response bodies are intentionally out of scope for AppSync and fail closed with deterministic
 system-error envelopes.

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -50,7 +50,11 @@ Important behaviors for Claude compatibility:
 - `initialize` returns `Mcp-Session-Id` and must negotiate `protocolVersion` (`2025-11-25`).
 - `notifications/initialized` must return `202 Accepted` with no body.
 - `tools/call` may stream with SSE when the client includes `Accept: text/event-stream`.
+- SSE frames stay on `event: message`; progress is emitted as JSON-RPC `notifications/progress`, not custom SSE event names.
 - Disconnections are not cancellation; resumability uses `GET /mcp` + `Last-Event-ID`.
+- `GET /mcp` without `Last-Event-ID` stays open as a keepalive listener for the current session.
+- If the request includes an `Origin` header, the default runtime allowlist is Claude-oriented (`https://claude.ai`,
+  `https://claude.com`); use `mcp.WithOriginValidator(...)` for other browser origins.
 
 ## 2) Add OAuth protection (Remote MCP auth `2025-06-18`)
 
@@ -77,6 +81,10 @@ See:
 - `docs/cdk/mcp-server-remote-mcp.md`
 - `docs/cdk/mcp-protected-resource.md`
 
+If you enable the optional Remote MCP stream table, treat it as infrastructure only until your app wires a concrete
+`StreamStore` with `mcp.WithStreamStore(...)`. The built-in runtime ships `MemoryStreamStore`, not a Dynamo-backed
+stream store.
+
 ## 4) Testing (no AWS required)
 
 Deterministic test helpers:
@@ -89,7 +97,7 @@ Deterministic test helpers:
 
 API Gateway REST response streaming connections are time-bounded and can disconnect. For “hours-long” logical sessions:
 - keep sessions durable (`SessionStore` backed by DynamoDB)
-- keep tool output durable (event log + `Last-Event-ID` replay)
+- keep tool output durable (event log + `Last-Event-ID` replay) by providing your own persistent `StreamStore`
 - execute long work asynchronously (worker Lambdas) and append progress/results into the event log
 
 Detailed compatibility notes and HTTP transcripts are maintained in non-canonical planning docs and intentionally kept

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -56,6 +56,20 @@ If exported APIs changed, refresh snapshots first and then re-run snapshot verif
 ./scripts/verify-api-snapshots.sh
 ```
 
+## Feature-specific deterministic harnesses
+
+Use the repo testkits to prove feature behavior without deploying infrastructure:
+
+- AppSync resolvers:
+  - Go: `testkit.AppSyncEvent(...)`, `env.InvokeAppSync(...)`
+  - TypeScript: `buildAppSyncEvent(...)`, `env.invokeAppSync(...)`
+  - Python: `build_appsync_event(...)`, `env.invoke_appsync(...)`
+- MCP servers:
+  - high-level client: `testkit/mcp` `NewClient(...).Initialize/ListTools/CallTool/ListResources/ReadResource/ListPrompts/GetPrompt`
+  - streaming helpers: `Client.RawStream(...)`, `Client.ResumeStream(...)`
+  - low-level JSON-RPC builders: `InitializeRequest`, `ListToolsRequest`, `CallToolRequest`, `ListResourcesRequest`,
+    `ReadResourceRequest`, `ListPromptsRequest`, `GetPromptRequest`
+
 ## Evidence to capture
 
 - commands run


### PR DESCRIPTION
## Summary
- expand AppSync docs to cover context metadata, response and error semantics, and deterministic testing
- align MCP runtime and operator docs with the current session, streaming, origin, and testkit behavior
- bring the canonical docs/cdk MCP guides up to the fuller operator guidance already used in package-local docs

## Verification
- bash ./scripts/verify-docs-standard.sh