### PR TITLE
fix(ci): harden theorycloud publish pipeline and docs staging

### DIFF
--- a/.github/workflows/theorycloud-apptheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-apptheory-subtree-publish.yml
@@ -78,14 +78,6 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: apptheory-${{ github.ref_name }}-${{ github.run_id }}
 
-      - name: Install awscurl
-        run: |
-          set -euo pipefail
-
-          python3 -m pip install --user --upgrade pip
-          python3 -m pip install --user awscurl
-          printf '%s\n' "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-
       - name: Sync AppTheory subtree into shared theorycloud source state
         run: |
           set -euo pipefail

--- a/scripts/stage-theorycloud-apptheory-subtree.sh
+++ b/scripts/stage-theorycloud-apptheory-subtree.sh
@@ -109,9 +109,21 @@ contract_only_patterns = [normalize(value) for value in sections["fixed_contract
 out_of_scope_patterns = [normalize(value) for value in sections["out_of_scope"]]
 exclusion_rules = out_of_scope_patterns + contract_only_patterns
 
+all_paths = sorted(docs_root.rglob("*"))
+symlink_paths = sorted(
+    path.relative_to(docs_root).as_posix()
+    for path in all_paths
+    if path.is_symlink()
+)
+if symlink_paths:
+    raise SystemExit(
+        "docs subtree staging does not allow symlinks: "
+        + ", ".join(symlink_paths)
+    )
+
 all_files = sorted(
     path.relative_to(docs_root).as_posix()
-    for path in docs_root.rglob("*")
+    for path in all_paths
     if path.is_file()
 )
 

--- a/scripts/trigger-theorycloud-publish.sh
+++ b/scripts/trigger-theorycloud-publish.sh
@@ -127,22 +127,44 @@ if [[ "${PUBLISH_DRY_RUN}" == "true" ]]; then
   fi
   echo "url=${PUBLISH_URL}"
   echo "payload=${PAYLOAD}"
-  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type: application/json --fail-with-body -o <response-file> --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "command=curl --aws-sigv4 aws:amz:${AWS_REGION}:execute-api --user <sigv4-credentials> -H content-type: application/json -H x-amz-security-token: <aws-session-token> -X POST --fail-with-body -o <response-file> --data ${PAYLOAD} ${PUBLISH_URL}"
   echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
   exit 0
 fi
 
-command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
+command -v curl >/dev/null 2>&1 || fail "curl is required for publish invocation"
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
+AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
+
+if [[ -z "${AWS_ACCESS_KEY_ID}" || -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+  fail "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required for publish invocation"
+fi
 
 response_file="$(mktemp)"
 trap 'rm -f "${response_file}"' EXIT
 
-if awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --fail-with-body --data "${PAYLOAD}" -o "${response_file}" "${PUBLISH_URL}"; then
+curl_args=(
+  --aws-sigv4 "aws:amz:${AWS_REGION}:execute-api"
+  --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
+  -X POST
+  -H 'content-type: application/json'
+  --fail-with-body
+  --data "${PAYLOAD}"
+  -o "${response_file}"
+)
+
+if [[ -n "${AWS_SESSION_TOKEN}" ]]; then
+  curl_args+=(-H "x-amz-security-token: ${AWS_SESSION_TOKEN}")
+fi
+
+if curl "${curl_args[@]}" "${PUBLISH_URL}"; then
   :
 else
   status=$?
   body="$(cat "${response_file}" 2>/dev/null || true)"
-  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status}): ${body}"
+  fail "curl invocation failed for ${PUBLISH_URL} (exit ${status}): ${body}"
 fi
 
 body="$(cat "${response_file}")"

--- a/scripts/verify-theorycloud-apptheory-publish-config.sh
+++ b/scripts/verify-theorycloud-apptheory-publish-config.sh
@@ -78,7 +78,7 @@ assert_contains "${lab_publish_output}" 'stage=lab'
 assert_contains "${lab_publish_output}" 'branch=premain'
 assert_contains "${lab_publish_output}" 'url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
 assert_contains "${lab_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-lab","reason":"docs sync complete","force":false}'
-assert_contains "${lab_publish_output}" 'command=awscurl --service execute-api --region us-east-1 -X POST -H content-type: application/json --fail-with-body -o <response-file> --data'
+assert_contains "${lab_publish_output}" 'command=curl --aws-sigv4 aws:amz:us-east-1:execute-api --user <sigv4-credentials>'
 assert_not_contains "${lab_publish_output}" "-w '%{http_code}'"
 
 live_publish_output="$(run_with_default_publish_env THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live)"
@@ -86,7 +86,7 @@ assert_contains "${live_publish_output}" 'stage=live'
 assert_contains "${live_publish_output}" 'branch=main'
 assert_contains "${live_publish_output}" 'url=https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
 assert_contains "${live_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-live","reason":"docs sync complete","force":false}'
-assert_contains "${live_publish_output}" 'command=awscurl --service execute-api --region us-east-1 -X POST -H content-type: application/json --fail-with-body -o <response-file> --data'
+assert_contains "${live_publish_output}" 'command=curl --aws-sigv4 aws:amz:us-east-1:execute-api --user <sigv4-credentials>'
 assert_not_contains "${live_publish_output}" "-w '%{http_code}'"
 
 lab_publish_workflow_reason_output="$(THEORYCLOUD_PUBLISH_REASON=github:theory-cloud/AppTheory:premain run_with_branch_stage_resolution THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-lab-workflow)"
@@ -99,13 +99,13 @@ assert_contains "${live_publish_workflow_reason_output}" 'stage=live'
 assert_contains "${live_publish_workflow_reason_output}" 'branch=main'
 assert_contains "${live_publish_workflow_reason_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-live-workflow","reason":"github:theory-cloud/AppTheory:main","force":false}'
 
-FAKE_AWSCURL_ARGS_LOG="${TMP_DIR}/awscurl-args.log"
+FAKE_CURL_ARGS_LOG="${TMP_DIR}/curl-args.log"
 mkdir -p "${TMP_DIR}/bin"
-cat > "${TMP_DIR}/bin/awscurl" <<'EOF_AWSCURL'
+cat > "${TMP_DIR}/bin/curl" <<'EOF_CURL'
 #!/usr/bin/env bash
 set -euo pipefail
 
-args_log="${FAKE_AWSCURL_ARGS_LOG:?}"
+args_log="${FAKE_CURL_ARGS_LOG:?}"
 output_file=""
 
 while [[ $# -gt 0 ]]; do
@@ -129,21 +129,22 @@ if [[ -z "${output_file}" ]]; then
 fi
 
 printf '%s' '{"job_id":"fake-job","status":"enqueued"}' > "${output_file}"
-EOF_AWSCURL
-chmod +x "${TMP_DIR}/bin/awscurl"
+EOF_CURL
+chmod +x "${TMP_DIR}/bin/curl"
 
-lab_publish_exec_output="$(run_with_default_publish_env PATH="${TMP_DIR}/bin:${PATH}" FAKE_AWSCURL_ARGS_LOG="${FAKE_AWSCURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-lab-exec)"
-lab_publish_exec_args="$(cat "${FAKE_AWSCURL_ARGS_LOG}")"
+lab_publish_exec_output="$(run_with_default_publish_env PATH="${TMP_DIR}/bin:${PATH}" FAKE_CURL_ARGS_LOG="${FAKE_CURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false AWS_ACCESS_KEY_ID=test-access-key AWS_SECRET_ACCESS_KEY=test-secret-key AWS_SESSION_TOKEN=test-session-token bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-lab-exec)"
+lab_publish_exec_args="$(cat "${FAKE_CURL_ARGS_LOG}")"
 assert_contains "${lab_publish_exec_output}" 'trigger-theorycloud-publish: PASS (url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud)'
 assert_contains "${lab_publish_exec_output}" '{"job_id":"fake-job","status":"enqueued"}'
-assert_contains "${lab_publish_exec_args}" '--service'
-assert_contains "${lab_publish_exec_args}" 'execute-api'
-assert_contains "${lab_publish_exec_args}" '--region'
-assert_contains "${lab_publish_exec_args}" 'us-east-1'
+assert_contains "${lab_publish_exec_args}" '--aws-sigv4'
+assert_contains "${lab_publish_exec_args}" 'aws:amz:us-east-1:execute-api'
+assert_contains "${lab_publish_exec_args}" '--user'
+assert_contains "${lab_publish_exec_args}" 'test-access-key:test-secret-key'
 assert_contains "${lab_publish_exec_args}" '-X'
 assert_contains "${lab_publish_exec_args}" 'POST'
 assert_contains "${lab_publish_exec_args}" '-H'
 assert_contains "${lab_publish_exec_args}" 'content-type: application/json'
+assert_contains "${lab_publish_exec_args}" 'x-amz-security-token: test-session-token'
 assert_contains "${lab_publish_exec_args}" '--fail-with-body'
 assert_contains "${lab_publish_exec_args}" '-o'
 assert_contains "${lab_publish_exec_args}" '--data'
@@ -151,19 +152,20 @@ assert_contains "${lab_publish_exec_args}" '{"source_revision":"abc123def456","i
 assert_contains "${lab_publish_exec_args}" 'https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
 assert_not_has_line "${lab_publish_exec_args}" "-w"
 
-: > "${FAKE_AWSCURL_ARGS_LOG}"
-live_publish_exec_output="$(run_with_default_publish_env PATH="${TMP_DIR}/bin:${PATH}" FAKE_AWSCURL_ARGS_LOG="${FAKE_AWSCURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live-exec)"
-live_publish_exec_args="$(cat "${FAKE_AWSCURL_ARGS_LOG}")"
+: > "${FAKE_CURL_ARGS_LOG}"
+live_publish_exec_output="$(run_with_default_publish_env PATH="${TMP_DIR}/bin:${PATH}" FAKE_CURL_ARGS_LOG="${FAKE_CURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false AWS_ACCESS_KEY_ID=test-access-key AWS_SECRET_ACCESS_KEY=test-secret-key AWS_SESSION_TOKEN=test-session-token bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live-exec)"
+live_publish_exec_args="$(cat "${FAKE_CURL_ARGS_LOG}")"
 assert_contains "${live_publish_exec_output}" 'trigger-theorycloud-publish: PASS (url=https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud)'
 assert_contains "${live_publish_exec_output}" '{"job_id":"fake-job","status":"enqueued"}'
-assert_contains "${live_publish_exec_args}" '--service'
-assert_contains "${live_publish_exec_args}" 'execute-api'
-assert_contains "${live_publish_exec_args}" '--region'
-assert_contains "${live_publish_exec_args}" 'us-east-1'
+assert_contains "${live_publish_exec_args}" '--aws-sigv4'
+assert_contains "${live_publish_exec_args}" 'aws:amz:us-east-1:execute-api'
+assert_contains "${live_publish_exec_args}" '--user'
+assert_contains "${live_publish_exec_args}" 'test-access-key:test-secret-key'
 assert_contains "${live_publish_exec_args}" '-X'
 assert_contains "${live_publish_exec_args}" 'POST'
 assert_contains "${live_publish_exec_args}" '-H'
 assert_contains "${live_publish_exec_args}" 'content-type: application/json'
+assert_contains "${live_publish_exec_args}" 'x-amz-security-token: test-session-token'
 assert_contains "${live_publish_exec_args}" '--fail-with-body'
 assert_contains "${live_publish_exec_args}" '-o'
 assert_contains "${live_publish_exec_args}" '--data'
@@ -171,15 +173,15 @@ assert_contains "${live_publish_exec_args}" '{"source_revision":"abc123def456","
 assert_contains "${live_publish_exec_args}" 'https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
 assert_not_has_line "${live_publish_exec_args}" "-w"
 
-: > "${FAKE_AWSCURL_ARGS_LOG}"
-lab_publish_workflow_exec_output="$(THEORYCLOUD_PUBLISH_REASON=github:theory-cloud/AppTheory:premain run_with_branch_stage_resolution PATH="${TMP_DIR}/bin:${PATH}" FAKE_AWSCURL_ARGS_LOG="${FAKE_AWSCURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-lab-workflow-exec)"
-lab_publish_workflow_exec_args="$(cat "${FAKE_AWSCURL_ARGS_LOG}")"
+: > "${FAKE_CURL_ARGS_LOG}"
+lab_publish_workflow_exec_output="$(THEORYCLOUD_PUBLISH_REASON=github:theory-cloud/AppTheory:premain run_with_branch_stage_resolution PATH="${TMP_DIR}/bin:${PATH}" FAKE_CURL_ARGS_LOG="${FAKE_CURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false AWS_ACCESS_KEY_ID=test-access-key AWS_SECRET_ACCESS_KEY=test-secret-key AWS_SESSION_TOKEN=test-session-token bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch premain --source-revision abc123def456 --idempotency-key test-lab-workflow-exec)"
+lab_publish_workflow_exec_args="$(cat "${FAKE_CURL_ARGS_LOG}")"
 assert_contains "${lab_publish_workflow_exec_output}" 'trigger-theorycloud-publish: PASS (url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud)'
 assert_contains "${lab_publish_workflow_exec_args}" '{"source_revision":"abc123def456","idempotency_key":"test-lab-workflow-exec","reason":"github:theory-cloud/AppTheory:premain","force":false}'
 
-: > "${FAKE_AWSCURL_ARGS_LOG}"
-live_publish_workflow_exec_output="$(THEORYCLOUD_PUBLISH_REASON=github:theory-cloud/AppTheory:main run_with_branch_stage_resolution PATH="${TMP_DIR}/bin:${PATH}" FAKE_AWSCURL_ARGS_LOG="${FAKE_AWSCURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live-workflow-exec)"
-live_publish_workflow_exec_args="$(cat "${FAKE_AWSCURL_ARGS_LOG}")"
+: > "${FAKE_CURL_ARGS_LOG}"
+live_publish_workflow_exec_output="$(THEORYCLOUD_PUBLISH_REASON=github:theory-cloud/AppTheory:main run_with_branch_stage_resolution PATH="${TMP_DIR}/bin:${PATH}" FAKE_CURL_ARGS_LOG="${FAKE_CURL_ARGS_LOG}" THEORYCLOUD_PUBLISH_DRY_RUN=false AWS_ACCESS_KEY_ID=test-access-key AWS_SECRET_ACCESS_KEY=test-secret-key AWS_SESSION_TOKEN=test-session-token bash "${SCRIPT_DIR}/trigger-theorycloud-publish.sh" --branch main --source-revision abc123def456 --idempotency-key test-live-workflow-exec)"
+live_publish_workflow_exec_args="$(cat "${FAKE_CURL_ARGS_LOG}")"
 assert_contains "${live_publish_workflow_exec_output}" 'trigger-theorycloud-publish: PASS (url=https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud)'
 assert_contains "${live_publish_workflow_exec_args}" '{"source_revision":"abc123def456","idempotency_key":"test-live-workflow-exec","reason":"github:theory-cloud/AppTheory:main","force":false}'
 

--- a/scripts/verify-theorycloud-apptheory-subtree.sh
+++ b/scripts/verify-theorycloud-apptheory-subtree.sh
@@ -20,6 +20,27 @@ if [[ -d "${OUTPUT_DIR}/docs" ]]; then
   exit 1
 fi
 
+SYMLINK_DOCS_ROOT="${TMP_DIR}/docs-symlink-check"
+mkdir -p "${SYMLINK_DOCS_ROOT}"
+cp -R "${REPO_ROOT}/docs/." "${SYMLINK_DOCS_ROOT}"
+ln -s /etc/passwd "${SYMLINK_DOCS_ROOT}/integrations/passwd.md"
+
+SYMLINK_OUTPUT_DIR="${TMP_DIR}/out-symlink-check"
+SYMLINK_FAILURE_LOG="${TMP_DIR}/symlink-failure.log"
+if bash "${SCRIPT_DIR}/stage-theorycloud-apptheory-subtree.sh" \
+  --docs-root "${SYMLINK_DOCS_ROOT}" \
+  --output "${SYMLINK_OUTPUT_DIR}" \
+  >"${TMP_DIR}/symlink-check.stdout" 2>"${SYMLINK_FAILURE_LOG}"; then
+  echo "expected docs subtree staging to reject symlinked files" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'docs subtree staging does not allow symlinks: integrations/passwd.md' "${SYMLINK_FAILURE_LOG}"; then
+  echo "expected symlink rejection message for integrations/passwd.md" >&2
+  cat "${SYMLINK_FAILURE_LOG}" >&2
+  exit 1
+fi
+
 python3 - "${REPO_ROOT}/docs" "${OUTPUT_DIR}" "$(git -C "${REPO_ROOT}" rev-parse HEAD)" <<'PY'
 import datetime as dt
 import fnmatch

--- a/scripts/verify-theorycloud-publish-workflow.sh
+++ b/scripts/verify-theorycloud-publish-workflow.sh
@@ -71,6 +71,8 @@ assert_file_contains "uses: aws-actions/configure-aws-credentials@7474bc4690e29a
 assert_file_contains "bash scripts/verify-theorycloud-publish-workflow.sh"
 assert_file_contains "bash scripts/sync-theorycloud-apptheory-subtree.sh \\"
 assert_file_contains "bash scripts/trigger-theorycloud-publish.sh \\"
+assert_file_not_contains "Install awscurl"
+assert_file_not_contains "pip install --user awscurl"
 assert_file_not_contains "vars.AWS_REGION"
 assert_file_not_contains "vars.THEORYCLOUD_AWS_ROLE_ARN_LAB"
 assert_file_not_contains "vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE"


### PR DESCRIPTION
## Milestone
ci-publish-supply-chain-hardening — harden the TheoryCloud publish pipeline and docs subtree staging before broader v1.0 security work continues.

## Why
This milestone removes a mutable dependency install after AWS credentials are assumed in CI and closes the docs subtree symlink leak path in staging artifacts.

## What changed
- removed the `awscurl` install step from the subtree publish workflow
- switched the publish helper to SigV4 using `curl`
- updated publish workflow/config verification to assert the mutable install is gone
- made docs subtree staging fail closed on any symlink under the docs root
- added verification that a symlink placed under `docs/integrations/` is rejected

## Impact
- CI publish runs no longer execute an unpinned third-party PyPI package after AWS role assumption
- docs staging artifacts cannot include files outside the docs tree via symlink traversal

## Linear
- THE-353
- THE-377

## Tasks
- [x] THE-353 Remove mutable awscurl installation from the publish workflow after AWS auth
- [x] THE-377 Reject symlink traversal in docs subtree staging

## Contract impact
internal-only

## Validation
- `bash scripts/verify-theorycloud-publish-workflow.sh`
- `bash scripts/verify-theorycloud-apptheory-publish-config.sh`
- `bash scripts/verify-theorycloud-apptheory-subtree.sh`
- `make test-unit`
- `make rubric`

## Release discipline
This PR targets `staging` only. No promotion beyond `staging` is intended until the broader v1.0.0 security-hardening project is complete.
