### PR TITLE
[codex] bump TableTheory to v1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/jsii-runtime-go v1.127.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/stretchr/testify v1.11.1
-	github.com/theory-cloud/tabletheory v1.5.5
+	github.com/theory-cloud/tabletheory v1.6.0
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/theory-cloud/tabletheory v1.5.5 h1:XW4TTHqMLUGN7NXvKlSFMUodnL7UIp0Begk3pXnyITg=
 github.com/theory-cloud/tabletheory v1.5.5/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/tabletheory v1.6.0 h1:n/LqQIb0IftotMnd5d5x1rDawkmmH2XkYo+NmtxN/dg=
+github.com/theory-cloud/tabletheory v1.6.0/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
-  "tabletheory-py @ https://github.com/theory-cloud/TableTheory/releases/download/v1.5.5/tabletheory_py-1.5.5-py3-none-any.whl",
+  "tabletheory-py @ https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/tabletheory_py-1.6.0-py3-none-any.whl",
 ]
 
 [tool.setuptools]

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.5/theory-cloud-tabletheory-ts-1.5.5.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/theory-cloud-tabletheory-ts-1.6.0.tgz"
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "1.5.5",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.5/theory-cloud-tabletheory-ts-1.5.5.tgz",
-      "integrity": "sha512-FXbst+zvhX8yJzkBgZ+LySdnQT9jCR+hAu2l0meBFNXE5DJrKYbzmX+DhFDutsJysuB2Zkm4tMw4j5+97HMtow==",
+      "version": "1.6.0",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/theory-cloud-tabletheory-ts-1.6.0.tgz",
+      "integrity": "sha512-ki/b8DKN9nRSvQ3/QABU3SuDEiXHS5BQhPe51iseZZkpKj2qOhIHWwj5kn/p8d25QdsNveszRbYrsoOLJmKIoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1002.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.5/theory-cloud-tabletheory-ts-1.5.5.tgz"
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/theory-cloud-tabletheory-ts-1.6.0.tgz"
   },
   "overrides": {
     "@typescript-eslint/typescript-estree": {


### PR DESCRIPTION
## What changed
- bumped the Go module pin for `github.com/theory-cloud/tabletheory` to `v1.6.0`
- updated the TypeScript release tarball URL and regenerated `ts/package-lock.json`
- updated the Python wheel URL in `py/pyproject.toml`

## Why
AppTheory should consume the published TableTheory `v1.6.0` release across all supported language surfaces instead of staying pinned to `v1.5.5`.

## Impact
- keeps the Go / TypeScript / Python dependency story aligned on one TableTheory release
- preserves AppTheory's GitHub Releases-only distribution posture for TS and Python
- full repo gates pass against TableTheory `v1.6.0`

## Validation
- `make rubric`

## Branch-flow note
This targets `staging`. Since `staging` has not yet absorbed the latest stable `main` baseline, this branch is based on `origin/main` so the dependency bump follows the released supply chain.
