### PR TITLE
[codex] Restore zero-config release flow and stop PR churn

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
   issues: write
   pull-requests: write
 
@@ -64,20 +63,9 @@ jobs:
         with:
           python-version: "3.14.3"
 
-      - name: Configure AWS credentials for SSR smoke gate
-        if: steps.release.outputs.release_created == 'true'
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: ${{ vars.APPTHEORY_SSR_SMOKE_ROLE_ARN }}
-          aws-region: ${{ vars.APPTHEORY_SSR_SMOKE_AWS_REGION }}
-
       - name: Build + verify
         if: steps.release.outputs.release_created == 'true'
-        env:
-          APPTHEORY_SSR_SITE_STACK_NAME: AppTheorySsrSiteSmoke-${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          make rubric
-          scripts/verify-ssr-site-smoke.sh
+        run: make rubric
 
       - name: Generate SHA-256 checksums
         if: steps.release.outputs.release_created == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
   issues: write
   pull-requests: write
 
@@ -46,17 +45,9 @@ jobs:
         with:
           python-version: "3.14.3"
 
-      - name: Configure AWS credentials for SSR smoke gate (existing tag path)
-        if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: ${{ vars.APPTHEORY_SSR_SMOKE_ROLE_ARN }}
-          aws-region: ${{ vars.APPTHEORY_SSR_SMOKE_AWS_REGION }}
-
       - name: Upload assets for existing tag release
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
         env:
-          APPTHEORY_SSR_SITE_STACK_NAME: AppTheorySsrSiteSmoke-${{ github.run_id }}-${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
@@ -83,7 +74,6 @@ jobs:
 
           export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
           make rubric
-          scripts/verify-ssr-site-smoke.sh
           scripts/generate-checksums.sh
           scripts/render-release-notes.sh "${TAG_NAME}"
 
@@ -164,20 +154,9 @@ jobs:
         with:
           python-version: "3.14.3"
 
-      - name: Configure AWS credentials for SSR smoke gate
-        if: steps.release.outputs.release_created == 'true'
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: ${{ vars.APPTHEORY_SSR_SMOKE_ROLE_ARN }}
-          aws-region: ${{ vars.APPTHEORY_SSR_SMOKE_AWS_REGION }}
-
       - name: Build + verify
         if: steps.release.outputs.release_created == 'true'
-        env:
-          APPTHEORY_SSR_SITE_STACK_NAME: AppTheorySsrSiteSmoke-${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          make rubric
-          scripts/verify-ssr-site-smoke.sh
+        run: make rubric
 
       - name: Generate SHA-256 checksums
         if: steps.release.outputs.release_created == 'true'

--- a/docs/cdk/ssr-site.md
+++ b/docs/cdk/ssr-site.md
@@ -105,16 +105,8 @@ Optional environment:
 - `APPTHEORY_SSR_SITE_STACK_NAME` to override the temporary stack name
 - `APPTHEORY_SSR_SMOKE_KEEP_STACK=1` to skip automatic destroy for debugging
 
-## Release workflow requirements
-
-The release and prerelease GitHub workflows now treat the live smoke verifier as a required gate. Configure these repo
-variables before relying on that path:
-
-- `APPTHEORY_SSR_SMOKE_ROLE_ARN`
-- `APPTHEORY_SSR_SMOKE_AWS_REGION`
-
-Those workflows assume OIDC-based AWS access through `aws-actions/configure-aws-credentials`, then run
-`./scripts/verify-ssr-site-smoke.sh` after `make rubric`.
+The live smoke verifier is intentionally separate from release automation so the normal release path stays zero-config.
+Use it as a manual deploy-grade check when you explicitly want a real AWS verification pass.
 
 ## Example
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -13,7 +13,7 @@ Use the smallest gate that proves the change, then escalate to the full rubric b
 - public API drift: `./scripts/update-api-snapshots.sh`, `./scripts/verify-api-snapshots.sh`
 - docs contract: `./scripts/verify-docs-standard.sh`
 - full repo gate: `make rubric`
-- release-only live SSR smoke: `./scripts/verify-ssr-site-smoke.sh`
+- optional live SSR smoke: `./scripts/verify-ssr-site-smoke.sh`
 
 ## Fast local loop
 
@@ -50,7 +50,7 @@ make rubric
 `make rubric` includes the language-specific unit-test verifiers above, shared contract fixtures, snapshot verification,
 docs contract checks, and release-build validation.
 
-For the FaceTheory-first SSR deployment path, the release and prerelease GitHub workflows also run:
+For the FaceTheory-first SSR deployment path, you can also run a manual deploy-grade smoke check:
 
 ```bash
 ./scripts/verify-ssr-site-smoke.sh
@@ -59,7 +59,7 @@ For the FaceTheory-first SSR deployment path, the release and prerelease GitHub 
 That verifier deploys `examples/cdk/ssr-site`, checks CloudFront root reachability, asset delivery, and the direct
 Function URL auth model, then destroys the stack. It also keeps the previous Host-header 403 regression covered by
 exercising the CloudFront-to-Function URL path end to end. It requires AWS credentials and is intentionally separate
-from the deterministic local rubric.
+from both the deterministic local rubric and the zero-config release workflow.
 
 If exported APIs changed, refresh snapshots first and then re-run snapshot verification:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,23 +172,21 @@ make rubric
 
 Review the failing synth example or construct before changing the verifier.
 
-## Issue: SSR smoke verification fails in release automation
+## Issue: manual SSR smoke verification fails
 
 Symptoms:
 
 - `./scripts/verify-ssr-site-smoke.sh` fails
-- release or prerelease workflow fails after `make rubric`
 - CloudFront returns `403`, `502`, or never serves the SSR example root path
 
 Cause:
 
-- AWS credentials or the OIDC role variables for the release smoke gate are missing
+- AWS credentials are missing
 - CloudFront cannot reach the Lambda Function URL under the signed origin model
 - a header-policy regression reintroduced a bad SSR origin contract
 
 Fix:
 
-- confirm the repo variables `APPTHEORY_SSR_SMOKE_ROLE_ARN` and `APPTHEORY_SSR_SMOKE_AWS_REGION` are configured
 - run the smoke verifier locally with valid AWS credentials to reproduce the deployed failure
 - inspect the deployed stack outputs, CloudFront root response, asset response, and direct Function URL response
 

--- a/examples/cdk/ssr-site/README.md
+++ b/examples/cdk/ssr-site/README.md
@@ -76,8 +76,8 @@ npx cdk synth
 
 ## Deploy-grade smoke verification
 
-The deterministic synth hash is only the local gate for this example. The release path also runs a live AWS smoke
-check through `scripts/verify-ssr-site-smoke.sh`.
+The deterministic synth hash is the normal automated gate for this example. When you want a real AWS verification pass,
+run the live smoke check through `scripts/verify-ssr-site-smoke.sh` manually.
 
 Manual run from the repo root:
 


### PR DESCRIPTION
## What changed
- remove the SSR smoke verifier from `release.yml` and `prerelease.yml`
- remove the AWS/OIDC release dependency introduced for that smoke gate
- restore the release and prerelease paths to the prior zero-config `make rubric` flow
- stop `release-pr.yml` and `prerelease-pr.yml` from reopening the next `release-please--branches--*` PR immediately after a release/prerelease cut
- document that the release-pr workflows ignore merged `release-please--branches--*` pushes to avoid PR churn
- keep the SSR live smoke verifier as a manual optional check only

## Why
Two release regressions needed to be removed before the next cut:
1. release automation was broken by a newly introduced AWS-config dependency
2. merging a release-please PR on `main` or `premain` immediately triggered the PR-generation workflow again and opened the next release PR, forcing manual cleanup

## Validation
- `bash scripts/verify-branch-release-supply-chain.sh`
- `make rubric`

## Outcome
- release stays zero-config
- cutting a release no longer reopens the next release PR on the merge commit itself
