### PR TITLE
docs(remote-mcp): clarify edge guidance

### DIFF
--- a/docs/cdk/mcp-protected-resource.md
+++ b/docs/cdk/mcp-protected-resource.md
@@ -63,3 +63,5 @@ new AppTheoryMcpProtectedResource(stack, "ProtectedResource", {
 - for API Gateway REST APIs, `/.well-known/...` sits under the same stage or base path as your `/mcp` route
 - for per-actor bundles (`/mcp/{actor}`), prefer `AppTheoryRemoteMcpServer({ actorPath: true })`, which co-registers
   the matching discovery route automatically
+- on that sanctioned REST API v1 actor-path deploy shape, AppTheory accepts both the canonical discovery path and the
+  same path with a trailing slash, so app-local slash stripping is no longer required there

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -80,6 +80,11 @@ const mcp = new AppTheoryRemoteMcpServer(stack, "RemoteMcpPerActor", {
 // discovery route === /.well-known/oauth-protected-resource/mcp/{actor}
 ```
 
+On this REST API v1 deploy path, the actor-scoped transport and discovery routes accept both the canonical path and the
+same path with a trailing slash. You do not need app-local trailing-slash stripping for `/mcp/{actor}` or
+`/.well-known/oauth-protected-resource/mcp/{actor}` when they are provisioned through
+`AppTheoryRemoteMcpServer({ actorPath: true })`.
+
 ## CORS option
 
 `AppTheoryRemoteMcpServer` exposes the underlying REST router `cors` option for API Gateway preflight handling.

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -198,6 +198,29 @@ For streaming tool calls, AppTheory assigns SSE event ids and persists them in t
 - `GET /mcp` without `last-event-id` opens a session listener that stays alive with keepalive comments so reconnecting
   clients do not hit immediate EOF loops
 
+### Budgeting the initial keepalive listener on Lambda
+
+If you want that initial `GET /mcp` keepalive listener to end before the Lambda deadline, opt in explicitly:
+
+```go
+srv := mcp.NewServer("my-mcp-server", "dev",
+  mcp.WithInitialSessionListenerBudget(mcp.InitialSessionListenerBudgetOptions{
+    SafetyBuffer: 5 * time.Second,
+    MaxDuration:  25 * time.Second,
+  }),
+)
+```
+
+Important scope notes:
+
+- this is explicit opt-in; without the option, the keepalive listener behavior is unchanged
+- it applies only to `GET /mcp` without `last-event-id`
+- replay/resume `GET /mcp` requests with `last-event-id` keep their existing behavior
+- when Lambda `RemainingMS` is available, AppTheory subtracts `SafetyBuffer` from the remaining time and caps the
+  listener with `MaxDuration`
+- when `RemainingMS` is unavailable, the keepalive listener continues unchanged even if the option is configured
+- early termination simply ends the listener; AppTheory does not emit a special final SSE event or comment
+
 ---
 
 ## Resources

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -130,6 +130,11 @@ API Gateway REST response streaming connections are time-bounded and can disconn
   persistent `StreamStore`
 - execute long work asynchronously (worker Lambdas) and append progress/results into the event log
 
+If you want the initial `GET /mcp` keepalive listener to end before the Lambda deadline, opt in with
+`mcp.WithInitialSessionListenerBudget(...)`. This applies only to the initial listener path with no `Last-Event-ID`;
+resume/replay `GET /mcp` requests keep their existing behavior. The example in `examples/mcp/resumable-sse` uses the
+default budget values (`SafetyBuffer: 5s`, `MaxDuration: 25s`) explicitly so the Lambda behavior is visible in code.
+
 Detailed compatibility notes and HTTP transcripts are maintained in non-canonical planning docs and intentionally kept
 out of this user-facing guide.
 

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -91,6 +91,12 @@ If you enable the optional Remote MCP stream table, wire a concrete persistent `
 `mcp.NewDynamoStreamStore(db)` with `mcp.WithStreamStore(...)`. `enableStreamTable` alone still only provisions the
 storage and env vars.
 
+For actor-scoped deployments on this sanctioned REST API v1 path, AppTheory now accepts both `/mcp/{actor}` and
+`/mcp/{actor}/`, plus the matching
+`/.well-known/oauth-protected-resource/mcp/{actor}` / `/.well-known/oauth-protected-resource/mcp/{actor}/` forms.
+You no longer need app-local trailing-slash stripping for those Remote MCP routes. This is intentionally narrow to the
+Remote MCP REST API v1 path and is not a broad router-wide canonicalization rule.
+
 ## 4) Testing (no AWS required)
 
 Deterministic test helpers:

--- a/examples/mcp/resumable-sse/README.md
+++ b/examples/mcp/resumable-sse/README.md
@@ -3,9 +3,12 @@
 This example demonstrates a streaming tool call where:
 - the server emits `notifications/progress` (as JSON-RPC, framed as SSE)
 - the client can disconnect and later resume via `GET /mcp` + `Last-Event-ID`
+- the server opts into Lambda-aware budgeting for the initial `GET /mcp` keepalive listener
 
 In production (AWS), ensure:
 - API Gateway **REST API v1** is used for `/mcp` streaming
 - long tasks append progress/results into a durable event log for replay
+- if you want the initial keepalive listener to close before the Lambda deadline, configure
+  `mcp.WithInitialSessionListenerBudget(...)`; replay/resume `GET /mcp` requests with `Last-Event-ID` are unchanged
 
 See `docs/integrations/remote-mcp.md`.

--- a/examples/mcp/resumable-sse/main.go
+++ b/examples/mcp/resumable-sse/main.go
@@ -12,7 +12,14 @@ import (
 )
 
 func buildServer() *mcp.Server {
-	srv := mcp.NewServer("resumable-sse", "dev")
+	srv := mcp.NewServer("resumable-sse", "dev",
+		// On Lambda, cap the initial keepalive listener before the function deadline.
+		// Replay/resume GET requests with Last-Event-ID keep the normal replay path.
+		mcp.WithInitialSessionListenerBudget(mcp.InitialSessionListenerBudgetOptions{
+			SafetyBuffer: 5 * time.Second,
+			MaxDuration:  25 * time.Second,
+		}),
+	)
 
 	_ = srv.Registry().RegisterStreamingTool(mcp.ToolDef{
 		Name:        "countdown",


### PR DESCRIPTION
## Milestone
remote-mcp-guidance — docs and example follow-ups for Remote MCP edge hardening

## Linear
Remote MCP edge hardening / remote-mcp-guidance
- THE-275 — https://linear.app/theorycloud/issue/THE-275/document-actor-path-trailing-slash-handling-for-remote-mcp-deployments
- THE-276 — https://linear.app/theorycloud/issue/THE-276/document-and-exemplify-lambda-aware-listener-budgeting

## Tasks
- [x] THE-275 — Document actor-path trailing-slash handling for Remote MCP deployments
- [x] THE-276 — Document and exemplify Lambda-aware listener budgeting

## Contract impact
doc-only

## Validation
Commands run on the final commit:
- `make rubric`
- `make test-unit`

## Cross-repo notes
None.
