### PR TITLE
Merge staging into premain

### DIFF
--- a/.github/workflows/theorycloud-apptheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-apptheory-subtree-publish.yml
@@ -6,6 +6,7 @@ on:
       - premain
       - main
     paths:
+      - ".github/workflows/theorycloud-apptheory-subtree-publish.yml"
       - "docs/README.md"
       - "docs/_contract.yaml"
       - "docs/_concepts.yaml"
@@ -22,6 +23,12 @@ on:
       - "docs/integrations/**"
       - "docs/migration/**"
       - "docs/llm-faq/**"
+      - "scripts/stage-theorycloud-apptheory-subtree.sh"
+      - "scripts/theorycloud-apptheory-env.sh"
+      - "scripts/sync-theorycloud-apptheory-subtree.sh"
+      - "scripts/trigger-theorycloud-publish.sh"
+      - "scripts/verify-theorycloud-apptheory-publish-config.sh"
+      - "scripts/verify-theorycloud-publish-workflow.sh"
 
 permissions:
   contents: read

--- a/scripts/verify-theorycloud-publish-workflow.sh
+++ b/scripts/verify-theorycloud-publish-workflow.sh
@@ -80,6 +80,7 @@ paths_block="$(awk '
 ' "${WORKFLOW_FILE}")"
 
 for required_path in \
+  '".github/workflows/theorycloud-apptheory-subtree-publish.yml"' \
   '"docs/README.md"' \
   '"docs/_contract.yaml"' \
   '"docs/_concepts.yaml"' \
@@ -95,14 +96,16 @@ for required_path in \
   '"docs/features/**"' \
   '"docs/integrations/**"' \
   '"docs/migration/**"' \
-  '"docs/llm-faq/**"'
+  '"docs/llm-faq/**"' \
+  '"scripts/stage-theorycloud-apptheory-subtree.sh"' \
+  '"scripts/theorycloud-apptheory-env.sh"' \
+  '"scripts/sync-theorycloud-apptheory-subtree.sh"' \
+  '"scripts/trigger-theorycloud-publish.sh"' \
+  '"scripts/verify-theorycloud-apptheory-publish-config.sh"' \
+  '"scripts/verify-theorycloud-publish-workflow.sh"'
 do
   assert_contains "${paths_block}" "${required_path}"
 done
-
-if grep -Eq 'scripts/|\.github/workflows/' <<<"${paths_block}"; then
-  fail "workflow paths must be limited to canonical docs changes"
-fi
 
 for disallowed_path in \
   'docs/development/' \


### PR DESCRIPTION
## Summary
Promote the current `staging` branch into `premain`.

This promotion includes the latest staging fixes since #385, including the TheoryCloud publish trigger repair from #388 so protected-branch merges that change the publish stack now queue `AppTheory TheoryCloud subtree publish`.

## Validation
Protected-branch CI will run on this promotion PR.
