### PR TITLE
fix(ci): trigger theorycloud publish for stack changes

### DIFF
--- a/.github/workflows/theorycloud-apptheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-apptheory-subtree-publish.yml
@@ -6,6 +6,7 @@ on:
       - premain
       - main
     paths:
+      - ".github/workflows/theorycloud-apptheory-subtree-publish.yml"
       - "docs/README.md"
       - "docs/_contract.yaml"
       - "docs/_concepts.yaml"
@@ -22,6 +23,12 @@ on:
       - "docs/integrations/**"
       - "docs/migration/**"
       - "docs/llm-faq/**"
+      - "scripts/stage-theorycloud-apptheory-subtree.sh"
+      - "scripts/theorycloud-apptheory-env.sh"
+      - "scripts/sync-theorycloud-apptheory-subtree.sh"
+      - "scripts/trigger-theorycloud-publish.sh"
+      - "scripts/verify-theorycloud-apptheory-publish-config.sh"
+      - "scripts/verify-theorycloud-publish-workflow.sh"
 
 permissions:
   contents: read

--- a/scripts/verify-theorycloud-publish-workflow.sh
+++ b/scripts/verify-theorycloud-publish-workflow.sh
@@ -80,6 +80,7 @@ paths_block="$(awk '
 ' "${WORKFLOW_FILE}")"
 
 for required_path in \
+  '".github/workflows/theorycloud-apptheory-subtree-publish.yml"' \
   '"docs/README.md"' \
   '"docs/_contract.yaml"' \
   '"docs/_concepts.yaml"' \
@@ -95,14 +96,16 @@ for required_path in \
   '"docs/features/**"' \
   '"docs/integrations/**"' \
   '"docs/migration/**"' \
-  '"docs/llm-faq/**"'
+  '"docs/llm-faq/**"' \
+  '"scripts/stage-theorycloud-apptheory-subtree.sh"' \
+  '"scripts/theorycloud-apptheory-env.sh"' \
+  '"scripts/sync-theorycloud-apptheory-subtree.sh"' \
+  '"scripts/trigger-theorycloud-publish.sh"' \
+  '"scripts/verify-theorycloud-apptheory-publish-config.sh"' \
+  '"scripts/verify-theorycloud-publish-workflow.sh"'
 do
   assert_contains "${paths_block}" "${required_path}"
 done
-
-if grep -Eq 'scripts/|\.github/workflows/' <<<"${paths_block}"; then
-  fail "workflow paths must be limited to canonical docs changes"
-fi
 
 for disallowed_path in \
   'docs/development/' \


### PR DESCRIPTION
## Summary
- expand the protected-branch TheoryCloud publish workflow trigger to include the publish stack itself
- keep the canonical docs trigger surface intact instead of broadening to every premain/main push
- update the workflow verifier so it enforces the expanded trigger contract

## Why
The current workflow only triggered on canonical docs paths. That let PR #385 merge a real TheoryCloud publish-stack repair into `premain` without ever queuing `AppTheory TheoryCloud subtree publish`, because the merge changed `scripts/verify-theorycloud-apptheory-publish-config.sh` and `.gitignore`, not canonical docs.

This patch makes publish-stack repairs trigger the same protected-branch workflow while still avoiding unrelated release-please-only merges.

## Validation
- `bash scripts/verify-theorycloud-publish-workflow.sh`
- `scripts/verify-builds.sh`
- `make rubric`

Refs #385
