### PR TITLE
feat(mcp): add initial listener budget options

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1893,6 +1893,11 @@ type Icon struct {
 	Theme    string   `json:"theme,omitempty"`
 }
 
+type InitialSessionListenerBudgetOptions struct {
+	SafetyBuffer time.Duration
+	MaxDuration  time.Duration
+}
+
 type MemorySessionStore struct {
 	mu    sync.RWMutex
 	store map[string]*Session
@@ -2002,6 +2007,8 @@ type Server struct {
 	idGen            apptheory.IDGenerator
 	logger           *slog.Logger
 	originValidator  OriginValidator
+
+	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
 
 type ServerOption func(*Server)
@@ -2107,6 +2114,8 @@ func ParseRequest([]byte) (*Request, error)
 func ParseResponse([]byte) (*Response, error)
 
 func WithClock(apptheory.Clock) MemorySessionStoreOption
+
+func WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions) ServerOption
 
 func WithLogger(*slog.Logger) ServerOption
 

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -47,6 +47,11 @@ const (
 	sessionInitializedValue  = "true"
 )
 
+const (
+	defaultInitialSessionListenerSafetyBuffer = 5 * time.Second
+	defaultInitialSessionListenerMaxDuration  = 25 * time.Second
+)
+
 // Server is the MCP protocol handler. It dispatches JSON-RPC 2.0 messages
 // to the appropriate MCP method handlers (initialize, tools/list, tools/call).
 type Server struct {
@@ -60,10 +65,32 @@ type Server struct {
 	idGen            apptheory.IDGenerator
 	logger           *slog.Logger
 	originValidator  OriginValidator
+
+	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
 
 // ServerOption configures a Server.
 type ServerOption func(*Server)
+
+// InitialSessionListenerBudgetOptions configures how the initial GET /mcp
+// session listener is capped against the Lambda remaining-time budget.
+//
+// The option is explicit opt-in and applies only when GET /mcp is used without
+// Last-Event-ID (the keepalive listener path). Resume/replay GET requests keep
+// their existing behavior.
+//
+// Zero values use the framework defaults:
+//   - SafetyBuffer: 5s
+//   - MaxDuration: 25s
+type InitialSessionListenerBudgetOptions struct {
+	SafetyBuffer time.Duration
+	MaxDuration  time.Duration
+}
+
+type initialSessionListenerBudgetConfig struct {
+	safetyBuffer time.Duration
+	maxDuration  time.Duration
+}
 
 // WithSessionStore sets the session store for the server.
 func WithSessionStore(store SessionStore) ServerOption {
@@ -100,6 +127,19 @@ func WithLogger(logger *slog.Logger) ServerOption {
 func WithOriginValidator(v OriginValidator) ServerOption {
 	return func(s *Server) {
 		s.originValidator = v
+	}
+}
+
+// WithInitialSessionListenerBudget caps the initial GET /mcp keepalive listener
+// against the Lambda remaining-time budget when RemainingMS is available.
+//
+// This option is explicit opt-in and applies only to GET /mcp requests without
+// Last-Event-ID. Resume/replay requests continue to use the existing stream
+// replay path unchanged.
+func WithInitialSessionListenerBudget(opts InitialSessionListenerBudgetOptions) ServerOption {
+	cfg := normalizeInitialSessionListenerBudgetOptions(opts)
+	return func(s *Server) {
+		s.initialSessionListenerBudget = &cfg
 	}
 }
 
@@ -276,7 +316,7 @@ func (s *Server) handleGET(c *apptheory.Context) (*apptheory.Response, error) {
 	if lastEventID == "" {
 		// No resumable stream requested. Keep the connection open as a session-level
 		// SSE listener (clients will reconnect in a tight loop if we return EOF).
-		return s.openSessionListener(ctx, sessionID)
+		return s.openSessionListener(ctx, sessionID, c.RemainingMS)
 	}
 
 	streamID, err := s.streamStore.StreamForEvent(ctx, sessionID, lastEventID)
@@ -300,19 +340,22 @@ func (s *Server) handleGET(c *apptheory.Context) (*apptheory.Response, error) {
 	return s.streamToSSE(ctx, sessionID, events)
 }
 
-func (s *Server) openSessionListener(ctx context.Context, sessionID string) (*apptheory.Response, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+func (s *Server) openSessionListener(ctx context.Context, sessionID string, remainingMS int) (*apptheory.Response, error) {
+	listenerCtx, cancel := s.initialSessionListenerContext(ctx, remainingMS)
 
 	pr, pw := io.Pipe()
 
 	go func() {
+		defer cancel()
 		defer func() {
 			if err := pw.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
-				s.logger.WarnContext(ctx, "session listener close error", "sessionId", sessionID, "error", err)
+				s.logger.WarnContext(listenerCtx, "session listener close error", "sessionId", sessionID, "error", err)
 			}
 		}()
+
+		if listenerCtx.Err() != nil {
+			return
+		}
 
 		// Emit an initial keepalive comment so the stream produces output quickly
 		// (useful for clients/proxies that expect early bytes).
@@ -327,7 +370,7 @@ func (s *Server) openSessionListener(ctx context.Context, sessionID string) (*ap
 
 		for {
 			select {
-			case <-ctx.Done():
+			case <-listenerCtx.Done():
 				return
 			case <-ticker.C:
 				if _, err := pw.Write([]byte(": keepalive\n\n")); err != nil {
@@ -348,6 +391,56 @@ func (s *Server) openSessionListener(ctx context.Context, sessionID string) (*ap
 		BodyReader: pr,
 	}
 	return resp, nil
+}
+
+func normalizeInitialSessionListenerBudgetOptions(opts InitialSessionListenerBudgetOptions) initialSessionListenerBudgetConfig {
+	safetyBuffer := opts.SafetyBuffer
+	if safetyBuffer <= 0 {
+		safetyBuffer = defaultInitialSessionListenerSafetyBuffer
+	}
+
+	maxDuration := opts.MaxDuration
+	if maxDuration <= 0 {
+		maxDuration = defaultInitialSessionListenerMaxDuration
+	}
+
+	return initialSessionListenerBudgetConfig{
+		safetyBuffer: safetyBuffer,
+		maxDuration:  maxDuration,
+	}
+}
+
+func (s *Server) initialSessionListenerBudgetDuration(remainingMS int) (time.Duration, bool) {
+	if s == nil || s.initialSessionListenerBudget == nil || remainingMS <= 0 {
+		return 0, false
+	}
+
+	budget := (time.Duration(remainingMS) * time.Millisecond) - s.initialSessionListenerBudget.safetyBuffer
+	if budget <= 0 {
+		return 0, true
+	}
+
+	if maxDuration := s.initialSessionListenerBudget.maxDuration; maxDuration > 0 && budget > maxDuration {
+		budget = maxDuration
+	}
+	return budget, true
+}
+
+func (s *Server) initialSessionListenerContext(ctx context.Context, remainingMS int) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	budget, ok := s.initialSessionListenerBudgetDuration(remainingMS)
+	if !ok {
+		return ctx, func() {}
+	}
+	if budget <= 0 {
+		listenerCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		return listenerCtx, cancel
+	}
+	return context.WithTimeout(ctx, budget)
 }
 
 func (s *Server) handleDELETE(c *apptheory.Context) (*apptheory.Response, error) {

--- a/runtime/mcp/server_listener_budget_test.go
+++ b/runtime/mcp/server_listener_budget_test.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInitialSessionListenerBudgetDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled without option", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewServer("test", "dev")
+		if got, ok := s.initialSessionListenerBudgetDuration(30_000); ok || got != 0 {
+			t.Fatalf("budget = %v, %v; want disabled", got, ok)
+		}
+	})
+
+	t.Run("zero values use defaults", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewServer("test", "dev", WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions{}))
+
+		got, ok := s.initialSessionListenerBudgetDuration(31_000)
+		if !ok {
+			t.Fatalf("expected budgeting to be enabled")
+		}
+		if got != 25*time.Second {
+			t.Fatalf("budget = %v, want %v", got, 25*time.Second)
+		}
+
+		got, ok = s.initialSessionListenerBudgetDuration(20_000)
+		if !ok {
+			t.Fatalf("expected budgeting to be enabled")
+		}
+		if got != 15*time.Second {
+			t.Fatalf("budget = %v, want %v", got, 15*time.Second)
+		}
+	})
+
+	t.Run("max duration clamps remaining budget", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewServer("test", "dev", WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions{
+			SafetyBuffer: 100 * time.Millisecond,
+			MaxDuration:  50 * time.Millisecond,
+		}))
+
+		got, ok := s.initialSessionListenerBudgetDuration(400)
+		if !ok {
+			t.Fatalf("expected budgeting to be enabled")
+		}
+		if got != 50*time.Millisecond {
+			t.Fatalf("budget = %v, want %v", got, 50*time.Millisecond)
+		}
+	})
+
+	t.Run("remaining time below safety buffer closes immediately", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewServer("test", "dev", WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions{
+			SafetyBuffer: 100 * time.Millisecond,
+			MaxDuration:  50 * time.Millisecond,
+		}))
+
+		got, ok := s.initialSessionListenerBudgetDuration(80)
+		if !ok {
+			t.Fatalf("expected budgeting to be enabled")
+		}
+		if got != 0 {
+			t.Fatalf("budget = %v, want immediate close", got)
+		}
+	})
+
+	t.Run("missing remaining time leaves keepalive unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewServer("test", "dev", WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions{}))
+		if got, ok := s.initialSessionListenerBudgetDuration(0); ok || got != 0 {
+			t.Fatalf("budget = %v, %v; want disabled without RemainingMS", got, ok)
+		}
+	})
+}
+
+func TestGET_NoLastEventID_WithInitialSessionListenerBudget_NoRemainingTime_KeepsAlive(t *testing.T) {
+	s := NewServer("test-server", "1.0.0", WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions{
+		SafetyBuffer: 100 * time.Millisecond,
+		MaxDuration:  50 * time.Millisecond,
+	}))
+	sessionID := initializeSession(t, s)
+
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"text/event-stream"}
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := invokeHandlerWithMethod(reqCtx, s, "GET", nil, headers)
+	if err != nil {
+		t.Fatalf("invoke GET: %v", err)
+	}
+	if resp.BodyReader == nil {
+		t.Fatalf("expected GET listener BodyReader to be set")
+	}
+
+	reader := bufio.NewReader(resp.BodyReader)
+	frame, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read keepalive SSE frame: %v (frame=%q)", err, frame)
+	}
+	if !strings.HasPrefix(frame, ":") || !strings.Contains(frame, "keepalive") {
+		t.Fatalf("expected keepalive comment frame, got:\n%s", frame)
+	}
+}
+
+func TestGET_NoLastEventID_WithInitialSessionListenerBudget_ClosesBeforeParentDeadline(t *testing.T) {
+	s := NewServer("test-server", "1.0.0", WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions{
+		SafetyBuffer: 200 * time.Millisecond,
+		MaxDuration:  2 * time.Second,
+	}))
+	sessionID := initializeSession(t, s)
+
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"text/event-stream"}
+
+	reqCtx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := invokeHandlerWithMethod(reqCtx, s, "GET", nil, headers)
+	if err != nil {
+		t.Fatalf("invoke GET: %v", err)
+	}
+	if resp.BodyReader == nil {
+		t.Fatalf("expected GET listener BodyReader to be set")
+	}
+
+	reader := bufio.NewReader(resp.BodyReader)
+	frame, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read keepalive SSE frame: %v (frame=%q)", err, frame)
+	}
+	if !strings.HasPrefix(frame, ":") || !strings.Contains(frame, "keepalive") {
+		t.Fatalf("expected keepalive comment frame, got:\n%s", frame)
+	}
+
+	if _, err := io.ReadAll(reader); err != nil {
+		t.Fatalf("read listener until close: %v", err)
+	}
+
+	if err := reqCtx.Err(); err != nil {
+		t.Fatalf("expected listener to close before parent deadline, got %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed >= 300*time.Millisecond {
+		t.Fatalf("listener closed too late: got %v, want < %v", elapsed, 300*time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Milestone
go-listener-budgeting — Lambda-aware budgeting for the initial MCP session listener

## Linear
Remote MCP edge hardening / go-listener-budgeting
- THE-271 — https://linear.app/theorycloud/issue/THE-271/add-a-go-mcp-session-listener-budget-surface-and-update-snapshots

## Tasks
- [x] THE-271 — Add a Go MCP session-listener budget surface and update snapshots

## Contract impact
API snapshot update for a new additive Go MCP surface.

## Validation
Commands run on the final commit:
- `make rubric`
- `go test ./runtime/...`
- `./scripts/update-api-snapshots.sh`
- `./scripts/verify-api-snapshots.sh`

## Cross-repo notes
None.
