### PR TITLE
fix(runtime): reject empty principal identities from principal auth hook

### DIFF
--- a/runtime/auth.go
+++ b/runtime/auth.go
@@ -28,7 +28,11 @@ func (a *App) authenticate(ctx *Context) (*AuthPrincipal, error) {
 		if err != nil {
 			return nil, err
 		}
-		return normalizeAuthPrincipal(principal), nil
+		principal = normalizeAuthPrincipal(principal)
+		if principal == nil || principal.Identity == "" {
+			return nil, nil
+		}
+		return principal, nil
 	}
 	if a.auth == nil {
 		return nil, nil

--- a/runtime/auth_test.go
+++ b/runtime/auth_test.go
@@ -128,3 +128,21 @@ func TestWithAuthHook_RemainsCompatibleWithPrincipalFlow(t *testing.T) {
 		t.Fatalf("unexpected payload: %#v", body)
 	}
 }
+
+func TestRequireAuth_RejectsEmptyPrincipalIdentity(t *testing.T) {
+	t.Parallel()
+
+	app := New(
+		WithTier(TierP2),
+		WithIDGenerator(fixedIDGenerator("req_1")),
+		WithAuthPrincipalHook(func(*Context) (*AuthPrincipal, error) {
+			return &AuthPrincipal{}, nil
+		}),
+	)
+	app.Get("/protected", func(*Context) (*Response, error) { return Text(200, "ok"), nil }, RequireAuth())
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/protected"})
+	if resp.Status != 401 {
+		t.Fatalf("expected 401, got %d", resp.Status)
+	}
+}


### PR DESCRIPTION
### Motivation
- Prevent an authentication bypass where a non-nil but empty `AuthPrincipal` returned by `WithAuthPrincipalHook` satisfied `RequireAuth` and allowed unauthenticated access.
- Restore parity with the legacy `AuthHook` behavior that trims and rejects empty identities.

### Description
- Update `authenticate` to normalize the principal returned by `principalAuth` and treat a `nil` principal or one with an empty `Identity` as unauthenticated (`nil`).
- Preserve existing normalization logic for identity, scopes, and claims via `normalizeAuthPrincipal` before the emptiness check.
- Add `TestRequireAuth_RejectsEmptyPrincipalIdentity` to assert that `RequireAuth()` returns `401` when the principal hook returns an empty `AuthPrincipal`.

### Testing
- Ran `go test ./runtime` and the test suite passed (`ok   github.com/theory-cloud/apptheory/runtime`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9143da3ec83339688eeb3e5985419)