### PR TITLE
[codex] Complete issue 338 SSR deploy verification and docs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -63,9 +64,20 @@ jobs:
         with:
           python-version: "3.14.3"
 
+      - name: Configure AWS credentials for SSR smoke gate
+        if: steps.release.outputs.release_created == 'true'
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ vars.APPTHEORY_SSR_SMOKE_ROLE_ARN }}
+          aws-region: ${{ vars.APPTHEORY_SSR_SMOKE_AWS_REGION }}
+
       - name: Build + verify
         if: steps.release.outputs.release_created == 'true'
-        run: make rubric
+        env:
+          APPTHEORY_SSR_SITE_STACK_NAME: AppTheorySsrSiteSmoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          make rubric
+          scripts/verify-ssr-site-smoke.sh
 
       - name: Generate SHA-256 checksums
         if: steps.release.outputs.release_created == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -45,9 +46,17 @@ jobs:
         with:
           python-version: "3.14.3"
 
+      - name: Configure AWS credentials for SSR smoke gate (existing tag path)
+        if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ vars.APPTHEORY_SSR_SMOKE_ROLE_ARN }}
+          aws-region: ${{ vars.APPTHEORY_SSR_SMOKE_AWS_REGION }}
+
       - name: Upload assets for existing tag release
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
         env:
+          APPTHEORY_SSR_SITE_STACK_NAME: AppTheorySsrSiteSmoke-${{ github.run_id }}-${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
@@ -74,6 +83,7 @@ jobs:
 
           export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
           make rubric
+          scripts/verify-ssr-site-smoke.sh
           scripts/generate-checksums.sh
           scripts/render-release-notes.sh "${TAG_NAME}"
 
@@ -154,9 +164,20 @@ jobs:
         with:
           python-version: "3.14.3"
 
+      - name: Configure AWS credentials for SSR smoke gate
+        if: steps.release.outputs.release_created == 'true'
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ vars.APPTHEORY_SSR_SMOKE_ROLE_ARN }}
+          aws-region: ${{ vars.APPTHEORY_SSR_SMOKE_AWS_REGION }}
+
       - name: Build + verify
         if: steps.release.outputs.release_created == 'true'
-        run: make rubric
+        env:
+          APPTHEORY_SSR_SITE_STACK_NAME: AppTheorySsrSiteSmoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          make rubric
+          scripts/verify-ssr-site-smoke.sh
 
       - name: Generate SHA-256 checksums
         if: steps.release.outputs.release_created == 'true'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ AppTheory today. See [CHANGELOG](CHANGELOG.md) for release history.
 
 - [Getting started guide](docs/getting-started.md) — local workspace, deterministic app path in each runtime, deployment
 - [API reference](docs/api-reference.md) — full Go runtime surface
+- [FaceTheory-first SSR CDK guide](docs/cdk/ssr-site.md) — canonical CloudFront + S3 + Lambda URL deployment story
 - [TypeScript docs](ts/docs/README.md) | [Python docs](py/docs/README.md) | [CDK docs](cdk/docs/README.md)
 
 ## Charter

--- a/cdk/docs/README.md
+++ b/cdk/docs/README.md
@@ -8,6 +8,7 @@
 ### 🚀 Getting started
 - [Getting Started](./getting-started.md) — deploy a minimal API backed by an AppTheory Lambda.
 - [Canonical CDK Getting Started](../../docs/cdk/getting-started.md) — canonical operator guide under `docs/cdk/`.
+- [Canonical SSR Site Guide](../../docs/cdk/ssr-site.md) — FaceTheory-first CloudFront + S3 + Lambda URL deployment.
 
 ### 📚 Core documentation
 - [Docs Contract](./_contract.yaml) — canonical CDK package knowledgebase scope: fixed ingestible, optional ingestible, and contract-only docs.
@@ -35,6 +36,7 @@
 - [Lambda Role Helper](./lambda-role.md) — Lambda execution roles (baseline + X-Ray + KMS + custom statements).
 - [CloudFront Path-Routed Frontend Distribution](./path-routed-frontend.md) — multi-SPA routing behind one stage domain.
 - [Media CDN Pattern](./media-cdn.md) — S3 + CloudFront distribution for media subdomains (optional private media).
+- [Canonical FaceTheory-First SSR Site](../../docs/cdk/ssr-site.md) — operator guide for `AppTheorySsrSite`.
 
 ### 🤖 AI knowledge base (YAML triad)
 - Docs Contract: `cdk/docs/_contract.yaml`

--- a/cdk/docs/api-reference.md
+++ b/cdk/docs/api-reference.md
@@ -32,7 +32,8 @@ AppTheory CDK exports constructs such as:
 - `AppTheoryLambdaRole` (Lambda execution role helper; baseline + X-Ray + KMS + escape hatches)
 - `AppTheoryPathRoutedFrontend` (CloudFront distribution: multi-SPA routing + API origin + SPA rewrite)
 - `AppTheoryMediaCdn` (CloudFront distribution: S3-backed media CDN; optional private media via key groups)
+- `AppTheorySsrSite` (FaceTheory-first CloudFront + S3 + Lambda URL SSR/SSG/ISR deployment; see `docs/cdk/ssr-site.md`)
 - Domain/cert helpers (hosted zone, certificate, custom domains)
-- Higher-level “app”/SSR patterns (where present; `AppTheorySsrSite` now exposes explicit `ssr-only` / `ssg-isr` modes with edge request-id/original-URI behavior)
+- Higher-level "app"/SSR patterns now converge on the FaceTheory-first deployment contract rather than a weaker helper path
 
 For the exact list and prop types, read `cdk/lib/*.d.ts`.

--- a/cdk/test/constructs.test.cjs
+++ b/cdk/test/constructs.test.cjs
@@ -1265,11 +1265,65 @@ test("AppTheorySsrSite signs the default Function URL origin", () => {
       resource.Properties?.Principal === "cloudfront.amazonaws.com" &&
       resource.Properties?.Action === "lambda:InvokeFunctionUrl",
   );
+  const publicUrlPermissions = resources.filter(
+    (resource) =>
+      resource.Type === "AWS::Lambda::Permission" &&
+      resource.Properties?.Principal === "*" &&
+      resource.Properties?.Action === "lambda:InvokeFunctionUrl",
+  );
 
   assert.equal(functionUrls.length, 1);
   assert.equal(functionUrls[0].Properties?.AuthType, "AWS_IAM");
   assert.equal(lambdaOriginAccessControls.length, 1);
   assert.equal(cloudfrontInvokePermissions.length, 1);
+  assert.equal(publicUrlPermissions.length, 0);
+});
+
+test("AppTheorySsrSite keeps the SSR origin on Function URL plus lambda OAC", () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack");
+
+  const fn = new lambda.Function(stack, "Fn", {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "index.handler",
+    code: lambda.Code.fromInline("exports.handler = async () => ({ statusCode: 200, body: 'ok' });"),
+  });
+
+  new apptheory.AppTheorySsrSite(stack, "Site", { ssrFunction: fn });
+
+  const template = assertions.Template.fromStack(stack).toJSON();
+  const resources = template.Resources ?? {};
+  const lambdaUrlEntry = Object.entries(resources).find(([, resource]) => resource.Type === "AWS::Lambda::Url");
+  const distribution = Object.values(resources).find((resource) => resource.Type === "AWS::CloudFront::Distribution");
+  const lambdaOriginAccessControl = Object.values(resources).find(
+    (resource) =>
+      resource.Type === "AWS::CloudFront::OriginAccessControl" &&
+      resource.Properties?.OriginAccessControlConfig?.OriginAccessControlOriginType === "lambda",
+  );
+
+  assert.ok(lambdaUrlEntry, "Should synthesize a Lambda Function URL");
+  assert.ok(distribution, "Should synthesize a CloudFront distribution");
+  assert.ok(lambdaOriginAccessControl, "Should synthesize lambda origin access control");
+
+  const [lambdaUrlLogicalId] = lambdaUrlEntry;
+  const origins = distribution.Properties?.DistributionConfig?.Origins ?? [];
+  const lambdaOrigin = origins.find((origin) => origin.CustomOriginConfig?.OriginProtocolPolicy === "https-only");
+
+  assert.ok(lambdaOrigin, "Should keep a dedicated HTTPS Lambda URL origin");
+  assert.deepEqual(lambdaOrigin.DomainName, {
+    "Fn::Select": [
+      2,
+      {
+        "Fn::Split": [
+          "/",
+          {
+            "Fn::GetAtt": [lambdaUrlLogicalId, "FunctionUrl"],
+          },
+        ],
+      },
+    ],
+  });
+  assert.ok(lambdaOrigin.OriginAccessControlId, "Lambda origin should be signed via CloudFront OAC");
 });
 
 test("AppTheorySsrSite defaults to ssr-only mode with edge functions", () => {
@@ -1367,6 +1421,8 @@ test("AppTheorySsrSite defaults to FaceTheory-safe SSR origin request headers", 
     "x-request-id",
     "x-tenant-id",
   ]);
+  assert.ok(!headers.includes("host"), "Should not forward raw host to Function URL origin");
+  assert.ok(!headers.includes("x-forwarded-proto"), "Should not forward x-forwarded-proto to Function URL origin");
 });
 
 test("AppTheorySsrSite wires first-class ISR HTML store and metadata resources", () => {

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -7,6 +7,7 @@ patterns and treat `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts` as the 
 
 - [Getting Started](./getting-started.md)
 - [API Reference](./api-reference.md)
+- [FaceTheory-First SSR Site](./ssr-site.md)
 - [AppSync Lambda Resolvers](./appsync-lambda-resolvers.md)
 - [REST API Router + Streaming](./rest-api-router-streaming.md)
 - [MCP Server for Bedrock AgentCore](./mcp-server-agentcore.md)
@@ -19,6 +20,7 @@ patterns and treat `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts` as the 
 These pages cover the canonical user-facing CDK patterns for:
 
 - AppSync Lambda resolver wiring with standard `aws-cdk-lib/aws-appsync` constructs
+- CloudFront + S3 + Lambda URL SSR/SSG/ISR deployment for FaceTheory-style apps
 - HTTP and REST API routing
 - response streaming and SSE
 - MCP and OAuth discovery endpoints

--- a/docs/cdk/api-reference.md
+++ b/docs/cdk/api-reference.md
@@ -17,6 +17,7 @@ constructs, read `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts`.
 - `AppTheoryEventBridgeBus`: custom EventBridge bus with explicit cross-account publish allowlist
 - `AppTheoryEventBridgeRuleTarget`: EventBridge rule or schedule to Lambda target
 - `AppTheoryHttpIngestionEndpoint`: authenticated HTTP API v2 ingestion endpoint with Lambda request authorizer
+- `AppTheorySsrSite`: FaceTheory-first CloudFront + S3 + Lambda URL deployment for SSR, SSG, and ISR
 - `AppTheoryQueue`, `AppTheoryQueueConsumer`, `AppTheoryQueueProcessor`: SQS queue and consumer patterns
 
 ## Supporting constructs exported from `cdk/lib/index.ts`
@@ -38,7 +39,12 @@ constructs, read `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts`.
 - Use `AppTheoryRestApiRouter` when you need SSE or response streaming
 - Use `AppTheoryMcpServer` for Bedrock AgentCore
 - Use `AppTheoryRemoteMcpServer` plus `AppTheoryMcpProtectedResource` for Claude Remote MCP
+- Use `AppTheorySsrSite` when you need the canonical FaceTheory-first SSR/SSG/ISR deployment story
 - Use `AppTheoryJobsTable`, `AppTheoryS3Ingest`, and `AppTheoryCodeBuildJobRunner` for import pipelines
+
+Guide:
+
+- [FaceTheory-First SSR Site](./ssr-site.md)
 
 ## AppSync note
 

--- a/docs/cdk/getting-started.md
+++ b/docs/cdk/getting-started.md
@@ -42,6 +42,7 @@ make rubric
 ## Next reads
 
 - [CDK API Reference](./api-reference.md)
+- [FaceTheory-First SSR Site](./ssr-site.md)
 - [AppSync Lambda Resolvers](./appsync-lambda-resolvers.md)
 - [REST API Router + Streaming](./rest-api-router-streaming.md)
 - [MCP Server for Bedrock AgentCore](./mcp-server-agentcore.md)

--- a/docs/cdk/ssr-site.md
+++ b/docs/cdk/ssr-site.md
@@ -1,0 +1,125 @@
+# FaceTheory-First SSR Site (CloudFront + S3 + Lambda URL)
+
+Use this guide when you want the canonical AppTheory deployment pattern for FaceTheory-style SSR, SSG, and ISR on AWS.
+
+`AppTheorySsrSite` is the supported AppTheory companion construct for this shape. The example under
+`examples/cdk/ssr-site/` is the canonical implementation to copy from; it is not a weaker helper path separate from
+the FaceTheory deployment contract.
+
+## Preferred mode
+
+Prefer `mode: AppTheorySsrSiteMode.SSG_ISR` unless you are intentionally keeping a narrower compatibility path.
+
+- `ssg-isr` is the FaceTheory-first topology:
+  - `/assets/*` and `/_facetheory/data/*` stay on direct S3 behaviors
+  - default `/*` uses an S3-primary origin group with Lambda Function URL fallback
+  - extensionless routes rewrite to `/index.html` at the edge
+- `ssr-only` remains available for compatibility, but it is not the preferred documented deployment story for new
+  FaceTheory work.
+
+## Canonical stack shape
+
+```ts
+import { AppTheorySsrSite, AppTheorySsrSiteMode } from "@theory-cloud/apptheory-cdk";
+
+new AppTheorySsrSite(this, "Site", {
+  ssrFunction,
+  mode: AppTheorySsrSiteMode.SSG_ISR,
+  assetsBucket,
+  assetsKeyPrefix: "assets",
+  assetsManifestKey: ".vite/manifest.json",
+
+  // FaceTheory ISR HTML store (`S3HtmlStore`)
+  htmlStoreBucket: isrBucket,
+  htmlStoreKeyPrefix: "isr",
+
+  // FaceTheory ISR metadata + lease coordination (TableTheory schema)
+  isrMetadataTable,
+
+  // Optional app-specific origin headers
+  ssrForwardHeaders: ["x-facetheory-tenant"],
+});
+```
+
+## Contract
+
+`AppTheorySsrSite` now assumes the stronger FaceTheory deployment contract by default:
+
+- SSR origin:
+  - Lambda Function URL uses `AWS_IAM` auth by default
+  - CloudFront reaches the Function URL through lambda Origin Access Control
+  - `ssrUrlAuthType: NONE` is a compatibility escape hatch, not the preferred path
+- Edge request normalization:
+  - viewer-request preserves an inbound `x-request-id`, otherwise falls back to the CloudFront request ID
+  - viewer-request records both `x-apptheory-original-host` / `x-apptheory-original-uri` and
+    `x-facetheory-original-host` / `x-facetheory-original-uri`
+  - raw `host` and `x-forwarded-proto` are intentionally rejected from the SSR origin request allowlist
+- CDN response headers:
+  - baseline security headers are set at CloudFront: HSTS, `nosniff`, frame options, referrer policy, XSS protection,
+    and restrictive `permissions-policy`
+  - Content-Security-Policy stays origin-defined so per-request SSR nonce flows remain possible
+- Cache semantics:
+  - CloudFront uses origin cache-control headers for both SSR and direct-S3 behaviors
+  - FaceTheory response headers remain the source of truth for SSR, SSG, and ISR freshness
+
+## Runtime env wiring
+
+When `wireRuntimeEnv` is left enabled (the default), AppTheory wires:
+
+- `APPTHEORY_ASSETS_BUCKET`
+- `APPTHEORY_ASSETS_PREFIX`
+- `APPTHEORY_ASSETS_MANIFEST_KEY`
+- `FACETHEORY_ISR_BUCKET`
+- `FACETHEORY_ISR_PREFIX`
+- `APPTHEORY_CACHE_TABLE_NAME`
+- `FACETHEORY_CACHE_TABLE_NAME`
+- `CACHE_TABLE_NAME`
+- `CACHE_TABLE`
+
+If you pass `htmlStoreBucket` and `isrMetadataTable`, AppTheory also grants the SSR Lambda the required S3 and
+DynamoDB permissions. If you use name-only wiring for the metadata table, you still need to grant access in your app
+stack.
+
+## Verification model
+
+There are two verification layers for this pattern:
+
+- deterministic local gate: `./scripts/verify-cdk-synth.sh` and `make rubric`
+- live deploy-grade smoke: `./scripts/verify-ssr-site-smoke.sh`
+
+The live smoke verifier deploys `examples/cdk/ssr-site`, checks:
+
+- CloudFront root path reaches the Lambda Function URL fallback and returns the SSR body
+- the previous `Host`-forwarding 403 regression stays covered by exercising the CloudFront-to-Function URL path end to end
+- asset delivery works from S3 through CloudFront
+- direct Function URL access remains blocked under the `AWS_IAM` auth model
+
+Run it manually when you want an end-to-end AWS check:
+
+```bash
+./scripts/verify-ssr-site-smoke.sh
+```
+
+Optional environment:
+
+- `APPTHEORY_SSR_SITE_STACK_NAME` to override the temporary stack name
+- `APPTHEORY_SSR_SMOKE_KEEP_STACK=1` to skip automatic destroy for debugging
+
+## Release workflow requirements
+
+The release and prerelease GitHub workflows now treat the live smoke verifier as a required gate. Configure these repo
+variables before relying on that path:
+
+- `APPTHEORY_SSR_SMOKE_ROLE_ARN`
+- `APPTHEORY_SSR_SMOKE_AWS_REGION`
+
+Those workflows assume OIDC-based AWS access through `aws-actions/configure-aws-credentials`, then run
+`./scripts/verify-ssr-site-smoke.sh` after `make rubric`.
+
+## Example
+
+The canonical runnable stack remains:
+
+- `examples/cdk/ssr-site/`
+
+Use that example plus this guide as the single AppTheory + FaceTheory deployment story.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -13,6 +13,7 @@ Use the smallest gate that proves the change, then escalate to the full rubric b
 - public API drift: `./scripts/update-api-snapshots.sh`, `./scripts/verify-api-snapshots.sh`
 - docs contract: `./scripts/verify-docs-standard.sh`
 - full repo gate: `make rubric`
+- release-only live SSR smoke: `./scripts/verify-ssr-site-smoke.sh`
 
 ## Fast local loop
 
@@ -48,6 +49,17 @@ make rubric
 
 `make rubric` includes the language-specific unit-test verifiers above, shared contract fixtures, snapshot verification,
 docs contract checks, and release-build validation.
+
+For the FaceTheory-first SSR deployment path, the release and prerelease GitHub workflows also run:
+
+```bash
+./scripts/verify-ssr-site-smoke.sh
+```
+
+That verifier deploys `examples/cdk/ssr-site`, checks CloudFront root reachability, asset delivery, and the direct
+Function URL auth model, then destroys the stack. It also keeps the previous Host-header 403 regression covered by
+exercising the CloudFront-to-Function URL path end to end. It requires AWS credentials and is intentionally separate
+from the deterministic local rubric.
 
 If exported APIs changed, refresh snapshots first and then re-run snapshot verification:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,7 @@ This guide maps common symptoms to verified fixes.
 | Snapshot drift | `./scripts/verify-api-snapshots.sh` | Run `./scripts/update-api-snapshots.sh` and review the public API delta |
 | Cross-language behavior mismatch | `./scripts/verify-contract-tests.sh` | Update fixtures/tests or fix runtime parity |
 | CDK synth or package failure | `make rubric` | Inspect the failing `verify-cdk-*` or build step and regenerate outputs |
+| Live SSR smoke failure | `./scripts/verify-ssr-site-smoke.sh` | Check AWS credentials, deploy outputs, and CloudFront / Function URL reachability |
 | Docs contract issue | `./scripts/verify-docs-standard.sh` | Restore the canonical docs set under `docs/` |
 
 ## Issue: version alignment check fails
@@ -170,6 +171,33 @@ make rubric
 ```
 
 Review the failing synth example or construct before changing the verifier.
+
+## Issue: SSR smoke verification fails in release automation
+
+Symptoms:
+
+- `./scripts/verify-ssr-site-smoke.sh` fails
+- release or prerelease workflow fails after `make rubric`
+- CloudFront returns `403`, `502`, or never serves the SSR example root path
+
+Cause:
+
+- AWS credentials or the OIDC role variables for the release smoke gate are missing
+- CloudFront cannot reach the Lambda Function URL under the signed origin model
+- a header-policy regression reintroduced a bad SSR origin contract
+
+Fix:
+
+- confirm the repo variables `APPTHEORY_SSR_SMOKE_ROLE_ARN` and `APPTHEORY_SSR_SMOKE_AWS_REGION` are configured
+- run the smoke verifier locally with valid AWS credentials to reproduce the deployed failure
+- inspect the deployed stack outputs, CloudFront root response, asset response, and direct Function URL response
+
+Verification:
+
+```bash
+./scripts/verify-ssr-site-smoke.sh
+make rubric
+```
 
 ## Issue: docs-standard fails after a docs change
 

--- a/examples/cdk/ssr-site/README.md
+++ b/examples/cdk/ssr-site/README.md
@@ -1,4 +1,6 @@
-# AppTheory SSR Site (Lambda URL + CloudFront) — CDK Example
+# AppTheory SSR Site (Lambda URL + CloudFront) - CDK Example
+
+Canonical operator guide: `docs/cdk/ssr-site.md`
 
 This example synthesizes an opinionated **SSR site** deployment pattern:
 
@@ -16,11 +18,11 @@ The construct (`AppTheorySsrSite`) also wires recommended runtime environment va
 
 ## FaceTheory-first deployment guide
 
-FaceTheory’s recommended topology splits CloudFront behaviors so static paths don’t traverse the SSR Lambda:
+FaceTheory's recommended topology splits CloudFront behaviors so static paths don't traverse the SSR Lambda:
 
-- `assets/*` → S3 (assets)
-- `/_facetheory/data/*` → S3 (SSG hydration JSON)
-- default `*` → S3 primary HTML origin with Lambda Function URL fallback
+- `assets/*` -> S3 (assets)
+- `/_facetheory/data/*` -> S3 (SSG hydration JSON)
+- default `*` -> S3 primary HTML origin with Lambda Function URL fallback
 
 Example configuration:
 
@@ -36,7 +38,7 @@ new AppTheorySsrSite(this, "Site", {
   // FaceTheory ISR metadata + lease coordination (TableTheory schema).
   isrMetadataTable,
 
-  // Forward FaceTheory’s tenant header to SSR when needed (normalized + de-duped).
+  // Forward FaceTheory's tenant header to SSR when needed (normalized + de-duped).
   ssrForwardHeaders: ["x-facetheory-tenant"],
 });
 ```
@@ -71,6 +73,22 @@ cd examples/cdk/ssr-site
 npm ci
 npx cdk synth
 ```
+
+## Deploy-grade smoke verification
+
+The deterministic synth hash is only the local gate for this example. The release path also runs a live AWS smoke
+check through `scripts/verify-ssr-site-smoke.sh`.
+
+Manual run from the repo root:
+
+```bash
+./scripts/verify-ssr-site-smoke.sh
+```
+
+Optional environment:
+
+- `APPTHEORY_SSR_SITE_STACK_NAME` to override the temporary stack name
+- `APPTHEORY_SSR_SMOKE_KEEP_STACK=1` to keep the deployed stack for debugging
 
 ## Build/deploy helpers (optional)
 

--- a/examples/cdk/ssr-site/bin/apptheory-ssr-site.ts
+++ b/examples/cdk/ssr-site/bin/apptheory-ssr-site.ts
@@ -6,5 +6,6 @@ import { SsrSiteStack } from "../lib/ssr-site-stack";
 
 const app = new cdk.App();
 
-new SsrSiteStack(app, "AppTheorySsrSiteDemo");
+const stackName = String(process.env.APPTHEORY_SSR_SITE_STACK_NAME ?? "").trim() || "AppTheorySsrSiteDemo";
 
+new SsrSiteStack(app, stackName);

--- a/scripts/verify-ssr-site-smoke.sh
+++ b/scripts/verify-ssr-site-smoke.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "ssr-site-smoke: BLOCKED (${cmd} not found)" >&2
+    exit 1
+  fi
+}
+
+for cmd in aws curl node npm python3; do
+  need_cmd "${cmd}"
+done
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "ssr-site-smoke: BLOCKED (AWS credentials not configured)" >&2
+  exit 1
+fi
+
+example_dir="examples/cdk/ssr-site"
+stack_name_raw="${APPTHEORY_SSR_SITE_STACK_NAME:-AppTheorySsrSiteSmoke-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}}"
+stack_name="$(printf '%s' "${stack_name_raw}" | tr -cd '[:alnum:]-')"
+if [[ -z "${stack_name}" || ! "${stack_name}" =~ ^[A-Za-z] ]]; then
+  stack_name="AppTheorySsrSiteSmoke-${stack_name}"
+fi
+
+keep_stack="${APPTHEORY_SSR_SMOKE_KEEP_STACK:-0}"
+outputs_file="$(mktemp)"
+headers_file="$(mktemp)"
+body_file="$(mktemp)"
+deploy_attempted="0"
+deployed="0"
+
+cleanup() {
+  local exit_code=$?
+
+  if [[ "${deploy_attempted}" == "1" && "${keep_stack}" != "1" ]]; then
+    if aws cloudformation describe-stacks --stack-name "${stack_name}" >/dev/null 2>&1; then
+      (
+        cd "${example_dir}"
+        APPTHEORY_SSR_SITE_STACK_NAME="${stack_name}" npx cdk destroy "${stack_name}" --force >/dev/null
+      ) || {
+        echo "ssr-site-smoke: WARN (failed to destroy ${stack_name})" >&2
+        if [[ "${exit_code}" -eq 0 ]]; then
+          exit_code=1
+        fi
+      }
+    fi
+  elif [[ "${deployed}" == "1" ]]; then
+    echo "ssr-site-smoke: KEEP (${stack_name})"
+  fi
+
+  rm -f "${outputs_file}" "${headers_file}" "${body_file}"
+  exit "${exit_code}"
+}
+trap cleanup EXIT
+
+extract_output() {
+  local key="$1"
+  python3 - "${outputs_file}" "${stack_name}" "${key}" <<'PY'
+import json
+import sys
+
+path, stack_name, key = sys.argv[1:4]
+data = json.load(open(path, encoding="utf-8"))
+stack_outputs = data.get(stack_name) or {}
+value = stack_outputs.get(key, "")
+print(str(value).strip())
+PY
+}
+
+probe_contains() {
+  local url="$1"
+  local expected_status="$2"
+  local needle="$3"
+  local expect_request_id="$4"
+  local attempts="${5:-40}"
+  local sleep_seconds="${6:-15}"
+
+  local attempt=1
+  while [[ "${attempt}" -le "${attempts}" ]]; do
+    local status
+    status="$(curl -sS -D "${headers_file}" -o "${body_file}" --max-time 30 "${url}" -w '%{http_code}' || true)"
+
+    if [[ "${status}" == "${expected_status}" ]] && grep -Fq "${needle}" "${body_file}"; then
+      if [[ "${expect_request_id}" != "1" || "$(grep -ic '^x-request-id:' "${headers_file}")" -ge 1 ]]; then
+        return 0
+      fi
+    fi
+
+    if [[ "${attempt}" -lt "${attempts}" ]]; then
+      sleep "${sleep_seconds}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "ssr-site-smoke: FAIL (url=${url} status=${status:-curl-error})" >&2
+  echo "ssr-site-smoke: headers" >&2
+  cat "${headers_file}" >&2 || true
+  echo "ssr-site-smoke: body" >&2
+  cat "${body_file}" >&2 || true
+  exit 1
+}
+
+probe_exact_trimmed() {
+  local url="$1"
+  local expected_status="$2"
+  local expected_body="$3"
+  local expect_request_id="$4"
+  local attempts="${5:-20}"
+  local sleep_seconds="${6:-10}"
+
+  local attempt=1
+  while [[ "${attempt}" -le "${attempts}" ]]; do
+    local status
+    status="$(curl -sS -D "${headers_file}" -o "${body_file}" --max-time 30 "${url}" -w '%{http_code}' || true)"
+    local trimmed_body
+    trimmed_body="$(tr -d '\r\n' < "${body_file}")"
+
+    if [[ "${status}" == "${expected_status}" && "${trimmed_body}" == "${expected_body}" ]]; then
+      if [[ "${expect_request_id}" != "1" || "$(grep -ic '^x-request-id:' "${headers_file}")" -ge 1 ]]; then
+        return 0
+      fi
+    fi
+
+    if [[ "${attempt}" -lt "${attempts}" ]]; then
+      sleep "${sleep_seconds}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "ssr-site-smoke: FAIL (url=${url} status=${status:-curl-error})" >&2
+  echo "ssr-site-smoke: headers" >&2
+  cat "${headers_file}" >&2 || true
+  echo "ssr-site-smoke: body" >&2
+  cat "${body_file}" >&2 || true
+  exit 1
+}
+
+probe_status() {
+  local url="$1"
+  local expected_status="$2"
+  local attempts="${3:-10}"
+  local sleep_seconds="${4:-5}"
+
+  local attempt=1
+  while [[ "${attempt}" -le "${attempts}" ]]; do
+    local status
+    status="$(curl -sS -D "${headers_file}" -o "${body_file}" --max-time 30 "${url}" -w '%{http_code}' || true)"
+    if [[ "${status}" == "${expected_status}" ]]; then
+      return 0
+    fi
+
+    if [[ "${attempt}" -lt "${attempts}" ]]; then
+      sleep "${sleep_seconds}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "ssr-site-smoke: FAIL (url=${url} expected status ${expected_status}, got ${status:-curl-error})" >&2
+  echo "ssr-site-smoke: headers" >&2
+  cat "${headers_file}" >&2 || true
+  echo "ssr-site-smoke: body" >&2
+  cat "${body_file}" >&2 || true
+  exit 1
+}
+
+deploy_attempted="1"
+(
+  cd "${example_dir}"
+  npm ci >/dev/null
+  APPTHEORY_SSR_SITE_STACK_NAME="${stack_name}" \
+    npx cdk deploy "${stack_name}" --require-approval never --outputs-file "${outputs_file}" >/dev/null
+)
+deployed="1"
+
+cloudfront_url="$(extract_output "CloudFrontUrl")"
+distribution_id="$(extract_output "CloudFrontDistributionId")"
+ssr_function_url="$(extract_output "SsrFunctionUrl")"
+
+if [[ -z "${cloudfront_url}" || -z "${distribution_id}" || -z "${ssr_function_url}" ]]; then
+  echo "ssr-site-smoke: FAIL (missing expected outputs from ${stack_name})" >&2
+  cat "${outputs_file}" >&2 || true
+  exit 1
+fi
+
+probe_contains "${cloudfront_url}" "200" "Hello from AppTheory SSR Site" "1" 40 15
+probe_exact_trimmed "${cloudfront_url%/}/assets/hello.txt" "200" "hello" "1" 20 10
+probe_status "${ssr_function_url}" "403" 10 5
+
+echo "ssr-site-smoke: PASS (stack=${stack_name} distribution=${distribution_id})"


### PR DESCRIPTION
## What changed
- add `scripts/verify-ssr-site-smoke.sh` to deploy `examples/cdk/ssr-site`, verify CloudFront root reachability, asset delivery, and direct Function URL denial, then destroy the stack even after partial deploy failures
- wire `release.yml` and `prerelease.yml` to assume AWS through OIDC and require the SSR smoke gate after `make rubric`
- backfill focused `AppTheorySsrSite` assertions for `AWS_IAM` Function URL defaults, lambda OAC usage, Function URL origin wiring, and disallowed SSR header regressions
- add a canonical FaceTheory-first SSR guide and update AppTheory docs/examples to converge on one deployment story

## Why
Synth snapshots alone allowed a broken CloudFront -> Function URL path to look valid. This change adds a deploy-grade release gate and makes the construct docs/examples reflect the stronger FaceTheory contract.

## Impact
- release and prerelease now require `APPTHEORY_SSR_SMOKE_ROLE_ARN` and `APPTHEORY_SSR_SMOKE_AWS_REGION`
- the SSR example accepts `APPTHEORY_SSR_SITE_STACK_NAME` so the smoke verifier can use ephemeral stack names safely in automation
- operators now have a single canonical AppTheory + FaceTheory SSR/SSG/ISR guide

## Validation
- `cd cdk && npm run build`
- `cd cdk && node --test test/*.test.cjs`
- `make rubric`
- `aws sts get-caller-identity` failed locally with `Unable to locate credentials`, so `./scripts/verify-ssr-site-smoke.sh` was not run from this terminal

Refs #338
Refs #347
Refs #348
Refs #349
