### PR TITLE
fix(runtime): canonicalize remote mcp apigw trailing slashes

### DIFF
--- a/contract-tests/fixtures/m3/apigw-proxy-preserves-proxy-trailing-slash-capture.json
+++ b/contract-tests/fixtures/m3/apigw-proxy-preserves-proxy-trailing-slash-capture.json
@@ -1,0 +1,39 @@
+{
+  "id": "m3.apigw_proxy.preserve_proxy_trailing_slash_capture",
+  "tier": "m3",
+  "name": "APIGW REST API v1: {proxy+} preserves a terminal slash in the captured value",
+  "setup": {
+    "routes": [{ "method": "GET", "path": "/files/{path+}", "handler": "echo_path_params" }]
+  },
+  "input": {
+    "aws_event": {
+      "source": "apigw_proxy",
+      "event": {
+        "resource": "/files/{path+}",
+        "path": "/files/a/b/",
+        "httpMethod": "GET",
+        "headers": {},
+        "multiValueHeaders": {},
+        "queryStringParameters": {},
+        "multiValueQueryStringParameters": {},
+        "requestContext": {
+          "requestId": "req-1",
+          "resourcePath": "/files/{path+}",
+          "path": "/files/a/b/",
+          "httpMethod": "GET"
+        },
+        "body": "",
+        "isBase64Encoded": false
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": { "params": { "path": "a/b/" } },
+      "is_base64": false
+    }
+  }
+}

--- a/contract-tests/fixtures/m3/apigw-proxy-remote-mcp-actor-trailing-slash.json
+++ b/contract-tests/fixtures/m3/apigw-proxy-remote-mcp-actor-trailing-slash.json
@@ -1,0 +1,39 @@
+{
+  "id": "m3.apigw_proxy.remote_mcp_actor_trailing_slash",
+  "tier": "m3",
+  "name": "APIGW REST API v1: /mcp/{actor} and /mcp/{actor}/ are equivalent on the Remote MCP adapter path",
+  "setup": {
+    "routes": [{ "method": "GET", "path": "/mcp/{actor}", "handler": "echo_path_params" }]
+  },
+  "input": {
+    "aws_event": {
+      "source": "apigw_proxy",
+      "event": {
+        "resource": "/mcp/{actor}",
+        "path": "/mcp/agent1/",
+        "httpMethod": "GET",
+        "headers": {},
+        "multiValueHeaders": {},
+        "queryStringParameters": {},
+        "multiValueQueryStringParameters": {},
+        "requestContext": {
+          "requestId": "req-1",
+          "resourcePath": "/mcp/{actor}",
+          "path": "/mcp/agent1/",
+          "httpMethod": "GET"
+        },
+        "body": "",
+        "isBase64Encoded": false
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": { "params": { "actor": "agent1" } },
+      "is_base64": false
+    }
+  }
+}

--- a/contract-tests/fixtures/m3/apigw-proxy-remote-mcp-root-trailing-slash.json
+++ b/contract-tests/fixtures/m3/apigw-proxy-remote-mcp-root-trailing-slash.json
@@ -1,0 +1,47 @@
+{
+  "id": "m3.apigw_proxy.remote_mcp_root_trailing_slash",
+  "tier": "m3",
+  "name": "APIGW REST API v1: /mcp and /mcp/ are equivalent on the Remote MCP adapter path",
+  "setup": {
+    "routes": [{ "method": "GET", "path": "/mcp", "handler": "echo_request" }]
+  },
+  "input": {
+    "aws_event": {
+      "source": "apigw_proxy",
+      "event": {
+        "resource": "/mcp",
+        "path": "/mcp/",
+        "httpMethod": "GET",
+        "headers": {},
+        "multiValueHeaders": {},
+        "queryStringParameters": {},
+        "multiValueQueryStringParameters": {},
+        "requestContext": {
+          "requestId": "req-1",
+          "resourcePath": "/mcp",
+          "path": "/mcp/",
+          "httpMethod": "GET"
+        },
+        "body": "",
+        "isBase64Encoded": false
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": {
+        "method": "GET",
+        "path": "/mcp",
+        "query": {},
+        "headers": {},
+        "cookies": {},
+        "body_b64": "",
+        "is_base64": false
+      },
+      "is_base64": false
+    }
+  }
+}

--- a/contract-tests/fixtures/m3/apigw-proxy-remote-protected-resource-actor-trailing-slash.json
+++ b/contract-tests/fixtures/m3/apigw-proxy-remote-protected-resource-actor-trailing-slash.json
@@ -1,0 +1,45 @@
+{
+  "id": "m3.apigw_proxy.remote_protected_resource_actor_trailing_slash",
+  "tier": "m3",
+  "name": "APIGW REST API v1: protected resource /mcp/{actor} and /mcp/{actor}/ are equivalent on the Remote MCP adapter path",
+  "setup": {
+    "routes": [
+      {
+        "method": "GET",
+        "path": "/.well-known/oauth-protected-resource/mcp/{actor}",
+        "handler": "echo_path_params"
+      }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "apigw_proxy",
+      "event": {
+        "resource": "/.well-known/oauth-protected-resource/mcp/{actor}",
+        "path": "/.well-known/oauth-protected-resource/mcp/agent1/",
+        "httpMethod": "GET",
+        "headers": {},
+        "multiValueHeaders": {},
+        "queryStringParameters": {},
+        "multiValueQueryStringParameters": {},
+        "requestContext": {
+          "requestId": "req-1",
+          "resourcePath": "/.well-known/oauth-protected-resource/mcp/{actor}",
+          "path": "/.well-known/oauth-protected-resource/mcp/agent1/",
+          "httpMethod": "GET"
+        },
+        "body": "",
+        "isBase64Encoded": false
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": { "params": { "actor": "agent1" } },
+      "is_base64": false
+    }
+  }
+}

--- a/contract-tests/fixtures/m3/apigw-proxy-remote-protected-resource-root-trailing-slash.json
+++ b/contract-tests/fixtures/m3/apigw-proxy-remote-protected-resource-root-trailing-slash.json
@@ -1,0 +1,53 @@
+{
+  "id": "m3.apigw_proxy.remote_protected_resource_root_trailing_slash",
+  "tier": "m3",
+  "name": "APIGW REST API v1: protected resource /mcp and /mcp/ are equivalent on the Remote MCP adapter path",
+  "setup": {
+    "routes": [
+      {
+        "method": "GET",
+        "path": "/.well-known/oauth-protected-resource/mcp",
+        "handler": "echo_request"
+      }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "apigw_proxy",
+      "event": {
+        "resource": "/.well-known/oauth-protected-resource/mcp",
+        "path": "/.well-known/oauth-protected-resource/mcp/",
+        "httpMethod": "GET",
+        "headers": {},
+        "multiValueHeaders": {},
+        "queryStringParameters": {},
+        "multiValueQueryStringParameters": {},
+        "requestContext": {
+          "requestId": "req-1",
+          "resourcePath": "/.well-known/oauth-protected-resource/mcp",
+          "path": "/.well-known/oauth-protected-resource/mcp/",
+          "httpMethod": "GET"
+        },
+        "body": "",
+        "isBase64Encoded": false
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": {
+        "method": "GET",
+        "path": "/.well-known/oauth-protected-resource/mcp",
+        "query": {},
+        "headers": {},
+        "cookies": {},
+        "body_b64": "",
+        "is_base64": false
+      },
+      "is_base64": false
+    }
+  }
+}

--- a/py/src/apptheory/aws_http.py
+++ b/py/src/apptheory/aws_http.py
@@ -10,6 +10,15 @@ from apptheory.request import Request
 from apptheory.response import Response
 from apptheory.util import normalize_path, to_bytes
 
+_REMOTE_MCP_APIGW_CANONICAL_RESOURCES = frozenset(
+    {
+        "/mcp",
+        "/mcp/{actor}",
+        "/.well-known/oauth-protected-resource/mcp",
+        "/.well-known/oauth-protected-resource/mcp/{actor}",
+    }
+)
+
 
 def request_from_apigw_v2(event: dict[str, Any]) -> Request:
     return _request_from_http_event(event)
@@ -32,7 +41,7 @@ def request_from_apigw_proxy(event: dict[str, Any]) -> Request:
 
     return Request(
         method=str(event.get("httpMethod") or request_context.get("httpMethod") or ""),
-        path=str(event.get("path") or request_context.get("path") or "/"),
+        path=_apigw_proxy_request_path(event, request_context),
         query=query,
         headers=headers,
         body=str(event.get("body") or ""),
@@ -369,6 +378,47 @@ def _query_from_proxy(
             continue
         out[str(key)] = [str(value)]
     return out
+
+
+def _apigw_proxy_request_path(event: dict[str, Any], request_context: dict[str, Any]) -> str:
+    path = str(event.get("path") or request_context.get("path") or "/")
+    if not _should_canonicalize_apigw_proxy_request_path(event, request_context):
+        return path
+    return _canonicalize_apigw_proxy_request_path(path)
+
+
+def _should_canonicalize_apigw_proxy_request_path(event: dict[str, Any], request_context: dict[str, Any]) -> bool:
+    return _apigw_proxy_matched_resource(event, request_context) in _REMOTE_MCP_APIGW_CANONICAL_RESOURCES
+
+
+def _apigw_proxy_matched_resource(event: dict[str, Any], request_context: dict[str, Any]) -> str:
+    resource = _normalize_apigw_proxy_route_path(event.get("resource"))
+    if resource != "/":
+        return resource
+
+    request_context_resource = _normalize_apigw_proxy_route_path(request_context.get("resourcePath"))
+    if request_context_resource != "/":
+        return request_context_resource
+
+    return ""
+
+
+def _normalize_apigw_proxy_route_path(path: Any) -> str:
+    trimmed = str(path or "").strip().strip("/")
+    if not trimmed:
+        return "/"
+
+    parts = [part.strip() for part in trimmed.split("/") if part.strip()]
+    if not parts:
+        return "/"
+    return "/" + "/".join(parts)
+
+
+def _canonicalize_apigw_proxy_request_path(path: str) -> str:
+    normalized = normalize_path(path)
+    if normalized == "/":
+        return normalized
+    return normalized.rstrip("/") or "/"
 
 
 def _parse_raw_query_string(raw: str) -> dict[str, list[str]]:

--- a/py/tests/test_aws_http.py
+++ b/py/tests/test_aws_http.py
@@ -97,6 +97,99 @@ class TestAwsHttp(unittest.TestCase):
         self.assertEqual(alb_req.headers["x"], ["override"])
         self.assertEqual(alb_req.headers["y"], ["2", "3"])
 
+    def test_request_from_proxy_canonicalizes_remote_mcp_trailing_slash_only(self) -> None:
+        cases = [
+            {
+                "name": "mcp root",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/mcp/",
+                    "resource": "/mcp",
+                    "requestContext": {"httpMethod": "GET", "path": "/mcp/"},
+                },
+                "want": "/mcp",
+            },
+            {
+                "name": "mcp actor",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/mcp/agent1/",
+                    "resource": "/mcp/{actor}",
+                    "requestContext": {"httpMethod": "GET", "path": "/mcp/agent1/"},
+                },
+                "want": "/mcp/agent1",
+            },
+            {
+                "name": "protected resource root via request context",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/.well-known/oauth-protected-resource/mcp/",
+                    "requestContext": {
+                        "httpMethod": "GET",
+                        "path": "/.well-known/oauth-protected-resource/mcp/",
+                        "resourcePath": "/.well-known/oauth-protected-resource/mcp",
+                    },
+                },
+                "want": "/.well-known/oauth-protected-resource/mcp",
+            },
+            {
+                "name": "protected resource actor",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/.well-known/oauth-protected-resource/mcp/agent1/",
+                    "resource": "/.well-known/oauth-protected-resource/mcp/{actor}",
+                    "requestContext": {
+                        "httpMethod": "GET",
+                        "path": "/.well-known/oauth-protected-resource/mcp/agent1/",
+                    },
+                },
+                "want": "/.well-known/oauth-protected-resource/mcp/agent1",
+            },
+            {
+                "name": "proxy route preserved",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/files/a/b/",
+                    "resource": "/files/{path+}",
+                    "requestContext": {"httpMethod": "GET", "path": "/files/a/b/"},
+                },
+                "want": "/files/a/b/",
+            },
+            {
+                "name": "unscoped route preserved",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/users/123/",
+                    "resource": "/users/{id}",
+                    "requestContext": {"httpMethod": "GET", "path": "/users/123/"},
+                },
+                "want": "/users/123/",
+            },
+            {
+                "name": "missing matched resource preserved",
+                "event": {
+                    "httpMethod": "GET",
+                    "path": "/mcp/",
+                    "requestContext": {"httpMethod": "GET", "path": "/mcp/"},
+                },
+                "want": "/mcp/",
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                event = {
+                    "headers": {},
+                    "multiValueHeaders": {},
+                    "queryStringParameters": {},
+                    "multiValueQueryStringParameters": {},
+                    "body": "",
+                    "isBase64Encoded": False,
+                    **case["event"],
+                }
+                req = request_from_apigw_proxy(event)
+                self.assertEqual(req.path, case["want"])
+
     def test_response_converters_preserve_headers_and_cookies(self) -> None:
         resp = Response(
             status=200,
@@ -132,4 +225,3 @@ class TestAwsHttp(unittest.TestCase):
         out = apigw_v2_response_from_response(b64)
         self.assertTrue(out["isBase64Encoded"])
         self.assertEqual(out["body"], base64.b64encode(b"\x00\xff").decode("ascii"))
-

--- a/runtime/aws_apigw_proxy.go
+++ b/runtime/aws_apigw_proxy.go
@@ -43,10 +43,7 @@ func (a *App) serveAPIGatewayProxyLambda(ctx context.Context, event events.APIGa
 }
 
 func requestFromAPIGatewayProxy(event events.APIGatewayProxyRequest) (Request, error) {
-	path := event.Path
-	if path == "" {
-		path = event.RequestContext.Path
-	}
+	path := apigatewayProxyRequestPath(event)
 
 	method := event.HTTPMethod
 	if method == "" {
@@ -61,6 +58,37 @@ func requestFromAPIGatewayProxy(event events.APIGatewayProxyRequest) (Request, e
 		Body:     []byte(event.Body),
 		IsBase64: event.IsBase64Encoded,
 	}, nil
+}
+
+func apigatewayProxyRequestPath(event events.APIGatewayProxyRequest) string {
+	path := event.Path
+	if path == "" {
+		path = event.RequestContext.Path
+	}
+	if !shouldCanonicalizeAPIGatewayProxyRequestPath(event) {
+		return path
+	}
+	return canonicalizeAPIGatewayProxyRequestPath(path)
+}
+
+func shouldCanonicalizeAPIGatewayProxyRequestPath(event events.APIGatewayProxyRequest) bool {
+	switch apigatewayProxyMatchedResource(event) {
+	case "/mcp",
+		"/mcp/{actor}",
+		"/.well-known/oauth-protected-resource/mcp",
+		"/.well-known/oauth-protected-resource/mcp/{actor}":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalizeAPIGatewayProxyRequestPath(path string) string {
+	normalized := normalizePath(path)
+	if normalized == "/" {
+		return normalized
+	}
+	return strings.TrimRight(normalized, "/")
 }
 
 func isTextEventStream(headers map[string][]string) bool {
@@ -103,13 +131,20 @@ func apigatewayProxyRouteMethod(event events.APIGatewayProxyRequest) string {
 }
 
 func apigatewayProxyRouteResource(event events.APIGatewayProxyRequest) string {
-	if resource := normalizeAPIGatewayProxyRoutePath(event.Resource); resource != "" {
-		return resource
-	}
-	if resource := normalizeAPIGatewayProxyRoutePath(event.RequestContext.ResourcePath); resource != "" {
+	if resource := apigatewayProxyMatchedResource(event); resource != "" {
 		return resource
 	}
 	return normalizeAPIGatewayProxyRoutePath(event.Path)
+}
+
+func apigatewayProxyMatchedResource(event events.APIGatewayProxyRequest) string {
+	if resource := normalizeAPIGatewayProxyRoutePath(event.Resource); resource != "/" {
+		return resource
+	}
+	if resource := normalizeAPIGatewayProxyRoutePath(event.RequestContext.ResourcePath); resource != "/" {
+		return resource
+	}
+	return ""
 }
 
 func normalizeAPIGatewayProxyRoutePath(path string) string {

--- a/runtime/aws_apigw_proxy_test.go
+++ b/runtime/aws_apigw_proxy_test.go
@@ -31,6 +31,114 @@ func TestRequestFromAPIGatewayProxy_UsesFallbacks(t *testing.T) {
 	}
 }
 
+func TestRequestFromAPIGatewayProxy_CanonicalizesRemoteMCPRouteFamilyTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		resource     string
+		resourcePath string
+		path         string
+		expectedPath string
+	}{
+		{
+			name:         "mcp root",
+			resource:     "/mcp",
+			path:         "/mcp/",
+			expectedPath: "/mcp",
+		},
+		{
+			name:         "mcp actor",
+			resource:     "/mcp/{actor}",
+			path:         "/mcp/agent1/",
+			expectedPath: "/mcp/agent1",
+		},
+		{
+			name:         "protected resource root via request context",
+			resourcePath: "/.well-known/oauth-protected-resource/mcp",
+			path:         "/.well-known/oauth-protected-resource/mcp/",
+			expectedPath: "/.well-known/oauth-protected-resource/mcp",
+		},
+		{
+			name:         "protected resource actor",
+			resource:     "/.well-known/oauth-protected-resource/mcp/{actor}",
+			path:         "/.well-known/oauth-protected-resource/mcp/agent1/",
+			expectedPath: "/.well-known/oauth-protected-resource/mcp/agent1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := requestFromAPIGatewayProxy(events.APIGatewayProxyRequest{
+				Resource:   tc.resource,
+				Path:       tc.path,
+				HTTPMethod: "GET",
+				RequestContext: events.APIGatewayProxyRequestContext{
+					ResourcePath: tc.resourcePath,
+					Path:         tc.path,
+					HTTPMethod:   "GET",
+				},
+			})
+			if err != nil {
+				t.Fatalf("requestFromAPIGatewayProxy returned error: %v", err)
+			}
+			if req.Path != tc.expectedPath {
+				t.Fatalf("path = %q, want %q", req.Path, tc.expectedPath)
+			}
+		})
+	}
+}
+
+func TestRequestFromAPIGatewayProxy_PreservesTrailingSlashOutsideScopedRemoteMCPRoutes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		resource string
+		path     string
+	}{
+		{
+			name:     "proxy route",
+			resource: "/files/{path+}",
+			path:     "/files/a/b/",
+		},
+		{
+			name:     "other param route",
+			resource: "/users/{id}",
+			path:     "/users/123/",
+		},
+		{
+			name:     "missing matched resource",
+			resource: "",
+			path:     "/mcp/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := requestFromAPIGatewayProxy(events.APIGatewayProxyRequest{
+				Resource:   tc.resource,
+				Path:       tc.path,
+				HTTPMethod: "GET",
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Path:       tc.path,
+					HTTPMethod: "GET",
+				},
+			})
+			if err != nil {
+				t.Fatalf("requestFromAPIGatewayProxy returned error: %v", err)
+			}
+			if req.Path != tc.path {
+				t.Fatalf("path = %q, want %q", req.Path, tc.path)
+			}
+		})
+	}
+}
+
 func TestIsTextEventStream(t *testing.T) {
 	if !isTextEventStream(map[string][]string{"content-type": {"text/event-stream; charset=utf-8"}}) {
 		t.Fatal("expected text/event-stream content type to be detected")

--- a/ts/dist/internal/aws-http.js
+++ b/ts/dist/internal/aws-http.js
@@ -1,5 +1,5 @@
 import { STATUS_CODES } from "node:http";
-import { headersFromSingle, parseRawQueryString, queryFromSingle, toBuffer, } from "./http.js";
+import { headersFromSingle, normalizePath, parseRawQueryString, queryFromSingle, toBuffer, } from "./http.js";
 import { normalizeRequest } from "./request.js";
 import { normalizeResponse } from "./response.js";
 export function requestFromWebSocketEvent(event) {
@@ -30,7 +30,7 @@ export function requestFromWebSocketEvent(event) {
         isBase64: Boolean(event.isBase64Encoded),
     });
 }
-function requestFromAPIGatewayProxyLike(event) {
+function requestFromAPIGatewayProxyLike(event, pathOverride) {
     const headers = {};
     for (const [key, values] of Object.entries(event.multiValueHeaders ?? {})) {
         headers[key] = Array.isArray(values) ? values.map((v) => String(v)) : [];
@@ -56,15 +56,61 @@ function requestFromAPIGatewayProxyLike(event) {
     const rcPath = rc && typeof rc["path"] === "string" ? String(rc["path"]) : "/";
     return {
         method: String(event.httpMethod ?? rcMethod ?? ""),
-        path: String(event.path ?? rcPath ?? "/"),
+        path: String(pathOverride ?? event.path ?? rcPath ?? "/"),
         query,
         headers,
         body: toBuffer(String(event.body ?? "")),
         isBase64: Boolean(event.isBase64Encoded),
     };
 }
+const REMOTE_MCP_APIGW_CANONICAL_RESOURCES = new Set([
+    "/mcp",
+    "/mcp/{actor}",
+    "/.well-known/oauth-protected-resource/mcp",
+    "/.well-known/oauth-protected-resource/mcp/{actor}",
+]);
+function normalizeAPIGatewayProxyRoutePath(path) {
+    const trimmed = String(path ?? "")
+        .trim()
+        .replace(/^\/+|\/+$/g, "");
+    if (!trimmed)
+        return "/";
+    const parts = trimmed
+        .split("/")
+        .map((part) => part.trim())
+        .filter((part) => part);
+    if (parts.length === 0)
+        return "/";
+    return `/${parts.join("/")}`;
+}
+function apigatewayProxyMatchedResource(event) {
+    const resource = normalizeAPIGatewayProxyRoutePath(event.resource);
+    if (resource !== "/")
+        return resource;
+    const rc = event.requestContext && typeof event.requestContext === "object"
+        ? event.requestContext
+        : null;
+    const rcResource = rc && typeof rc["resourcePath"] === "string"
+        ? normalizeAPIGatewayProxyRoutePath(rc["resourcePath"])
+        : "";
+    return rcResource === "/" ? "" : rcResource;
+}
+function shouldCanonicalizeAPIGatewayProxyRequestPath(event) {
+    return REMOTE_MCP_APIGW_CANONICAL_RESOURCES.has(apigatewayProxyMatchedResource(event));
+}
+function canonicalizeAPIGatewayProxyRequestPath(path) {
+    const normalized = normalizePath(path);
+    if (normalized === "/")
+        return normalized;
+    return normalized.replace(/\/+$/, "") || "/";
+}
 export function requestFromAPIGatewayProxy(event) {
-    return requestFromAPIGatewayProxyLike(event);
+    const path = shouldCanonicalizeAPIGatewayProxyRequestPath(event)
+        ? canonicalizeAPIGatewayProxyRequestPath(event.path ??
+            event.requestContext?.["path"] ??
+            "/")
+        : undefined;
+    return requestFromAPIGatewayProxyLike(event, path);
 }
 export function requestFromALBTargetGroup(event) {
     return requestFromAPIGatewayProxyLike(event);

--- a/ts/src/internal/aws-http.ts
+++ b/ts/src/internal/aws-http.ts
@@ -15,6 +15,7 @@ import type { Headers, Query, Request, Response } from "../types.js";
 
 import {
   headersFromSingle,
+  normalizePath,
   parseRawQueryString,
   queryFromSingle,
   toBuffer,
@@ -59,6 +60,7 @@ export function requestFromWebSocketEvent(
 
 function requestFromAPIGatewayProxyLike(
   event: APIGatewayProxyRequest,
+  pathOverride?: string,
 ): Request {
   const headers: Headers = {};
   for (const [key, values] of Object.entries(event.multiValueHeaders ?? {})) {
@@ -93,7 +95,7 @@ function requestFromAPIGatewayProxyLike(
 
   return {
     method: String(event.httpMethod ?? rcMethod ?? ""),
-    path: String(event.path ?? rcPath ?? "/"),
+    path: String(pathOverride ?? event.path ?? rcPath ?? "/"),
     query,
     headers,
     body: toBuffer(String(event.body ?? "")),
@@ -101,10 +103,69 @@ function requestFromAPIGatewayProxyLike(
   };
 }
 
+const REMOTE_MCP_APIGW_CANONICAL_RESOURCES = new Set<string>([
+  "/mcp",
+  "/mcp/{actor}",
+  "/.well-known/oauth-protected-resource/mcp",
+  "/.well-known/oauth-protected-resource/mcp/{actor}",
+]);
+
+function normalizeAPIGatewayProxyRoutePath(path: unknown): string {
+  const trimmed = String(path ?? "")
+    .trim()
+    .replace(/^\/+|\/+$/g, "");
+  if (!trimmed) return "/";
+
+  const parts = trimmed
+    .split("/")
+    .map((part) => part.trim())
+    .filter((part) => part);
+  if (parts.length === 0) return "/";
+  return `/${parts.join("/")}`;
+}
+
+function apigatewayProxyMatchedResource(event: APIGatewayProxyRequest): string {
+  const resource = normalizeAPIGatewayProxyRoutePath(event.resource);
+  if (resource !== "/") return resource;
+
+  const rc =
+    event.requestContext && typeof event.requestContext === "object"
+      ? (event.requestContext as Record<string, unknown>)
+      : null;
+  const rcResource =
+    rc && typeof rc["resourcePath"] === "string"
+      ? normalizeAPIGatewayProxyRoutePath(rc["resourcePath"])
+      : "";
+  return rcResource === "/" ? "" : rcResource;
+}
+
+function shouldCanonicalizeAPIGatewayProxyRequestPath(
+  event: APIGatewayProxyRequest,
+): boolean {
+  return REMOTE_MCP_APIGW_CANONICAL_RESOURCES.has(
+    apigatewayProxyMatchedResource(event),
+  );
+}
+
+function canonicalizeAPIGatewayProxyRequestPath(path: unknown): string {
+  const normalized = normalizePath(path);
+  if (normalized === "/") return normalized;
+  return normalized.replace(/\/+$/, "") || "/";
+}
+
 export function requestFromAPIGatewayProxy(
   event: APIGatewayProxyRequest,
 ): Request {
-  return requestFromAPIGatewayProxyLike(event);
+  const path = shouldCanonicalizeAPIGatewayProxyRequestPath(event)
+    ? canonicalizeAPIGatewayProxyRequestPath(
+        event.path ??
+          (event.requestContext as Record<string, unknown> | undefined)?.[
+            "path"
+          ] ??
+          "/",
+      )
+    : undefined;
+  return requestFromAPIGatewayProxyLike(event, path);
 }
 
 export function requestFromALBTargetGroup(


### PR DESCRIPTION
## Milestone
apigw-slash-contract — Remote MCP API Gateway trailing-slash parity across fixtures and runtimes

## Linear
Remote MCP edge hardening / apigw-slash-contract
- THE-270 — https://linear.app/theorycloud/issue/THE-270/implement-remote-mcp-api-gateway-trailing-slash-parity-across-fixtures

## Tasks
- [x] THE-270 — Implement Remote MCP API Gateway trailing-slash parity across fixtures and runtimes

## Contract impact
Fixture-first, bundled with parity implementation in the same green execution unit.

## Validation
Commands run on the final commit:
- `make rubric`
- `./scripts/verify-contract-tests.sh`
- `./scripts/verify-version-alignment.sh`
- `go test ./runtime/...`
- `cd ts && npm run check && npm run build`
- `python3 -m unittest discover -s py/tests`

## Cross-repo notes
None.
