### PR TITLE
test(contract): specify base64 request size guardrails

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -26,7 +26,8 @@ Each fixture is a single JSON object.
   - `handler` (string): built-in handler name provided by each language runner.
 - `setup.middlewares` (array, optional): built-in middleware chain names applied in registration order.
 - `setup.limits` (object, optional): guardrails configuration.
-  - `max_request_bytes` (number): reject requests over this size with `app.too_large`.
+  - `max_request_bytes` (number): reject requests over this size with `app.too_large`. When `input.request.is_base64`
+    is `true`, this limit applies to the decoded request body bytes.
   - `max_response_bytes` (number): reject responses over this size with `app.too_large`.
 - `input.request` (object): request presented to the runtime under test.
 - `input.context` (object, optional): synthetic invocation context (portable subset).

--- a/contract-tests/fixtures/p1/guardrails-request-too-large-base64.json
+++ b/contract-tests/fixtures/p1/guardrails-request-too-large-base64.json
@@ -1,0 +1,39 @@
+{
+  "id": "p1.guardrails.request_too_large_base64",
+  "tier": "p1",
+  "name": "Base64 request size guardrail maps decoded bytes to app.too_large",
+  "setup": {
+    "limits": { "max_request_bytes": 4 },
+    "routes": [
+      { "method": "POST", "path": "/context", "handler": "echo_context" }
+    ]
+  },
+  "input": {
+    "request": {
+      "method": "POST",
+      "path": "/context",
+      "query": {},
+      "headers": { "content-type": ["text/plain"] },
+      "body": { "encoding": "utf8", "value": "MTIzNDU=" },
+      "is_base64": true
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 413,
+      "headers": {
+        "content-type": ["application/json; charset=utf-8"],
+        "x-request-id": ["req_test_123"]
+      },
+      "cookies": [],
+      "body_json": {
+        "error": {
+          "code": "app.too_large",
+          "message": "request too large",
+          "request_id": "req_test_123"
+        }
+      },
+      "is_base64": false
+    }
+  }
+}


### PR DESCRIPTION
## Milestone
request-size-contract — pin the contract semantics for base64 request-size guardrails before the runtime implementation hardening lands.

## Why
The current roadmap intentionally separates fixture-first contract work from later runtime changes. This milestone makes the decoded-body request-size behavior explicit across Go, TypeScript, and Python.

## What changed
- added a new P1 fixture for a base64 request whose decoded body exceeds `max_request_bytes`
- documented that `max_request_bytes` applies to decoded request bytes when `input.request.is_base64` is `true`

## Impact
The shared contract now explicitly requires a base64 HTTP request whose decoded body exceeds the configured request limit to return the standard `app.too_large` P1 envelope.

## Linear
- THE-343

## Tasks
- [x] THE-343 Pin base64 request guardrail semantics in contract fixtures

## Contract impact
fixture-first

## Validation
- `./scripts/verify-contract-tests.sh`
- `make rubric`

## Release discipline
This PR targets `staging` only. No promotion beyond `staging` is intended until the broader v1.0.0 security-hardening project is complete.
