### PR TITLE
fix(runtime): principal-auth fail-closed correction

### DIFF
--- a/runtime/auth.go
+++ b/runtime/auth.go
@@ -28,7 +28,11 @@ func (a *App) authenticate(ctx *Context) (*AuthPrincipal, error) {
 		if err != nil {
 			return nil, err
 		}
-		return normalizeAuthPrincipal(principal), nil
+		principal = normalizeAuthPrincipal(principal)
+		if principal == nil || principal.Identity == "" {
+			return nil, nil
+		}
+		return principal, nil
 	}
 	if a.auth == nil {
 		return nil, nil

--- a/runtime/auth_test.go
+++ b/runtime/auth_test.go
@@ -128,3 +128,21 @@ func TestWithAuthHook_RemainsCompatibleWithPrincipalFlow(t *testing.T) {
 		t.Fatalf("unexpected payload: %#v", body)
 	}
 }
+
+func TestRequireAuth_RejectsEmptyPrincipalIdentity(t *testing.T) {
+	t.Parallel()
+
+	app := New(
+		WithTier(TierP2),
+		WithIDGenerator(fixedIDGenerator("req_1")),
+		WithAuthPrincipalHook(func(*Context) (*AuthPrincipal, error) {
+			return &AuthPrincipal{}, nil
+		}),
+	)
+	app.Get("/protected", func(*Context) (*Response, error) { return Text(200, "ok"), nil }, RequireAuth())
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/protected"})
+	if resp.Status != 401 {
+		t.Fatalf("expected 401, got %d", resp.Status)
+	}
+}


### PR DESCRIPTION
## Milestone
principal-auth-hardening — land the fail-closed principal-auth correction that was originally prepared in PR #426, but on top of current `staging`.

## Why
`WithAuthPrincipalHook` normalized principals but still allowed a non-nil principal with an empty identity to flow through protected routes. That shape is semantically unauthenticated and must fail closed.

## What changed
- normalized principal-hook results are now treated as unauthenticated when the principal is nil or the normalized identity is empty
- added a runtime regression test proving `RequireAuth()` returns `401` for an empty principal identity

## Impact
Protected Go runtime routes no longer accept empty principal identities from the principal auth hook. This closes the auth bypass class identified in PR #426 without changing the public API surface.

## Linear
- THE-341

## Tasks
- [x] THE-341 Land the PR #426 principal-auth fail-closed correction

## Contract impact
internal-only

## Validation
- `go test ./runtime`
- `make test-unit`
- `make rubric`

## Release discipline
This PR targets `staging` only. No promotion beyond `staging` is intended until the broader v1.0.0 security-hardening project is complete.
