### PR TITLE
[codex] Stop release-please PR churn after cuts

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, 'release-please--branches--premain')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, 'release-please--branches--main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
+++ b/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
@@ -27,6 +27,8 @@ Release flow (TableTheory pattern):
   - The `Release PR (main)` workflow aligns stable releases to the premain RC baseline (via `release-as`), then opens the stable
     release-please PR.
   - **Merging the stable release-please PR** cuts the stable tag + GitHub release.
+- The release-pr workflows ignore pushes whose head commit is the merged `release-please--branches--*` branch, so cutting a
+  release does not immediately open the next release PR again.
 - **post-release sync**: back-merge `main` into `staging` (and `premain` as needed) so the next cycle starts from the latest stable baseline.
 
 Important: release automation is driven by **Conventional Commits**. Commits typed as `fix:` / `feat:` are treated as user-facing


### PR DESCRIPTION
## What changed
- update `release-pr.yml` to skip the PR-generation job when the push commit is the merged `release-please--branches--main` branch
- update `prerelease-pr.yml` to do the same for `release-please--branches--premain`
- document that behavior in the AppTheory release policy doc

## Why
After merging a release-please PR, the corresponding release-pr workflow immediately ran again on the merge commit and opened the next release PR, forcing manual cleanup every cycle.

## Validation
- `make rubric`
