### PR TITLE
fix(oauth): remote mcp auth fail-closed hardening

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -242,6 +242,12 @@ AppTheory includes Go runtime support for MCP and OAuth-adjacent remote-MCP flow
 - `testkit/oauth`: Claude-like end-to-end OAuth flow helpers for remote MCP tests (`NewClaudePublicClient`,
   `AuthorizeOptions`, `Authorize`)
 
+Remote MCP auth hardening note:
+
+- `oauth.RequireBearerTokenMiddleware(...)` is fail-closed in Go: you must provide a `Validator`, and metadata
+  discovery for the `WWW-Authenticate` challenge comes from `ResourceMetadataURL` or `MCP_ENDPOINT`, not request
+  headers.
+
 Related canonical integration guides:
 
 - [Integration Guides](./integrations/README.md)

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -141,6 +141,15 @@ This matters for OAuth discovery. If `oauth.RequireBearerTokenMiddleware(...)` i
 `ResourceMetadataURL`, the middleware derives the RFC9728 `/.well-known/oauth-protected-resource` challenge URL from
 `MCP_ENDPOINT`.
 
+Important fail-closed rules:
+
+- `RequireBearerTokenMiddleware(...)` requires an explicit `Validator`; omitting it causes every request to be rejected
+  with `401`.
+- The middleware no longer derives protected-resource metadata from `Host` / `X-Forwarded-Proto` request headers.
+  Use `MCP_ENDPOINT` or pass `ResourceMetadataURL` explicitly.
+
+For migration notes, see `docs/migration/v1-security.md`.
+
 ## Keepalive, replay, and origin guidance
 
 For SSE connections, expect disconnects. Prefer:

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -72,9 +72,17 @@ You typically:
    see below).
 3) Validate Bearer tokens against Autheory (JWT verify via JWKS or introspection).
 
-When you deploy with `AppTheoryRemoteMcpServer`, the construct injects `MCP_ENDPOINT`. If
-`RequireBearerTokenMiddleware(...)` is used without an explicit `ResourceMetadataURL`, the middleware derives the
-RFC9728 protected-resource metadata challenge URL from that endpoint by default.
+Important fail-closed rules:
+- `RequireBearerTokenMiddleware(...)` now requires a `Validator`. If you omit it, the middleware rejects every request
+  with `401` instead of accepting any syntactically valid Bearer token.
+- The middleware derives the RFC9728 protected-resource metadata challenge URL only from an explicit
+  `ResourceMetadataURL` or from the injected `MCP_ENDPOINT`. It no longer falls back to `Host` /
+  `X-Forwarded-Proto` request headers.
+
+When you deploy with `AppTheoryRemoteMcpServer`, the construct injects `MCP_ENDPOINT`. That is the canonical metadata
+source when you do not provide `ResourceMetadataURL` explicitly.
+
+For migration notes, see `docs/migration/v1-security.md`.
 
 ## 3) Deploy on AWS (REST API v1 response streaming)
 

--- a/docs/migration/v1-security.md
+++ b/docs/migration/v1-security.md
@@ -1,0 +1,31 @@
+# AppTheory v1.0 Security Migration Guide
+
+This guide tracks security-hardening changes that are intentionally moving AppTheory toward the v1.0 fail-closed
+baseline.
+
+## Remote MCP bearer protection now fails closed
+
+Affected surface:
+
+- `runtime/oauth.RequireBearerTokenMiddleware(...)`
+
+What changed:
+
+- You must provide a `Validator`. If you omit it, the middleware now rejects every request with `401` instead of
+  accepting any syntactically valid `Authorization: Bearer ...` token.
+- The `WWW-Authenticate` `resource_metadata` challenge is derived only from an explicit `ResourceMetadataURL` or from
+  `MCP_ENDPOINT`. It is no longer derived from `Host` / `X-Forwarded-Proto` request headers.
+
+What you need to do:
+
+1. Provide a real token validator (JWT verification, introspection, or equivalent) whenever you use
+   `RequireBearerTokenMiddleware(...)`.
+2. Ensure the middleware has an explicit metadata source:
+   - set `ResourceMetadataURL`, or
+   - deploy through `AppTheoryRemoteMcpServer` so `MCP_ENDPOINT` is injected.
+3. If you previously depended on request-header-derived metadata discovery, replace that with explicit configuration.
+
+Why this changed:
+
+- Accepting arbitrary Bearer tokens when no validator was configured was not fail-closed.
+- Deriving protected-resource metadata from request headers trusted attacker-influenced inputs in proxy setups.

--- a/runtime/oauth/bearer.go
+++ b/runtime/oauth/bearer.go
@@ -21,12 +21,11 @@ type BearerTokenValidator func(ctx context.Context, token string) error
 type RequireBearerTokenOptions struct {
 	// ResourceMetadataURL is used to build the RFC9728 discovery challenge.
 	//
-	// If empty, the middleware attempts to derive it from MCP_ENDPOINT, and then
-	// from request headers (Host + X-Forwarded-Proto) as a last resort.
+	// If empty, the middleware attempts to derive it from MCP_ENDPOINT only.
 	ResourceMetadataURL string
 
-	// Validator, when provided, is called for every request. If it returns an
-	// error the request is rejected with 401.
+	// Validator is called for every request. If it is omitted, or if it returns
+	// an error, the request is rejected with 401.
 	Validator BearerTokenValidator
 }
 
@@ -40,10 +39,11 @@ func RequireBearerTokenMiddleware(opts RequireBearerTokenOptions) apptheory.Midd
 			if err != nil {
 				return unauthorizedResponse(c, opts), nil
 			}
-			if opts.Validator != nil {
-				if err := opts.Validator(c.Context(), token); err != nil {
-					return unauthorizedResponse(c, opts), nil
-				}
+			if opts.Validator == nil {
+				return unauthorizedResponse(c, opts), nil
+			}
+			if err := opts.Validator(c.Context(), token); err != nil {
+				return unauthorizedResponse(c, opts), nil
 			}
 
 			c.Set(ContextKeyBearerToken, token)
@@ -78,8 +78,6 @@ func unauthorizedResponse(c *apptheory.Context, opts RequireBearerTokenOptions) 
 			mcpEndpoint = resolved
 		}
 		if derived, ok := ResourceMetadataURLFromMcpEndpoint(mcpEndpoint); ok {
-			metaURL = derived
-		} else if derived, ok := ProtectedResourceMetadataURLForRequest(c.Request.Headers); ok {
 			metaURL = derived
 		}
 	}

--- a/runtime/oauth/bearer_test.go
+++ b/runtime/oauth/bearer_test.go
@@ -90,3 +90,48 @@ func TestRequireBearerTokenMiddleware_ValidatorRuns(t *testing.T) {
 	require.Equal(t, 200, resp.Status)
 	require.Equal(t, 1, called)
 }
+
+func TestRequireBearerTokenMiddleware_RejectsWhenValidatorMissing(t *testing.T) {
+	mw := RequireBearerTokenMiddleware(RequireBearerTokenOptions{
+		ResourceMetadataURL: "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+	})
+
+	called := false
+	handler := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+		called = true
+		return &apptheory.Response{Status: 200}, nil
+	})
+
+	resp, err := handler(&apptheory.Context{
+		Request: apptheory.Request{
+			Headers: map[string][]string{
+				"authorization": {"Bearer ok"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 401, resp.Status)
+	require.Equal(t, []string{`Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"`}, resp.Headers["www-authenticate"])
+	require.False(t, called)
+}
+
+func TestRequireBearerTokenMiddleware_DoesNotDeriveMetadataFromRequestHeaders(t *testing.T) {
+	t.Setenv("MCP_ENDPOINT", "")
+
+	mw := RequireBearerTokenMiddleware(RequireBearerTokenOptions{})
+	handler := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+		return &apptheory.Response{Status: 200}, nil
+	})
+
+	resp, err := handler(&apptheory.Context{
+		Request: apptheory.Request{
+			Headers: map[string][]string{
+				"host":              {"mcp.example.com"},
+				"x-forwarded-proto": {"https"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 401, resp.Status)
+	require.Equal(t, []string{"Bearer"}, resp.Headers["www-authenticate"])
+}

--- a/runtime/oauth/protected_resource.go
+++ b/runtime/oauth/protected_resource.go
@@ -130,12 +130,13 @@ func CanonicalizeIssuerURL(raw string) (string, bool) {
 	return out.String(), true
 }
 
-// ProtectedResourceMetadataURLForRequest attempts to derive an absolute
-// root `/.well-known/oauth-protected-resource` URL from common proxy headers.
+// ProtectedResourceMetadataURLForRequest derives an absolute root
+// `/.well-known/oauth-protected-resource` URL from common proxy headers.
 //
-// Prefer using ResourceMetadataURLFromMcpEndpoint with MCP_ENDPOINT for AWS
-// deployments. This helper is intentionally root-only and does not attempt to
-// infer path-scoped protected resources from request paths.
+// Prefer using ResourceMetadataURLFromMcpEndpoint with an explicit MCP endpoint
+// URL for AWS Remote MCP deployments. This helper is intentionally root-only
+// and does not attempt to infer path-scoped protected resources from request
+// paths.
 func ProtectedResourceMetadataURLForRequest(headers map[string][]string) (string, bool) {
 	host := firstHeader(headers, "host")
 	if host == "" {

--- a/testkit/mcp/claude_remote_mcp_contract_test.go
+++ b/testkit/mcp/claude_remote_mcp_contract_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,12 @@ func TestClaudeRemoteMcp_UnauthorizedChallenge_AndProtectedResourceMetadata(t *t
 	// Protect all MCP routes.
 	auth := oauthruntime.RequireBearerTokenMiddleware(oauthruntime.RequireBearerTokenOptions{
 		ResourceMetadataURL: "https://mcp.example.com/.well-known/oauth-protected-resource",
+		Validator: func(ctx context.Context, token string) error {
+			if strings.TrimSpace(token) == "token-123" {
+				return nil
+			}
+			return errors.New("invalid bearer token")
+		},
 	})
 	protected := auth(mcpServer.Handler())
 	app.Post("/mcp", protected)
@@ -154,6 +161,12 @@ func TestClaudeRemoteMcp_Lifecycle_AndStreamingResume_WithBearerAuth(t *testing.
 
 	auth := oauthruntime.RequireBearerTokenMiddleware(oauthruntime.RequireBearerTokenOptions{
 		ResourceMetadataURL: "https://mcp.example.com/.well-known/oauth-protected-resource",
+		Validator: func(ctx context.Context, token string) error {
+			if strings.TrimSpace(token) == "token-123" {
+				return nil
+			}
+			return errors.New("invalid bearer token")
+		},
 	})
 	protected := auth(mcpServer.Handler())
 	app.Post("/mcp", protected)


### PR DESCRIPTION
## Milestone
remote-mcp-auth-hardening — harden Go Remote MCP bearer enforcement so the middleware fails closed and only derives OAuth protected-resource metadata from explicit configuration.

## Why
The Go Remote MCP bearer middleware accepted any syntactically valid bearer token when no validator was configured, and it could derive protected-resource metadata from request headers. Both behaviors violated AppTheory’s fail-closed posture.

## What changed
- `oauth.RequireBearerTokenMiddleware(...)` now rejects requests when `Validator` is omitted
- unauthorized challenges derive `resource_metadata` from `ResourceMetadataURL` or `MCP_ENDPOINT` only
- added regression tests for missing-validator rejection and no request-header metadata fallback
- updated the MCP contract test harness to provide an explicit validator
- updated Remote MCP docs and seeded `docs/migration/v1-security.md` with the migration note for this hardening change

## Impact
Remote MCP Go deployments must provide a real bearer validator and an explicit metadata source (`ResourceMetadataURL` or `MCP_ENDPOINT`). Header-derived metadata fallback is gone.

## Linear
- THE-342

## Tasks
- [x] THE-342 Harden Go Remote MCP bearer enforcement and remove header-derived metadata fallback

## Contract impact
internal-only

## Validation
- `go test ./runtime/oauth ./runtime/mcp`
- `make test-unit`
- `make rubric`

## Release discipline
This PR targets `staging` only. No promotion beyond `staging` is intended until the broader v1.0.0 security-hardening project is complete.
