### PR TITLE
chore(ci): wire AppTheory theorycloud subtree sync helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # AppTheory Makefile
 
 .PHONY: all build test test-unit lint fmt fmt-check rubric verify-builds \
-	theorycloud-apptheory-subtree verify-theorycloud-apptheory-subtree
+	theorycloud-apptheory-subtree verify-theorycloud-apptheory-subtree \
+	sync-theorycloud-apptheory-subtree trigger-theorycloud-publish \
+	verify-theorycloud-apptheory-publish-config
 
 TOOLCHAIN := $(shell awk '/^toolchain / {print $$2}' go.mod | head -n 1)
 export GOTOOLCHAIN ?= $(TOOLCHAIN)
@@ -46,3 +48,12 @@ theorycloud-apptheory-subtree:
 
 verify-theorycloud-apptheory-subtree:
 	@bash ./scripts/verify-theorycloud-apptheory-subtree.sh
+
+sync-theorycloud-apptheory-subtree:
+	@bash ./scripts/sync-theorycloud-apptheory-subtree.sh
+
+trigger-theorycloud-publish:
+	@bash ./scripts/trigger-theorycloud-publish.sh
+
+verify-theorycloud-apptheory-publish-config:
+	@bash ./scripts/verify-theorycloud-apptheory-publish-config.sh

--- a/scripts/sync-theorycloud-apptheory-subtree.sh
+++ b/scripts/sync-theorycloud-apptheory-subtree.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/theorycloud-apptheory-env.sh"
+
+usage() {
+  cat <<'EOF_USAGE'
+Usage:
+  bash scripts/sync-theorycloud-apptheory-subtree.sh [--stage STAGE] [--branch BRANCH] [--source-s3-uri URI] [--output DIR]
+
+Environment:
+  THEORYCLOUD_STAGE                          Optional explicit stage override
+  THEORYCLOUD_BRANCH_NAME                    Optional branch-name override for premain/main mapping
+  THEORYCLOUD_APPTHEORY_SUBTREE_OUTPUT_DIR   Staging root directory. Default: /tmp/apptheory-theorycloud
+  THEORYCLOUD_APPTHEORY_SOURCE_S3_URI        Optional override for the subtree destination S3 URI
+  KT_SOURCE_S3_URI                           Alternate override for the subtree destination S3 URI
+  THEORYCLOUD_S3_SYNC_DELETE                 Default: true. When true, prune objects under theorycloud/apptheory/
+  THEORYCLOUD_S3_SYNC_DRY_RUN                Default: false. When true, print the sync plan without calling AWS
+EOF_USAGE
+}
+
+fail() {
+  echo "sync-theorycloud-apptheory-subtree: FAIL ($*)" >&2
+  exit 1
+}
+
+require_s3_uri() {
+  local value="$1"
+  local label="$2"
+  if [[ -z "${value}" ]]; then
+    fail "missing ${label}"
+  fi
+  if [[ "${value}" != s3://* ]]; then
+    fail "${label} must be an s3:// URI: ${value}"
+  fi
+}
+
+STAGE="${THEORYCLOUD_STAGE:-}"
+BRANCH_NAME="${THEORYCLOUD_BRANCH_NAME:-}"
+OUTPUT_DIR="${THEORYCLOUD_APPTHEORY_SUBTREE_OUTPUT_DIR:-/tmp/apptheory-theorycloud}"
+SOURCE_S3_URI="${THEORYCLOUD_APPTHEORY_SOURCE_S3_URI:-${KT_SOURCE_S3_URI:-}}"
+SYNC_DELETE="${THEORYCLOUD_S3_SYNC_DELETE:-true}"
+SYNC_DRY_RUN="${THEORYCLOUD_S3_SYNC_DRY_RUN:-false}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH_NAME="$2"
+      shift 2
+      ;;
+    --source-s3-uri)
+      SOURCE_S3_URI="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+STAGE="$(THEORYCLOUD_BRANCH_NAME="${BRANCH_NAME}" apptheory_theorycloud_resolve_stage "${STAGE}")"
+if [[ -z "${SOURCE_S3_URI}" ]]; then
+  SOURCE_S3_URI="$(apptheory_theorycloud_source_s3_uri_for_stage "${STAGE}" || true)"
+fi
+require_s3_uri "${SOURCE_S3_URI}" "THEORYCLOUD_APPTHEORY_SOURCE_S3_URI"
+SOURCE_S3_URI="${SOURCE_S3_URI%/}/"
+
+bash "${SCRIPT_DIR}/stage-theorycloud-apptheory-subtree.sh" --output "${OUTPUT_DIR}"
+
+if [[ ! -f "${OUTPUT_DIR}/source-manifest.json" ]]; then
+  fail "missing staged provenance manifest at ${OUTPUT_DIR}/source-manifest.json"
+fi
+
+sync_flags=()
+if [[ "${SYNC_DELETE}" == "true" ]]; then
+  sync_flags+=(--delete)
+fi
+
+if [[ "${SYNC_DRY_RUN}" == "true" ]]; then
+  echo "sync-theorycloud-apptheory-subtree: DRY RUN"
+  echo "stage=${STAGE}"
+  if [[ -n "${BRANCH_NAME}" ]]; then
+    echo "branch=${BRANCH_NAME}"
+  fi
+  echo "source=${OUTPUT_DIR%/}/"
+  echo "destination=${SOURCE_S3_URI}"
+  if [[ "${SYNC_DELETE}" == "true" ]]; then
+    echo "delete=true"
+  else
+    echo "delete=false"
+  fi
+  echo "command=aws s3 sync ${OUTPUT_DIR%/}/ ${SOURCE_S3_URI} ${sync_flags[*]:-}"
+  echo "sync-theorycloud-apptheory-subtree: PASS (dry-run; target=${SOURCE_S3_URI})"
+  exit 0
+fi
+
+command -v aws >/dev/null 2>&1 || fail "aws CLI is required"
+
+echo "syncing AppTheory subtree to ${SOURCE_S3_URI}"
+if ! aws s3 sync "${OUTPUT_DIR%/}/" "${SOURCE_S3_URI}" "${sync_flags[@]}"; then
+  fail "aws s3 sync failed for ${SOURCE_S3_URI}"
+fi
+
+echo "sync-theorycloud-apptheory-subtree: PASS (target=${SOURCE_S3_URI})"

--- a/scripts/theorycloud-apptheory-env.sh
+++ b/scripts/theorycloud-apptheory-env.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+theorycloud_apptheory_env_fail() {
+  echo "theorycloud-apptheory-env: FAIL ($*)" >&2
+  exit 1
+}
+
+apptheory_theorycloud_stage_for_branch() {
+  local branch="${1:-}"
+  branch="${branch#refs/heads/}"
+  case "${branch}" in
+    premain) printf '%s\n' 'lab' ;;
+    main) printf '%s\n' 'live' ;;
+    *) return 1 ;;
+  esac
+}
+
+apptheory_theorycloud_source_s3_uri_for_stage() {
+  local stage="${1:-}"
+  case "${stage}" in
+    lab) printf '%s\n' 's3://kt-sources-lab-787107040121/theorycloud/apptheory/' ;;
+    live) printf '%s\n' 's3://kt-sources-live-787107040121/theorycloud/apptheory/' ;;
+    *) return 1 ;;
+  esac
+}
+
+apptheory_theorycloud_publish_url_for_stage() {
+  local stage="${1:-}"
+  case "${stage}" in
+    lab) printf '%s\n' 'https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud' ;;
+    live) printf '%s\n' 'https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud' ;;
+    *) return 1 ;;
+  esac
+}
+
+apptheory_theorycloud_branch_name() {
+  if [[ -n "${THEORYCLOUD_BRANCH_NAME:-}" ]]; then
+    printf '%s\n' "${THEORYCLOUD_BRANCH_NAME}"
+    return 0
+  fi
+  if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    printf '%s\n' "${GITHUB_REF_NAME}"
+    return 0
+  fi
+  git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+apptheory_theorycloud_resolve_stage() {
+  local stage="${1:-${THEORYCLOUD_STAGE:-}}"
+  if [[ -n "${stage}" ]]; then
+    stage="${stage,,}"
+    case "${stage}" in
+      lab|live)
+        printf '%s\n' "${stage}"
+        return 0
+        ;;
+      *)
+        theorycloud_apptheory_env_fail "unsupported stage '${stage}' (expected lab or live)"
+        ;;
+    esac
+  fi
+
+  local branch
+  branch="$(apptheory_theorycloud_branch_name)"
+  if [[ -n "${branch}" ]]; then
+    if stage="$(apptheory_theorycloud_stage_for_branch "${branch}" 2>/dev/null)"; then
+      printf '%s\n' "${stage}"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' 'lab'
+}
+
+theorycloud_apptheory_env_usage() {
+  cat <<'EOF_USAGE'
+Usage:
+  bash scripts/theorycloud-apptheory-env.sh --resolve-stage [--stage STAGE] [--branch BRANCH]
+  bash scripts/theorycloud-apptheory-env.sh --stage-for-branch BRANCH
+  bash scripts/theorycloud-apptheory-env.sh --source-s3-uri [--stage STAGE] [--branch BRANCH]
+  bash scripts/theorycloud-apptheory-env.sh --publish-url [--stage STAGE] [--branch BRANCH]
+
+Environment:
+  THEORYCLOUD_STAGE        Optional explicit stage override
+  THEORYCLOUD_BRANCH_NAME  Optional branch-name override for premain/main mapping
+EOF_USAGE
+}
+
+theorycloud_apptheory_env_main() {
+  local command=""
+  local stage_arg=""
+  local branch_arg=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --resolve-stage)
+        command="resolve-stage"
+        shift
+        ;;
+      --stage-for-branch)
+        command="stage-for-branch"
+        branch_arg="$2"
+        shift 2
+        ;;
+      --source-s3-uri)
+        command="source-s3-uri"
+        shift
+        ;;
+      --publish-url)
+        command="publish-url"
+        shift
+        ;;
+      --stage)
+        stage_arg="$2"
+        shift 2
+        ;;
+      --branch)
+        branch_arg="$2"
+        shift 2
+        ;;
+      -h|--help)
+        theorycloud_apptheory_env_usage
+        exit 0
+        ;;
+      *)
+        echo "unknown argument: $1" >&2
+        theorycloud_apptheory_env_usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  case "${command}" in
+    resolve-stage)
+      THEORYCLOUD_BRANCH_NAME="${branch_arg}" apptheory_theorycloud_resolve_stage "${stage_arg}"
+      ;;
+    stage-for-branch)
+      apptheory_theorycloud_stage_for_branch "${branch_arg}" ||
+        theorycloud_apptheory_env_fail "unsupported branch '${branch_arg}'"
+      ;;
+    source-s3-uri)
+      local resolved_stage
+      resolved_stage="$(THEORYCLOUD_BRANCH_NAME="${branch_arg}" apptheory_theorycloud_resolve_stage "${stage_arg}")"
+      apptheory_theorycloud_source_s3_uri_for_stage "${resolved_stage}" ||
+        theorycloud_apptheory_env_fail "unsupported stage '${resolved_stage}'"
+      ;;
+    publish-url)
+      local resolved_stage
+      resolved_stage="$(THEORYCLOUD_BRANCH_NAME="${branch_arg}" apptheory_theorycloud_resolve_stage "${stage_arg}")"
+      apptheory_theorycloud_publish_url_for_stage "${resolved_stage}" ||
+        theorycloud_apptheory_env_fail "unsupported stage '${resolved_stage}'"
+      ;;
+    *)
+      theorycloud_apptheory_env_usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  theorycloud_apptheory_env_main "$@"
+fi

--- a/scripts/trigger-theorycloud-publish.sh
+++ b/scripts/trigger-theorycloud-publish.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/theorycloud-apptheory-env.sh"
+
+usage() {
+  cat <<'EOF_USAGE'
+Usage:
+  bash scripts/trigger-theorycloud-publish.sh [--stage STAGE] [--branch BRANCH] [--publish-url URL] [--source-revision SHA] [--idempotency-key KEY] [--reason TEXT] [--force]
+
+Environment:
+  THEORYCLOUD_STAGE           Optional explicit stage override
+  THEORYCLOUD_BRANCH_NAME     Optional branch-name override for premain/main mapping
+  THEORYCLOUD_PUBLISH_URL     Optional override for the publish endpoint URL
+  KT_PUBLISH_URL              Alternate override for the publish endpoint URL
+  THEORYCLOUD_PUBLISH_DRY_RUN Default: false. When true, print the request instead of invoking KT
+  THEORYCLOUD_PUBLISH_REASON  Default: docs sync complete
+  THEORYCLOUD_PUBLISH_FORCE   Default: false
+  SOURCE_REVISION             Optional source revision override
+  AWS_REGION                  Default: us-east-1
+EOF_USAGE
+}
+
+fail() {
+  echo "trigger-theorycloud-publish: FAIL ($*)" >&2
+  exit 1
+}
+
+STAGE="${THEORYCLOUD_STAGE:-}"
+BRANCH_NAME="${THEORYCLOUD_BRANCH_NAME:-}"
+PUBLISH_URL="${THEORYCLOUD_PUBLISH_URL:-${KT_PUBLISH_URL:-}}"
+SOURCE_REVISION="${SOURCE_REVISION:-}"
+IDEMPOTENCY_KEY=""
+REASON="${THEORYCLOUD_PUBLISH_REASON:-docs sync complete}"
+FORCE="${THEORYCLOUD_PUBLISH_FORCE:-false}"
+PUBLISH_DRY_RUN="${THEORYCLOUD_PUBLISH_DRY_RUN:-false}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH_NAME="$2"
+      shift 2
+      ;;
+    --publish-url)
+      PUBLISH_URL="$2"
+      shift 2
+      ;;
+    --source-revision)
+      SOURCE_REVISION="$2"
+      shift 2
+      ;;
+    --idempotency-key)
+      IDEMPOTENCY_KEY="$2"
+      shift 2
+      ;;
+    --reason)
+      REASON="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+STAGE="$(THEORYCLOUD_BRANCH_NAME="${BRANCH_NAME}" apptheory_theorycloud_resolve_stage "${STAGE}")"
+if [[ -z "${PUBLISH_URL}" ]]; then
+  PUBLISH_URL="$(apptheory_theorycloud_publish_url_for_stage "${STAGE}" || true)"
+fi
+if [[ -z "${PUBLISH_URL}" ]]; then
+  fail "missing publish URL for stage ${STAGE}"
+fi
+if [[ ! "${PUBLISH_URL}" =~ ^https:// ]]; then
+  fail "publish URL must be https://...: ${PUBLISH_URL}"
+fi
+
+if [[ -z "${SOURCE_REVISION}" ]]; then
+  SOURCE_REVISION="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || true)"
+fi
+if [[ -z "${SOURCE_REVISION}" ]]; then
+  fail "missing source revision"
+fi
+
+short_sha="${SOURCE_REVISION:0:12}"
+if [[ -z "${IDEMPOTENCY_KEY}" ]]; then
+  if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    IDEMPOTENCY_KEY="github-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}-${short_sha}"
+  else
+    IDEMPOTENCY_KEY="manual-${short_sha}"
+  fi
+fi
+
+PAYLOAD="$(python3 - <<PY
+import json
+payload = {
+  'source_revision': ${SOURCE_REVISION@Q},
+  'idempotency_key': ${IDEMPOTENCY_KEY@Q},
+  'reason': ${REASON@Q},
+  'force': ${FORCE@Q}.lower() == 'true',
+}
+print(json.dumps(payload, separators=(',', ':')))
+PY
+)"
+
+if [[ "${PUBLISH_DRY_RUN}" == "true" ]]; then
+  echo "trigger-theorycloud-publish: DRY RUN"
+  echo "stage=${STAGE}"
+  if [[ -n "${BRANCH_NAME}" ]]; then
+    echo "branch=${BRANCH_NAME}"
+  fi
+  echo "url=${PUBLISH_URL}"
+  echo "payload=${PAYLOAD}"
+  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type:application/json --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
+  exit 0
+fi
+
+command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
+
+response_file="$(mktemp)"
+http_code="$(awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" -w '%{http_code}' "${PUBLISH_URL}")" || {
+  status=$?
+  rm -f "${response_file}"
+  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
+}
+
+if [[ ! "${http_code}" =~ ^2 ]]; then
+  body="$(cat "${response_file}")"
+  rm -f "${response_file}"
+  fail "publish returned HTTP ${http_code}: ${body}"
+fi
+
+body="$(cat "${response_file}")"
+rm -f "${response_file}"
+echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL}; http=${http_code})"
+printf '%s\n' "${body}"

--- a/scripts/verify-theorycloud-apptheory-publish-config.sh
+++ b/scripts/verify-theorycloud-apptheory-publish-config.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  echo "verify-theorycloud-apptheory-publish-config: FAIL ($*)" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" <<<"${haystack}"; then
+    fail "expected to find '${needle}'"
+  fi
+}
+
+assert_equals() {
+  local actual="$1"
+  local expected="$2"
+  if [[ "${actual}" != "${expected}" ]]; then
+    fail "expected '${expected}' but got '${actual}'"
+  fi
+}
+
+assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --stage-for-branch premain)" "lab"
+assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --stage-for-branch main)" "live"
+assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --source-s3-uri --stage lab)" "s3://kt-sources-lab-787107040121/theorycloud/apptheory/"
+assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --source-s3-uri --stage live)" "s3://kt-sources-live-787107040121/theorycloud/apptheory/"
+assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --publish-url --stage lab)" "https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud"
+assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --publish-url --stage live)" "https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+lab_sync_output="$(THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync-theorycloud-apptheory-subtree.sh" --branch premain --output "${TMP_DIR}/lab")"
+assert_contains "${lab_sync_output}" 'stage=lab'
+assert_contains "${lab_sync_output}" 'branch=premain'
+assert_contains "${lab_sync_output}" 'destination=s3://kt-sources-lab-787107040121/theorycloud/apptheory/'
+assert_contains "${lab_sync_output}" 'delete=true'
+assert_contains "${lab_sync_output}" 'command=aws s3 sync'
+
+live_sync_output="$(THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync-theorycloud-apptheory-subtree.sh" --branch main --output "${TMP_DIR}/live")"
+assert_contains "${live_sync_output}" 'stage=live'
+assert_contains "${live_sync_output}" 'branch=main'
+assert_contains "${live_sync_output}" 'destination=s3://kt-sources-live-787107040121/theorycloud/apptheory/'
+assert_contains "${live_sync_output}" 'delete=true'
+
+lab_publish_output="$(THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-lab)"
+assert_contains "${lab_publish_output}" 'stage=lab'
+assert_contains "${lab_publish_output}" 'branch=premain'
+assert_contains "${lab_publish_output}" 'url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
+assert_contains "${lab_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-lab","reason":"docs sync complete","force":false}'
+
+live_publish_output="$(THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live)"
+assert_contains "${live_publish_output}" 'stage=live'
+assert_contains "${live_publish_output}" 'branch=main'
+assert_contains "${live_publish_output}" 'url=https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
+assert_contains "${live_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-live","reason":"docs sync complete","force":false}'
+
+echo 'verify-theorycloud-apptheory-publish-config: PASS'


### PR DESCRIPTION
## Milestone
`apptheory-subtree-sync` — Add stage-aware sync and shared publish helpers for the exact AppTheory lab/live destinations and publish endpoints.

## Linear
- Project: https://linear.app/theorycloud/project/apptheory-theorycloud-subtree-publishing-1fae509c8f7f
- Issue: https://linear.app/theorycloud/issue/THE-114/add-exact-lablive-sync-and-signed-publish-helpers

## Tasks
- [x] Add exact lab/live sync and signed publish helpers

## Contract impact
internal-only

## Validation
Commands run on the final commit:
- `bash ./scripts/verify-theorycloud-apptheory-publish-config.sh`
- `make test-unit`
- `make rubric`

## Cross-repo notes
- KnowledgeTheory #12 defines the exact TheoryCloud subtree destinations and publish endpoints this change encodes.
