### PR TITLE
chore(ci): switch theorycloud publish to no-vars OIDC

### DIFF
--- a/.github/workflows/theorycloud-apptheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-apptheory-subtree-publish.yml
@@ -35,9 +35,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_REGION: us-east-1
       THEORYCLOUD_STAGE: ${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}
-      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}
+      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-AppTheory-lab-Publisher' || github.ref_name == 'main' && 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-AppTheory-live-Publisher' || '' }}
       THEORYCLOUD_PUBLISH_REASON: ${{ format('github:{0}:{1}', github.repository, github.ref_name) }}
     steps:
       - name: Checkout protected branch head
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          : "${AWS_REGION:?missing vars.AWS_REGION (or default)}"
+          : "${AWS_REGION:?missing literal AWS region}"
           : "${THEORYCLOUD_STAGE:?missing stage resolution}"
           : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN}"
 

--- a/scripts/trigger-theorycloud-publish.sh
+++ b/scripts/trigger-theorycloud-publish.sh
@@ -127,7 +127,7 @@ if [[ "${PUBLISH_DRY_RUN}" == "true" ]]; then
   fi
   echo "url=${PUBLISH_URL}"
   echo "payload=${PAYLOAD}"
-  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type:application/json --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type: application/json --fail-with-body -o <response-file> --data ${PAYLOAD} ${PUBLISH_URL}"
   echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
   exit 0
 fi
@@ -135,19 +135,18 @@ fi
 command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
 
 response_file="$(mktemp)"
-http_code="$(awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" -w '%{http_code}' "${PUBLISH_URL}")" || {
-  status=$?
-  rm -f "${response_file}"
-  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
-}
+trap 'rm -f "${response_file}"' EXIT
 
-if [[ ! "${http_code}" =~ ^2 ]]; then
-  body="$(cat "${response_file}")"
-  rm -f "${response_file}"
-  fail "publish returned HTTP ${http_code}: ${body}"
+if awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --fail-with-body --data "${PAYLOAD}" -o "${response_file}" "${PUBLISH_URL}"; then
+  :
+else
+  status=$?
+  body="$(cat "${response_file}" 2>/dev/null || true)"
+  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status}): ${body}"
 fi
 
 body="$(cat "${response_file}")"
-rm -f "${response_file}"
-echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL}; http=${http_code})"
+echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL})"
 printf '%s\n' "${body}"
+rm -f "${response_file}"
+trap - EXIT

--- a/scripts/verify-theorycloud-apptheory-publish-config.sh
+++ b/scripts/verify-theorycloud-apptheory-publish-config.sh
@@ -11,8 +11,24 @@ fail() {
 assert_contains() {
   local haystack="$1"
   local needle="$2"
-  if ! grep -Fq "${needle}" <<<"${haystack}"; then
+  if ! grep -Fq -- "${needle}" <<<"${haystack}"; then
     fail "expected to find '${needle}'"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if grep -Fq -- "${needle}" <<<"${haystack}"; then
+    fail "did not expect to find '${needle}'"
+  fi
+}
+
+assert_not_has_line() {
+  local haystack="$1"
+  local needle="$2"
+  if grep -Fxq -- "${needle}" <<<"${haystack}"; then
+    fail "did not expect to find line '${needle}'"
   fi
 }
 
@@ -52,11 +68,67 @@ assert_contains "${lab_publish_output}" 'stage=lab'
 assert_contains "${lab_publish_output}" 'branch=premain'
 assert_contains "${lab_publish_output}" 'url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
 assert_contains "${lab_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-lab","reason":"docs sync complete","force":false}'
+assert_contains "${lab_publish_output}" 'command=awscurl --service execute-api --region us-east-1 -X POST -H content-type: application/json --fail-with-body -o <response-file> --data'
+assert_not_contains "${lab_publish_output}" "-w '%{http_code}'"
 
 live_publish_output="$(THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live)"
 assert_contains "${live_publish_output}" 'stage=live'
 assert_contains "${live_publish_output}" 'branch=main'
 assert_contains "${live_publish_output}" 'url=https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
 assert_contains "${live_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-live","reason":"docs sync complete","force":false}'
+assert_contains "${live_publish_output}" 'command=awscurl --service execute-api --region us-east-1 -X POST -H content-type: application/json --fail-with-body -o <response-file> --data'
+assert_not_contains "${live_publish_output}" "-w '%{http_code}'"
+
+FAKE_AWSCURL_ARGS_LOG="${TMP_DIR}/awscurl-args.log"
+mkdir -p "${TMP_DIR}/bin"
+cat > "${TMP_DIR}/bin/awscurl" <<'EOF_AWSCURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args_log="${FAKE_AWSCURL_ARGS_LOG:?}"
+output_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      printf '%s\n' "$1" >> "${args_log}"
+      output_file="$2"
+      printf '%s\n' "${output_file}" >> "${args_log}"
+      shift 2
+      ;;
+    *)
+      printf '%s\n' "$1" >> "${args_log}"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${output_file}" ]]; then
+  echo "missing -o output file" >&2
+  exit 91
+fi
+
+printf '%s' '{"job_id":"fake-job","status":"enqueued"}' > "${output_file}"
+EOF_AWSCURL
+chmod +x "${TMP_DIR}/bin/awscurl"
+
+live_publish_exec_output="$(PATH="${TMP_DIR}/bin:${PATH}" FAKE_AWSCURL_ARGS_LOG="${FAKE_AWSCURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-exec)"
+live_publish_exec_args="$(cat "${FAKE_AWSCURL_ARGS_LOG}")"
+assert_contains "${live_publish_exec_output}" 'trigger-theorycloud-publish: PASS (url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud)'
+assert_contains "${live_publish_exec_output}" '{"job_id":"fake-job","status":"enqueued"}'
+assert_contains "${live_publish_exec_args}" '--service'
+assert_contains "${live_publish_exec_args}" 'execute-api'
+assert_contains "${live_publish_exec_args}" '--region'
+assert_contains "${live_publish_exec_args}" 'us-east-1'
+assert_contains "${live_publish_exec_args}" '-X'
+assert_contains "${live_publish_exec_args}" 'POST'
+assert_contains "${live_publish_exec_args}" '-H'
+assert_contains "${live_publish_exec_args}" 'content-type: application/json'
+assert_contains "${live_publish_exec_args}" '--fail-with-body'
+assert_contains "${live_publish_exec_args}" '-o'
+assert_contains "${live_publish_exec_args}" '--data'
+assert_contains "${live_publish_exec_args}" '{"source_revision":"abc123def456","idempotency_key":"test-exec","reason":"docs sync complete","force":false}'
+assert_contains "${live_publish_exec_args}" 'https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
+assert_not_has_line "${live_publish_exec_args}" "-w"
 
 echo 'verify-theorycloud-apptheory-publish-config: PASS'

--- a/scripts/verify-theorycloud-publish-workflow.sh
+++ b/scripts/verify-theorycloud-publish-workflow.sh
@@ -17,6 +17,13 @@ assert_file_contains() {
   fi
 }
 
+assert_file_not_contains() {
+  local needle="$1"
+  if grep -Fq -- "${needle}" "${WORKFLOW_FILE}"; then
+    fail "workflow must not contain '${needle}'"
+  fi
+}
+
 assert_contains() {
   local haystack="$1"
   local needle="$2"
@@ -45,13 +52,17 @@ assert_file_contains "permissions:"
 assert_file_contains "  contents: read"
 assert_file_contains "  id-token: write"
 assert_file_contains "group: apptheory-theorycloud-subtree-publish-\${{ github.ref_name }}"
+assert_file_contains "AWS_REGION: us-east-1"
 assert_file_contains "THEORYCLOUD_STAGE: \${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}"
-assert_file_contains "AWS_ROLE_ARN: \${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}"
+assert_file_contains "AWS_ROLE_ARN: \${{ github.ref_name == 'premain' && 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-AppTheory-lab-Publisher' || github.ref_name == 'main' && 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-AppTheory-live-Publisher' || '' }}"
 assert_file_contains "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
 assert_file_contains "uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4"
 assert_file_contains "bash scripts/verify-theorycloud-publish-workflow.sh"
 assert_file_contains "bash scripts/sync-theorycloud-apptheory-subtree.sh \\"
 assert_file_contains "bash scripts/trigger-theorycloud-publish.sh \\"
+assert_file_not_contains "vars.AWS_REGION"
+assert_file_not_contains "vars.THEORYCLOUD_AWS_ROLE_ARN_LAB"
+assert_file_not_contains "vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE"
 
 branches_block="$(awk '
   /^    branches:$/ {capture=1; next}


### PR DESCRIPTION
## Summary
- switch the TheoryCloud subtree publish workflow from repo vars to the settled no-vars OIDC contract
- pin the AppTheory lab/live publisher role ARNs directly in the workflow and make AWS region literal `us-east-1`
- update the workflow verifier so rubric now enforces the no-vars contract and rejects stale `vars.*` references

## Issue
- Refs #379

## Validation
- `bash scripts/verify-theorycloud-publish-workflow.sh`
- `scripts/verify-builds.sh`
- `make rubric`

## Notes
- There are currently no live runs of this workflow yet because it only exists on `staging` today and the trigger is intentionally limited to canonical docs changes on protected `premain` / `main`.
- The first real lab proof still requires promotion to `premain` plus a qualifying canonical docs change so the protected-branch push trigger can fire.
