### PR TITLE
chore(ci): add protected AppTheory theorycloud publish workflow

### DIFF
--- a/.github/workflows/theorycloud-apptheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-apptheory-subtree-publish.yml
@@ -1,0 +1,98 @@
+name: AppTheory TheoryCloud subtree publish
+
+on:
+  push:
+    branches:
+      - premain
+      - main
+    paths:
+      - "docs/README.md"
+      - "docs/_contract.yaml"
+      - "docs/_concepts.yaml"
+      - "docs/_patterns.yaml"
+      - "docs/_decisions.yaml"
+      - "docs/getting-started.md"
+      - "docs/api-reference.md"
+      - "docs/core-patterns.md"
+      - "docs/testing-guide.md"
+      - "docs/troubleshooting.md"
+      - "docs/migration-guide.md"
+      - "docs/cdk/**"
+      - "docs/features/**"
+      - "docs/integrations/**"
+      - "docs/migration/**"
+      - "docs/llm-faq/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: apptheory-theorycloud-subtree-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      THEORYCLOUD_STAGE: ${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}
+      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}
+      THEORYCLOUD_PUBLISH_REASON: ${{ format('github:{0}:{1}', github.repository, github.ref_name) }}
+    steps:
+      - name: Checkout protected branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate workflow and helper configuration
+        run: |
+          set -euo pipefail
+
+          : "${AWS_REGION:?missing vars.AWS_REGION (or default)}"
+          : "${THEORYCLOUD_STAGE:?missing stage resolution}"
+          : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN}"
+
+          case "${THEORYCLOUD_STAGE}" in
+            lab|live) ;;
+            *)
+              echo "unsupported theorycloud stage: ${THEORYCLOUD_STAGE}" >&2
+              exit 1
+              ;;
+          esac
+
+          bash scripts/verify-theorycloud-apptheory-publish-config.sh
+          bash scripts/verify-theorycloud-publish-workflow.sh
+
+      - name: Assume stage-scoped theorycloud publish role
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: apptheory-${{ github.ref_name }}-${{ github.run_id }}
+
+      - name: Install awscurl
+        run: |
+          set -euo pipefail
+
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user awscurl
+          printf '%s\n' "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Sync AppTheory subtree into shared theorycloud source state
+        run: |
+          set -euo pipefail
+
+          bash scripts/sync-theorycloud-apptheory-subtree.sh \
+            --stage "${THEORYCLOUD_STAGE}" \
+            --output /tmp/apptheory-theorycloud
+
+      - name: Trigger shared theorycloud publish
+        env:
+          SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          bash scripts/trigger-theorycloud-publish.sh \
+            --stage "${THEORYCLOUD_STAGE}" \
+            --source-revision "${SOURCE_REVISION}"

--- a/scripts/verify-rubric.sh
+++ b/scripts/verify-rubric.sh
@@ -24,5 +24,6 @@ bash ./scripts/verify-branch-version-sync.sh
 ./scripts/verify-contract-tests.sh
 ./scripts/verify-testkit-examples.sh
 bash ./scripts/verify-docs-standard.sh
+bash ./scripts/verify-theorycloud-publish-workflow.sh
 
 echo "rubric: PASS"

--- a/scripts/verify-theorycloud-apptheory-publish-config.sh
+++ b/scripts/verify-theorycloud-apptheory-publish-config.sh
@@ -34,14 +34,14 @@ assert_equals "$(bash "${SCRIPT_DIR}/theorycloud-apptheory-env.sh" --publish-url
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
-lab_sync_output="$(THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync-theorycloud-apptheory-subtree.sh" --branch premain --output "${TMP_DIR}/lab")"
+lab_sync_output="$(THEORYCLOUD_APPTHEORY_SOURCE_REVISION=abc123def456 THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync-theorycloud-apptheory-subtree.sh" --branch premain --output "${TMP_DIR}/lab")"
 assert_contains "${lab_sync_output}" 'stage=lab'
 assert_contains "${lab_sync_output}" 'branch=premain'
 assert_contains "${lab_sync_output}" 'destination=s3://kt-sources-lab-787107040121/theorycloud/apptheory/'
 assert_contains "${lab_sync_output}" 'delete=true'
 assert_contains "${lab_sync_output}" 'command=aws s3 sync'
 
-live_sync_output="$(THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync-theorycloud-apptheory-subtree.sh" --branch main --output "${TMP_DIR}/live")"
+live_sync_output="$(THEORYCLOUD_APPTHEORY_SOURCE_REVISION=abc123def456 THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync-theorycloud-apptheory-subtree.sh" --branch main --output "${TMP_DIR}/live")"
 assert_contains "${live_sync_output}" 'stage=live'
 assert_contains "${live_sync_output}" 'branch=main'
 assert_contains "${live_sync_output}" 'destination=s3://kt-sources-live-787107040121/theorycloud/apptheory/'

--- a/scripts/verify-theorycloud-publish-workflow.sh
+++ b/scripts/verify-theorycloud-publish-workflow.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/theorycloud-apptheory-subtree-publish.yml"
+
+fail() {
+  echo "verify-theorycloud-publish-workflow: FAIL ($*)" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local needle="$1"
+  if ! grep -Fq -- "${needle}" "${WORKFLOW_FILE}"; then
+    fail "expected workflow to contain '${needle}'"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq -- "${needle}" <<<"${haystack}"; then
+    fail "expected block to contain '${needle}'"
+  fi
+}
+
+if [[ ! -f "${WORKFLOW_FILE}" ]]; then
+  fail "missing workflow file ${WORKFLOW_FILE}"
+fi
+
+bash -n \
+  "${REPO_ROOT}/scripts/stage-theorycloud-apptheory-subtree.sh" \
+  "${REPO_ROOT}/scripts/verify-theorycloud-apptheory-subtree.sh" \
+  "${REPO_ROOT}/scripts/theorycloud-apptheory-env.sh" \
+  "${REPO_ROOT}/scripts/sync-theorycloud-apptheory-subtree.sh" \
+  "${REPO_ROOT}/scripts/trigger-theorycloud-publish.sh" \
+  "${REPO_ROOT}/scripts/verify-theorycloud-apptheory-publish-config.sh" \
+  "${REPO_ROOT}/scripts/verify-theorycloud-publish-workflow.sh"
+
+bash "${REPO_ROOT}/scripts/verify-theorycloud-apptheory-publish-config.sh"
+
+assert_file_contains "name: AppTheory TheoryCloud subtree publish"
+assert_file_contains "permissions:"
+assert_file_contains "  contents: read"
+assert_file_contains "  id-token: write"
+assert_file_contains "group: apptheory-theorycloud-subtree-publish-\${{ github.ref_name }}"
+assert_file_contains "THEORYCLOUD_STAGE: \${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}"
+assert_file_contains "AWS_ROLE_ARN: \${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}"
+assert_file_contains "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+assert_file_contains "uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4"
+assert_file_contains "bash scripts/verify-theorycloud-publish-workflow.sh"
+assert_file_contains "bash scripts/sync-theorycloud-apptheory-subtree.sh \\"
+assert_file_contains "bash scripts/trigger-theorycloud-publish.sh \\"
+
+branches_block="$(awk '
+  /^    branches:$/ {capture=1; next}
+  capture && /^[[:space:]]{4}[A-Za-z0-9_-]+:/ {exit}
+  capture && /^[^[:space:]]/ {exit}
+  capture {print}
+' "${WORKFLOW_FILE}")"
+assert_contains "${branches_block}" "- premain"
+assert_contains "${branches_block}" "- main"
+
+paths_block="$(awk '
+  /^    paths:$/ {capture=1; next}
+  capture && /^[^[:space:]]/ {exit}
+  capture {print}
+' "${WORKFLOW_FILE}")"
+
+for required_path in \
+  '"docs/README.md"' \
+  '"docs/_contract.yaml"' \
+  '"docs/_concepts.yaml"' \
+  '"docs/_patterns.yaml"' \
+  '"docs/_decisions.yaml"' \
+  '"docs/getting-started.md"' \
+  '"docs/api-reference.md"' \
+  '"docs/core-patterns.md"' \
+  '"docs/testing-guide.md"' \
+  '"docs/troubleshooting.md"' \
+  '"docs/migration-guide.md"' \
+  '"docs/cdk/**"' \
+  '"docs/features/**"' \
+  '"docs/integrations/**"' \
+  '"docs/migration/**"' \
+  '"docs/llm-faq/**"'
+do
+  assert_contains "${paths_block}" "${required_path}"
+done
+
+if grep -Eq 'scripts/|\.github/workflows/' <<<"${paths_block}"; then
+  fail "workflow paths must be limited to canonical docs changes"
+fi
+
+for disallowed_path in \
+  'docs/development/' \
+  'docs/planning/' \
+  'docs/internal/' \
+  'docs/archive/' \
+  'docs/development-guidelines.md'
+do
+  if grep -Fq "${disallowed_path}" <<<"${paths_block}"; then
+    fail "workflow paths unexpectedly include out-of-scope content: ${disallowed_path}"
+  fi
+done
+
+echo "verify-theorycloud-publish-workflow: PASS"


### PR DESCRIPTION
## Milestone
`apptheory-protected-publish` — Wire a dedicated workflow file trusted by IAM that runs on post-merge pushes to protected `premain` and `main`, only when canonical AppTheory docs change.

## Linear
- Project: https://linear.app/theorycloud/project/apptheory-theorycloud-subtree-publishing-1fae509c8f7f
- Issue: https://linear.app/theorycloud/issue/THE-115/add-dedicated-protected-branch-publish-workflow

## Tasks
- [x] Add dedicated protected-branch publish workflow

## Contract impact
internal-only

## Validation
Commands run on the final commit:
- `bash ./scripts/verify-theorycloud-publish-workflow.sh`
- `./scripts/verify-rubric.sh`
- `make rubric`

## Cross-repo notes
- KnowledgeTheory #12 owns the repo+stage OIDC roles and shared publish path contract this workflow targets.
