### PR TITLE
docs: complete AppSync and MCP coverage

### DIFF
--- a/docs/_concepts.yaml
+++ b/docs/_concepts.yaml
@@ -6,7 +6,7 @@ concepts:
     tagline: "One runtime contract, three language SDKs, snapshot-backed drift prevention."
     provides:
       - "App container and routing primitives across Go/TypeScript/Python"
-      - "AWS adapter entrypoints for HTTP, event sources, and WebSockets"
+      - "AWS adapter entrypoints for HTTP, AppSync, event sources, and WebSockets"
       - "Deterministic testkit helpers for event building, time control, and ID control"
       - "Public API drift gates via api-snapshots/go.txt, api-snapshots/ts.txt, api-snapshots/py.txt"
     requires:
@@ -89,7 +89,35 @@ concepts:
       - handle_lambda: "Python universal dispatcher (dict event)."
     provides:
       - event_shape_detection
+      - appsync_resolver_detection
       - single_lambda_entrypoint
+
+  appsync_resolvers:
+    type: component
+    purpose: "Direct Lambda resolver support that adapts standard AWS AppSync events into the normal AppTheory router."
+    provides:
+      - explicit_appsync_entrypoints
+      - standard_resolver_event_detection
+      - typed_appsync_context
+      - resolver_payload_projection
+      - lift_compatible_error_envelopes
+      - deterministic_appsync_test_builders
+    configuration:
+      - runtime/aws_appsync.go
+      - runtime/context.go
+      - ts/src/internal/aws-appsync.ts
+      - py/src/apptheory/aws_events.py
+      - testkit/event_sources.go
+      - ts/src/testkit.ts
+      - py/src/apptheory/testkit.py
+    related:
+      - universal_lambda_dispatch
+      - testkits
+    docs:
+      - docs/api-reference.md
+      - docs/getting-started.md
+      - docs/migration/appsync-lambda-resolvers.md
+      - docs/cdk/appsync-lambda-resolvers.md
 
   limited_rate_limiting:
     type: component
@@ -162,14 +190,17 @@ concepts:
 
   mcp_runtime:
     type: component
-    purpose: "Expose MCP (Model Context Protocol) over HTTP for Bedrock AgentCore and remote-MCP integrations."
+    purpose: "Expose MCP (Model Context Protocol) over Streamable HTTP for Bedrock AgentCore and remote-MCP integrations."
     provides:
+      - streamable_http_transport
+      - protocol_version_negotiation
       - jsonrpc_2_0_methods
       - tools_registry
       - resources_registry
       - prompts_registry
       - session_management
-      - optional_sse_progress_streaming
+      - origin_validation
+      - resumable_sse_progress_streaming
     configuration:
       - runtime/mcp/
       - runtime/oauth/
@@ -179,4 +210,7 @@ concepts:
       - docs/agentcore-mcp.md
       - docs/mcp.md
       - docs/remote-mcp.md
+      - docs/remote-mcp-autheory.md
       - docs/cdk/mcp-server-agentcore.md
+      - docs/cdk/mcp-server-remote-mcp.md
+      - docs/cdk/mcp-protected-resource.md

--- a/docs/_decisions.yaml
+++ b/docs/_decisions.yaml
@@ -2,6 +2,22 @@ decisions:
   choose_entrypoint_shape:
     question: "How should Lambda handlers be wired when integrating AppTheory?"
     decision_tree:
+      - condition: "The Lambda is dedicated to standard AWS AppSync resolver events."
+        check: "Can the handler accept the AppSync resolver event type directly?"
+        if_yes:
+          choice: "Use the explicit AppSync entrypoint"
+          reason: "ServeAppSync / serveAppSync / serve_appsync keeps the resolver contract obvious while still routing through the normal AppTheory router."
+          example: |
+            func handler(ctx context.Context, event apptheory.AppSyncResolverEvent) any {
+              return app.ServeAppSync(ctx, event)
+            }
+        if_no:
+          choice: "Use the universal dispatcher entrypoint"
+          reason: "HandleLambda / handleLambda / handle_lambda still detect standard AppSync resolver events for mixed-trigger or generic handlers."
+          example: |
+            func handler(ctx context.Context, event json.RawMessage) (any, error) {
+              return app.HandleLambda(ctx, event)
+            }
       - condition: "The Lambda may receive multiple AWS trigger types (HTTP, queues, streams, or WebSockets)."
         check: "Can you delegate event detection to the runtime dispatcher?"
         if_yes:
@@ -16,6 +32,37 @@ decisions:
           reason: "Manual branching is high drift risk and must be explicitly justified."
           example: |
             TODO: If a custom dispatcher is required, document unsupported event shapes and add parity tests.
+
+  choose_mcp_deployment_shape:
+    question: "Which MCP deployment shape should I choose?"
+    decision_tree:
+      - condition: "The client is Bedrock AgentCore or another POST-only MCP caller."
+        check: "Do you only need the simpler HTTP API v2 edge and not Streamable HTTP replay semantics?"
+        if_yes:
+          choice: "Use AppTheoryMcpServer"
+          reason: "It provisions the AgentCore-oriented POST /mcp edge with optional session storage and domain mapping."
+          example: |
+            new AppTheoryMcpServer(this, "McpServer", { handler })
+        if_no:
+          choice: "Use AppTheoryRemoteMcpServer plus AppTheoryMcpProtectedResource"
+          reason: "Claude Remote MCP needs Streamable HTTP POST/GET/DELETE, OAuth protected-resource discovery, and a streaming-capable REST API v1 edge."
+          example: |
+            new AppTheoryRemoteMcpServer(this, "RemoteMcp", {
+              handler,
+              enableSessionTable: true,
+            })
+      - condition: "You enabled the Remote MCP stream table."
+        check: "Did the application also provide a persistent StreamStore implementation?"
+        if_yes:
+          choice: "Document replay as durable"
+          reason: "The runtime can now persist stream events across reconnects and cold starts."
+          example: |
+            srv := mcp.NewServer("server", "dev", mcp.WithStreamStore(myPersistentStore))
+        if_no:
+          choice: "Treat the table as infrastructure only"
+          reason: "The built-in runtime ships MemoryStreamStore; enableStreamTable alone does not make replay durable."
+          example: |
+            TODO: wire mcp.WithStreamStore(...) before claiming durable replay.
 
   choose_api_source_of_truth:
     question: "What source should drive API docs and migration guidance?"

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -20,7 +20,7 @@ patterns:
   universal_lambda_dispatch:
     name: "Delegate mixed AWS trigger handling to the runtime dispatcher"
     problem: "Manual event-shape branching in Lambda handlers drifts across languages and misses edge event types."
-    solution: "Use AppTheory dispatcher entrypoints (HandleLambda, handleLambda, handle_lambda) so routing behavior stays contract-tested."
+    solution: "Use AppTheory dispatcher entrypoints (HandleLambda, handleLambda, handle_lambda) so routing behavior stays contract-tested, including standard AppSync resolver event detection."
     correct_example: |
       # CORRECT: keep the Lambda entrypoint thin and delegate dispatch.
       func handler(ctx context.Context, event json.RawMessage) (any, error) {
@@ -37,6 +37,29 @@ patterns:
         consequences:
           - "Cross-language behavior drift"
           - "Unhandled production event shapes"
+
+  appsync_router_adaptation:
+    name: "Route AppSync resolvers through the normal AppTheory router"
+    problem: "Treating AppSync as a bespoke handler path duplicates request adaptation and bypasses the runtime's typed resolver context."
+    solution: "Register routes that match the GraphQL field name (`Query` and `Subscription` -> `GET /fieldName`, `Mutation` -> `POST /fieldName`) and read resolver metadata from the typed AppSync context. Use the explicit AppSync entrypoint for AppSync-only Lambdas, or keep mixed-trigger handlers on the universal dispatcher."
+    correct_example: |
+      # CORRECT: let the runtime adapt Query.getThing into GET /getThing.
+      app.Get("/getThing", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+        appsync := ctx.AsAppSync()
+        return apptheory.JSON(200, map[string]any{"field": appsync.FieldName})
+      })
+    anti_patterns:
+      - name: "Handling GraphQL fields outside the router"
+        why: "Bypassing AppTheory routing loses the shared request model, typed AppSync context, and tested error projection."
+        incorrect_example: |
+          # INCORRECT
+          switch event.Info.FieldName {
+          case "getThing":
+            // bespoke resolver handling here
+          }
+        consequences:
+          - "Cross-language AppSync drift"
+          - "Inconsistent error and metadata handling"
 
   headers_canonicalization:
     name: "Treat headers case-insensitively and assert lowercase response keys"
@@ -74,6 +97,26 @@ patterns:
         consequences:
           - "Unexpected 404s"
           - "Slow debugging cycles"
+
+  mcp_deployment_shape:
+    name: "Choose the MCP deployment shape by client and transport requirements"
+    problem: "Bedrock AgentCore and Claude Remote MCP do not have the same transport, streaming, or OAuth discovery requirements."
+    solution: "Use `AppTheoryMcpServer` on HTTP API v2 for AgentCore-style POST-only deployments. Use `AppTheoryRemoteMcpServer` plus `AppTheoryMcpProtectedResource` when you need Streamable HTTP `POST/GET/DELETE /mcp`, OAuth protected-resource discovery, and a streaming-capable REST API v1 edge. Durable replay still requires application code to provide a persistent `StreamStore`."
+    correct_example: |
+      # CORRECT: choose the Remote MCP stack when the client needs resumable SSE.
+      new AppTheoryRemoteMcpServer(stack, "RemoteMcp", {
+        handler,
+        enableSessionTable: true,
+      })
+    anti_patterns:
+      - name: "Using the AgentCore construct as a drop-in Remote MCP edge"
+        why: "HTTP API v2 POST-only deployments do not provide the same transport surface or streaming behavior as the Remote MCP stack."
+        incorrect_example: |
+          # INCORRECT
+          new AppTheoryMcpServer(stack, "McpServer", { handler })
+        consequences:
+          - "Missing GET /mcp and DELETE /mcp support"
+          - "Remote-MCP reconnect and replay gaps"
 
   sanitize_before_logging:
     name: "Sanitize payloads before logging"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -161,6 +161,12 @@ AppTheory supports the standard AWS direct Lambda resolver event shape in all th
 Recipe:
 
 - [AppSync Lambda Resolvers](./migration/appsync-lambda-resolvers.md)
+- [CDK AppSync Lambda Resolvers](./cdk/appsync-lambda-resolvers.md)
+
+Infrastructure note:
+
+- use `aws-cdk-lib/aws-appsync` for the GraphQL API, schema, auth, and Lambda data source wiring
+- AppTheory does not currently export an AppSync-specific CDK construct
 
 ## Strict route registration
 
@@ -228,10 +234,11 @@ AppTheory includes Go runtime support for MCP and OAuth-adjacent remote-MCP flow
   SSE, and the MCP request surface (`initialize`, `ping`, `tools/*`, `resources/*`, `prompts/*`, plus accepted
   `notifications/initialized` / `notifications/cancelled`)
 - `testkit/mcp`: deterministic in-process MCP client helpers (`NewClient`, `Initialize`, `ListTools`, `CallTool`,
-  `ListResources`, `ReadResource`, `ListPrompts`, `GetPrompt`, `RawStream`, `ResumeStream`) plus JSON-RPC request
-  builders and assertions
+  `ListResources`, `ReadResource`, `ListPrompts`, `GetPrompt`, `RawStream`, `ResumeStream`, `Stream.Response`,
+  `Stream.Cancel`, `Stream.Next`, `Stream.ReadAll`) plus JSON-RPC request builders and assertions
 - `runtime/oauth`: protected-resource metadata, challenges, DCR, PKCE, and token-store helpers
-- `testkit/oauth`: end-to-end OAuth flow helpers for remote MCP tests
+- `testkit/oauth`: Claude-like end-to-end OAuth flow helpers for remote MCP tests (`NewClaudePublicClient`,
+  `AuthorizeOptions`, `Authorize`)
 
 Related repo guides outside the current KT ingest set:
 

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -7,6 +7,7 @@ patterns and treat `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts` as the 
 
 - [Getting Started](./getting-started.md)
 - [API Reference](./api-reference.md)
+- [AppSync Lambda Resolvers](./appsync-lambda-resolvers.md)
 - [REST API Router + Streaming](./rest-api-router-streaming.md)
 - [MCP Server for Bedrock AgentCore](./mcp-server-agentcore.md)
 - [Claude Remote MCP + Streaming](./mcp-server-remote-mcp.md)
@@ -17,6 +18,7 @@ patterns and treat `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts` as the 
 
 These pages cover the canonical user-facing CDK patterns for:
 
+- AppSync Lambda resolver wiring with standard `aws-cdk-lib/aws-appsync` constructs
 - HTTP and REST API routing
 - response streaming and SSE
 - MCP and OAuth discovery endpoints

--- a/docs/cdk/api-reference.md
+++ b/docs/cdk/api-reference.md
@@ -37,3 +37,14 @@ constructs, read `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts`.
 - Use `AppTheoryMcpServer` for Bedrock AgentCore
 - Use `AppTheoryRemoteMcpServer` plus `AppTheoryMcpProtectedResource` for Claude Remote MCP
 - Use `AppTheoryJobsTable`, `AppTheoryS3Ingest`, and `AppTheoryCodeBuildJobRunner` for import pipelines
+
+## AppSync note
+
+AppTheory does not currently export an AppSync-specific CDK construct.
+
+Use `aws-cdk-lib/aws-appsync` for the GraphQL API, schema, auth, and Lambda data source wiring, and keep the Lambda
+handler on AppTheory's AppSync runtime entrypoints.
+
+Guide:
+
+- [AppSync Lambda Resolvers](./appsync-lambda-resolvers.md)

--- a/docs/cdk/appsync-lambda-resolvers.md
+++ b/docs/cdk/appsync-lambda-resolvers.md
@@ -1,0 +1,107 @@
+# AppSync Lambda Resolvers
+
+Use this guide when AppSync owns the GraphQL API and AppTheory owns the Lambda resolver runtime.
+
+AppTheory does not export an AppSync-specific CDK construct. Use `aws-cdk-lib/aws-appsync` for the GraphQL API,
+schema, auth, and Lambda data source wiring, and keep the Lambda handler on AppTheory's AppSync runtime entrypoints.
+
+## Use this when
+
+- AppSync should manage schema, auth, and resolver registration
+- the Lambda handler should keep AppTheory routing, middleware, and typed AppSync context behavior
+- you want the same resolver Lambda pattern in Go, TypeScript, or Python
+
+## Minimal TypeScript stack
+
+```ts
+import * as path from "node:path";
+
+import * as cdk from "aws-cdk-lib";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+export class AppSyncResolverStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const handler = new lambda.Function(this, "ResolverHandler", {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      handler: "index.handler",
+      code: lambda.Code.fromAsset(path.join(__dirname, "..", "dist")),
+      timeout: cdk.Duration.seconds(30),
+    });
+
+    const api = new appsync.GraphqlApi(this, "GraphqlApi", {
+      name: "apptheory-things",
+      definition: appsync.Definition.fromFile(
+        path.join(__dirname, "..", "schema.graphql"),
+      ),
+      authorizationConfig: {
+        defaultAuthorization: {
+          authorizationType: appsync.AuthorizationType.API_KEY,
+        },
+      },
+    });
+
+    const lambdaSource = api.addLambdaDataSource("ThingResolvers", handler);
+
+    lambdaSource.createResolver("GetThingResolver", {
+      typeName: "Query",
+      fieldName: "getThing",
+    });
+
+    lambdaSource.createResolver("CreateThingResolver", {
+      typeName: "Mutation",
+      fieldName: "createThing",
+    });
+
+    new cdk.CfnOutput(this, "GraphqlUrl", { value: api.graphqlUrl });
+  }
+}
+```
+
+The AppSync side owns:
+
+- GraphQL schema files
+- auth mode selection and AppSync-specific policies
+- resolver registration (`Query`, `Mutation`, `Subscription`) and data sources
+
+The AppTheory Lambda side owns:
+
+- request adaptation from the standard direct Lambda resolver event
+- route registration (`GET /fieldName` or `POST /fieldName`)
+- middleware, error shaping, and typed AppSync context access
+
+## Resolver-to-route mapping
+
+Keep the AppTheory route name aligned with the GraphQL field name:
+
+- `Query.getThing` -> `GET /getThing`
+- `Mutation.createThing` -> `POST /createThing`
+- `Subscription.onThingUpdated` -> `GET /onThingUpdated`
+
+Use the explicit AppSync runtime entrypoint when the Lambda is AppSync-only:
+
+- Go: `app.ServeAppSync(ctx, event)`
+- TypeScript: `app.serveAppSync(event, ctx)`
+- Python: `app.serve_appsync(event, ctx)`
+
+Use the universal dispatcher when the same Lambda also accepts other AWS trigger types:
+
+- Go: `app.HandleLambda(ctx, event)`
+- TypeScript: `app.handleLambda(event, ctx)`
+- Python: `app.handle_lambda(event, ctx)`
+
+## Scope boundaries
+
+- AppTheory does not generate GraphQL schemas, AppSync auth policies, or AppSync resolver infrastructure
+- AppTheory does not currently export an `AppTheoryAppSyncApi` or resolver-specific construct under
+  `@theory-cloud/apptheory-cdk`
+- you do not need custom request mapping rewrites just to use AppTheory's AppSync runtime adapters with the standard
+  direct Lambda event shape
+
+## Related guides
+
+- [AppSync Lambda Resolver Runtime Recipe](../migration/appsync-lambda-resolvers.md)
+- [AppTheory API Reference](../api-reference.md)

--- a/docs/cdk/getting-started.md
+++ b/docs/cdk/getting-started.md
@@ -42,5 +42,8 @@ make rubric
 ## Next reads
 
 - [CDK API Reference](./api-reference.md)
+- [AppSync Lambda Resolvers](./appsync-lambda-resolvers.md)
 - [REST API Router + Streaming](./rest-api-router-streaming.md)
+- [MCP Server for Bedrock AgentCore](./mcp-server-agentcore.md)
+- [Claude Remote MCP + Streaming](./mcp-server-remote-mcp.md)
 - [Import Pipeline Constructs](./import-pipeline.md)

--- a/docs/cdk/mcp-server-agentcore.md
+++ b/docs/cdk/mcp-server-agentcore.md
@@ -63,6 +63,7 @@ This deploys:
 
 - HTTP API Gateway v2
 - `POST /mcp` route -> your Lambda
+- Lambda env var `MCP_ENDPOINT` pointing at the resolved `/mcp` URL
 - output `mcp.endpoint` (the URL you configure in AgentCore)
 
 ---

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -19,6 +19,7 @@ Claude Remote MCP requires real incremental streaming for tool calls. On AWS tha
   - `POST /mcp` (streaming enabled)
   - `GET /mcp` (streaming enabled; used for `Last-Event-ID` replay and session listeners)
   - `DELETE /mcp`
+- Lambda env var `MCP_ENDPOINT` pointing at the resolved `/mcp` URL
 - optional DynamoDB tables:
   - session table (matches `runtime/mcp/session_dynamo.go` schema)
   - stream/event table (infra only unless the app wires a concrete `StreamStore`)
@@ -48,6 +49,7 @@ const handler = new lambda.Function(stack, "McpHandler", {
 const mcp = new AppTheoryRemoteMcpServer(stack, "RemoteMcp", {
   handler,
   apiName: "remote-mcp",
+  // cors: true,
   enableSessionTable: true,
   sessionTtlMinutes: 120,
   // enableStreamTable: true,
@@ -60,6 +62,16 @@ new AppTheoryMcpProtectedResource(stack, "ProtectedResource", {
   authorizationServers: ["https://auth.example.com"],
 });
 ```
+
+## CORS option
+
+`AppTheoryRemoteMcpServer` exposes the underlying REST router `cors` option for API Gateway preflight handling.
+
+Important caveat:
+
+- API Gateway CORS alone is not enough for browser-based callers
+- your Lambda still needs to emit `Access-Control-Allow-Origin` on actual `/mcp` responses
+- runtime origin validation is separate and still controlled by `mcp.WithOriginValidator(...)`
 
 ## Session and stream tables
 
@@ -85,6 +97,24 @@ Important caveat:
 - the built-in runtime currently ships `MemoryStreamStore`
 - `enableStreamTable` only provisions storage and injects env vars
 - durable replay requires application code to provide a matching persistent `StreamStore` via `mcp.WithStreamStore(...)`
+
+## Injected environment variables
+
+`AppTheoryRemoteMcpServer` injects these environment variables when the corresponding features are enabled:
+
+- always: `MCP_ENDPOINT`
+- session table: `MCP_SESSION_TABLE`, `MCP_SESSION_TTL_MINUTES`
+- stream table: `MCP_STREAM_TABLE`, `MCP_STREAM_TTL_MINUTES`
+
+`MCP_ENDPOINT` is the canonical deployed `/mcp` URL:
+
+- execute-api hostname: `https://{apiId}.execute-api.{region}.amazonaws.com/{stage}/mcp`
+- custom domain without base path: `https://mcp.example.com/mcp`
+- custom domain with base path: `https://api.example.com/{basePath}/mcp`
+
+This matters for OAuth discovery. If `oauth.RequireBearerTokenMiddleware(...)` is used without an explicit
+`ResourceMetadataURL`, the middleware derives the RFC9728 `/.well-known/oauth-protected-resource` challenge URL from
+`MCP_ENDPOINT`.
 
 ## Keepalive, replay, and origin guidance
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -38,6 +38,33 @@ if event.RequestContext.HTTP.Method != "" {
 ```
 
 The dispatcher already knows how to route HTTP, queues, streams, WebSockets, and other supported AWS shapes.
+That includes standard AppSync resolver events.
+
+## Pattern: route AppSync resolvers through the normal router
+
+Problem: bespoke GraphQL field switching duplicates request adaptation and bypasses the runtime's typed AppSync
+context.
+
+CORRECT:
+
+```go
+app.Get("/getThing", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+	appsync := ctx.AsAppSync()
+	return apptheory.JSON(200, map[string]any{"field": appsync.FieldName})
+})
+```
+
+Use `ServeAppSync` / `serveAppSync` / `serve_appsync` for AppSync-only Lambdas, or keep mixed-trigger Lambdas on the
+universal dispatcher.
+
+INCORRECT:
+
+```go
+switch event.Info.FieldName {
+case "getThing":
+	// bespoke resolver handling outside the AppTheory router
+}
+```
 
 ## Pattern: header handling is case-insensitive and response keys are lowercase
 
@@ -118,6 +145,23 @@ CORRECT:
 INCORRECT:
 
 - assuming every AWS integration supports streaming the same way
+
+## Pattern: choose the MCP deployment shape by client transport needs
+
+Problem: Bedrock AgentCore and Claude Remote MCP do not share the same transport, streaming, or OAuth discovery
+requirements.
+
+CORRECT:
+
+- use `AppTheoryMcpServer` for AgentCore or other POST-only MCP clients on HTTP API v2
+- use `AppTheoryRemoteMcpServer` plus `AppTheoryMcpProtectedResource` for Claude Remote MCP when you need
+  `POST/GET/DELETE /mcp`, OAuth protected-resource discovery, and a REST API v1 streaming edge
+- provide a persistent `StreamStore` in application code if replay must survive reconnects and cold starts
+
+INCORRECT:
+
+- assuming `AppTheoryMcpServer` is a drop-in deployment for resumable Remote MCP
+- assuming `enableStreamTable` alone makes replay durable without `mcp.WithStreamStore(...)`
 
 ## Pattern: sanitize user payloads before logging
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,6 +133,9 @@ Use the runtime entrypoint that matches your deployment shape:
 Standard AppSync direct Lambda resolver events also route through the mixed-trigger dispatcher, so a Lift-style
 single-Lambda entrypoint can continue to use `HandleLambda`, `handleLambda`, or `handle_lambda`.
 
+For the GraphQL front door itself, use native AppSync infrastructure such as `aws-cdk-lib/aws-appsync`; AppTheory owns
+the Lambda resolver adapter, not the GraphQL API construct.
+
 ## Next reads
 
 - [Documentation Index](./README.md)
@@ -142,6 +145,7 @@ single-Lambda entrypoint can continue to use `HandleLambda`, `handleLambda`, or 
 - [CDK Guides](./cdk/README.md)
 - [Lift Migration Guide](./migration/from-lift.md)
 - [AppSync Lambda Resolver Recipe](./migration/appsync-lambda-resolvers.md)
+- [CDK AppSync Lambda Resolvers](./cdk/appsync-lambda-resolvers.md)
 
 Additional repo guide outside the current KT ingest set:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -347,9 +347,14 @@ Low-level JSON-RPC request builders:
 
 SSE helpers and assertions:
 
+- `Stream.Response`
+- `Stream.Cancel`
 - `Stream.Next`
 - `Stream.ReadAll`
 - `ReadSSEMessage`
 - `AssertError`
 - `AssertHasTools`
 - `AssertToolResult`
+
+Use `Stream.Response()` to assert the initial HTTP status, headers, and negotiated `mcp-session-id`.
+Use `Stream.Cancel()` to simulate a client disconnect before calling `ResumeStream(...)`.

--- a/docs/migration/appsync-lambda-resolvers.md
+++ b/docs/migration/appsync-lambda-resolvers.md
@@ -5,6 +5,8 @@ Use this guide when wiring an AWS AppSync Lambda data source to an AppTheory app
 AppTheory supports the standard direct Lambda resolver event shape in Go, TypeScript, and Python. You do not need
 request mapping template rewrites to use the runtime adapters documented here.
 
+If you also need the infrastructure side, see [CDK AppSync Lambda Resolvers](../cdk/appsync-lambda-resolvers.md).
+
 ## Choose the entrypoint
 
 Use the explicit AppSync entrypoint when the Lambda is dedicated to AppSync:

--- a/docs/remote-mcp-autheory.md
+++ b/docs/remote-mcp-autheory.md
@@ -46,6 +46,22 @@ Use the Claude-like harness in AppTheory to pin behavior in CI:
 - `testkit/oauth` (`ClaudePublicClient`)
 - It exercises: discovery → DCR → PKCE auth code → token → refresh.
 
+Example:
+
+```go
+oauthClient := oauthtest.NewClaudePublicClient(nil)
+
+discovery, dcr, tokenResp, refreshResp, err := oauthClient.Authorize(ctx, oauthtest.AuthorizeOptions{
+  McpEndpoint: "https://api.example.com/prod/mcp",
+})
+```
+
+Defaults match Claude-first expectations:
+
+- `Origin`: `https://claude.ai`
+- `RedirectURI`: `https://claude.ai/api/mcp/auth_callback`
+- `McpEndpoint` is normalized to the canonical `/mcp` resource URL before the discovery flow begins
+
 ## Related notes
 
 Additional maintainer planning notes exist outside the canonical docs root and are intentionally omitted here.

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -71,6 +71,10 @@ You typically:
 2) Expose `/.well-known/oauth-protected-resource` (often via CDK mock integration; see below).
 3) Validate Bearer tokens against Autheory (JWT verify via JWKS or introspection).
 
+When you deploy with `AppTheoryRemoteMcpServer`, the construct injects `MCP_ENDPOINT`. If
+`RequireBearerTokenMiddleware(...)` is used without an explicit `ResourceMetadataURL`, the middleware derives the
+RFC9728 protected-resource metadata challenge URL from that endpoint by default.
+
 ## 3) Deploy on AWS (REST API v1 response streaming)
 
 Use these CDK constructs:
@@ -91,7 +95,24 @@ Deterministic test helpers:
 - Streamable HTTP MCP client: `testkit/mcp`
   - buffered JSON calls: `NewClient(...).Initialize/ListTools/CallTool`
   - streaming SSE: `Client.RawStream(...)` + `Client.ResumeStream(...)`
+  - disconnect/replay assertions: `Stream.Response()`, `Stream.Cancel()`, `Stream.Next()`, `Stream.ReadAll()`
 - Claude-like OAuth harness (DCR → PKCE → refresh): `testkit/oauth`
+
+Example OAuth harness usage:
+
+```go
+oauthClient := oauthtest.NewClaudePublicClient(nil)
+
+discovery, dcr, tokenResp, refreshResp, err := oauthClient.Authorize(ctx, oauthtest.AuthorizeOptions{
+  McpEndpoint: "https://api.example.com/prod/mcp",
+})
+```
+
+Notes:
+
+- `AuthorizeOptions.Origin` defaults to `https://claude.ai`
+- `AuthorizeOptions.RedirectURI` defaults to `https://claude.ai/api/mcp/auth_callback`
+- `McpEndpoint` is normalized to the canonical `/mcp` resource URL before discovery starts
 
 ## 5) Operational constraints (design for reconnect)
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -66,9 +66,11 @@ Use the repo testkits to prove feature behavior without deploying infrastructure
   - Python: `build_appsync_event(...)`, `env.invoke_appsync(...)`
 - MCP servers:
   - high-level client: `testkit/mcp` `NewClient(...).Initialize/ListTools/CallTool/ListResources/ReadResource/ListPrompts/GetPrompt`
-  - streaming helpers: `Client.RawStream(...)`, `Client.ResumeStream(...)`
+  - streaming helpers: `Client.RawStream(...)`, `Client.ResumeStream(...)`, `Stream.Response()`, `Stream.Cancel()`,
+    `Stream.Next()`, `Stream.ReadAll()`
   - low-level JSON-RPC builders: `InitializeRequest`, `ListToolsRequest`, `CallToolRequest`, `ListResourcesRequest`,
     `ReadResourceRequest`, `ListPromptsRequest`, `GetPromptRequest`
+  - OAuth harness: `testkit/oauth` `NewClaudePublicClient(nil).Authorize(...)`
 
 ## Evidence to capture
 


### PR DESCRIPTION
## Summary
- add the missing CDK-side AppSync Lambda resolver guide and wire it into canonical docs navigation
- extend the canonical concepts, patterns, and decision docs for AppSync routing and MCP deployment choices
- document MCP operator details including MCP_ENDPOINT, Remote MCP CORS caveats, and the latest MCP/OAuth testkit helpers

## Verification
- bash ./scripts/verify-docs-standard.sh