### PR TITLE
fix(runtime): request-size hardening

### DIFF
--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -35,7 +35,7 @@ from apptheory.errors import (
     status_for_error_code,
 )
 from apptheory.ids import IdGenerator, RealIdGenerator
-from apptheory.request import Request, normalize_request
+from apptheory.request import Request, normalize_request, normalize_request_with_max_bytes
 from apptheory.response import Response, normalize_response
 from apptheory.router import Router
 from apptheory.util import canonicalize_headers, clone_query
@@ -588,7 +588,7 @@ class App:
             return finish(normalize_response(resp))
 
         try:
-            normalized = normalize_request(request)
+            normalized = normalize_request_with_max_bytes(request, self._limits.max_request_bytes)
         except Exception as exc:  # noqa: BLE001
             error_code = exc.code if isinstance(exc, (AppError, AppTheoryError)) else "app.internal"
             return finish(respond_to_error(exc, request, request_id), error_code)

--- a/py/src/apptheory/request.py
+++ b/py/src/apptheory/request.py
@@ -19,6 +19,39 @@ class Request:
 
 
 def normalize_request(req: Request) -> Request:
+    return normalize_request_with_max_bytes(req, 0)
+
+
+def _validated_base64_decoded_length(body: bytes) -> int:
+    if not body:
+        return 0
+    if len(body) % 4 != 0:
+        raise AppError("app.bad_request", "invalid base64")
+
+    pad_start = len(body)
+    pad_len = 0
+    for index, byte in enumerate(body):
+        is_alnum = (65 <= byte <= 90) or (97 <= byte <= 122) or (48 <= byte <= 57)
+        if is_alnum or byte in (43, 47):  # + /
+            if pad_len:
+                raise AppError("app.bad_request", "invalid base64")
+            continue
+        if byte == 61:  # =
+            if pad_start == len(body):
+                pad_start = index
+            pad_len += 1
+            if pad_len > 2:
+                raise AppError("app.bad_request", "invalid base64")
+            continue
+        raise AppError("app.bad_request", "invalid base64")
+
+    if pad_len and len(body) - pad_start > 2:
+        raise AppError("app.bad_request", "invalid base64")
+
+    return (len(body) // 4) * 3 - pad_len
+
+
+def normalize_request_with_max_bytes(req: Request, max_request_bytes: int = 0) -> Request:
     method = str(req.method or "").strip().upper()
     path = normalize_path(req.path)
     query = clone_query(req.query)
@@ -27,10 +60,10 @@ def normalize_request(req: Request) -> Request:
     body = to_bytes(req.body)
     is_base64 = bool(req.is_base64)
     if is_base64:
-        try:
-            body = base64.b64decode(body, validate=True)
-        except Exception:  # noqa: BLE001
-            raise AppError("app.bad_request", "invalid base64") from None
+        decoded_length = _validated_base64_decoded_length(body)
+        if max_request_bytes > 0 and decoded_length > max_request_bytes:
+            raise AppError("app.too_large", "request too large")
+        body = base64.b64decode(body, validate=True)
 
     cookies = parse_cookies(headers.get("cookie", []))
 

--- a/py/tests/test_app.py
+++ b/py/tests/test_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import sys
 import unittest
@@ -28,7 +29,7 @@ from apptheory.app import (  # noqa: E402
     _websocket_management_endpoint,
 )
 from apptheory.errors import AppError, AppTheoryError  # noqa: E402
-from apptheory.request import Request  # noqa: E402
+from apptheory.request import Request, normalize_request_with_max_bytes  # noqa: E402
 from apptheory.response import Response  # noqa: E402
 
 
@@ -149,6 +150,21 @@ class TestApp(unittest.TestCase):
         limited_req.get("/", _ok)
         too_large_req = limited_req.serve(Request(method="POST", path="/", body="ab"))
         self.assertEqual(too_large_req.status, 413)
+        too_large_base64_req = limited_req.serve(
+            Request(
+                method="POST",
+                path="/",
+                body=base64.b64encode(b"ab").decode("ascii"),
+                is_base64=True,
+            )
+        )
+        self.assertEqual(too_large_base64_req.status, 413)
+        with self.assertRaises(AppError) as invalid_base64:
+            normalize_request_with_max_bytes(
+                Request(method="POST", path="/", body="AAAA=AAA", is_base64=True),
+                max_request_bytes=1,
+            )
+        self.assertEqual(invalid_base64.exception.code, "app.bad_request")
 
         limited_resp: App = create_app(tier="p2", limits=Limits(max_response_bytes=1))
 

--- a/runtime/request.go
+++ b/runtime/request.go
@@ -61,26 +61,10 @@ func decodedBase64Len(src []byte) (int, error) {
 	padCount := 0
 
 	for _, b := range src {
-		switch {
-		case b == '\r' || b == '\n':
+		if b == '\r' || b == '\n' {
 			continue
-		case b >= 'A' && b <= 'Z':
-			if padStart >= 0 {
-				return 0, base64.CorruptInputError(cleanLen)
-			}
-		case b >= 'a' && b <= 'z':
-			if padStart >= 0 {
-				return 0, base64.CorruptInputError(cleanLen)
-			}
-		case b >= '0' && b <= '9':
-			if padStart >= 0 {
-				return 0, base64.CorruptInputError(cleanLen)
-			}
-		case b == '+' || b == '/':
-			if padStart >= 0 {
-				return 0, base64.CorruptInputError(cleanLen)
-			}
-		case b == '=':
+		}
+		if b == '=' {
 			if padStart < 0 {
 				padStart = cleanLen
 			}
@@ -88,7 +72,10 @@ func decodedBase64Len(src []byte) (int, error) {
 			if padCount > 2 {
 				return 0, base64.CorruptInputError(cleanLen)
 			}
-		default:
+			cleanLen++
+			continue
+		}
+		if padStart >= 0 || !isBase64AlphabetByte(b) {
 			return 0, base64.CorruptInputError(cleanLen)
 		}
 		cleanLen++
@@ -104,6 +91,14 @@ func decodedBase64Len(src []byte) (int, error) {
 		return 0, base64.CorruptInputError(padStart)
 	}
 	return (cleanLen/4)*3 - padCount, nil
+}
+
+func isBase64AlphabetByte(b byte) bool {
+	return (b >= 'A' && b <= 'Z') ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= '0' && b <= '9') ||
+		b == '+' ||
+		b == '/'
 }
 
 func normalizePath(path string) string {

--- a/runtime/request.go
+++ b/runtime/request.go
@@ -20,6 +20,10 @@ type Request struct {
 }
 
 func normalizeRequest(in Request) (Request, error) {
+	return normalizeRequestWithMaxBytes(in, 0)
+}
+
+func normalizeRequestWithMaxBytes(in Request, maxRequestBytes int) (Request, error) {
 	out := in
 	out.Method = strings.ToUpper(strings.TrimSpace(in.Method))
 	out.Path = normalizePath(in.Path)
@@ -28,6 +32,15 @@ func normalizeRequest(in Request) (Request, error) {
 	out.Headers = canonicalizeHeaders(in.Headers)
 
 	if in.IsBase64 {
+		decodedLen, err := decodedBase64Len(in.Body)
+		if err != nil {
+			return Request{}, &AppError{Code: errorCodeBadRequest, Message: "invalid base64"}
+		}
+		if maxRequestBytes > 0 && decodedLen > maxRequestBytes {
+			out.Cookies = parseCookies(out.Headers["cookie"])
+			out.IsBase64 = in.IsBase64
+			return out, &AppError{Code: errorCodeTooLarge, Message: errorMessageRequestTooLarge}
+		}
 		decoded, err := base64.StdEncoding.DecodeString(string(in.Body))
 		if err != nil {
 			return Request{}, &AppError{Code: errorCodeBadRequest, Message: "invalid base64"}
@@ -40,6 +53,57 @@ func normalizeRequest(in Request) (Request, error) {
 	out.Cookies = parseCookies(out.Headers["cookie"])
 	out.IsBase64 = in.IsBase64
 	return out, nil
+}
+
+func decodedBase64Len(src []byte) (int, error) {
+	cleanLen := 0
+	padStart := -1
+	padCount := 0
+
+	for _, b := range src {
+		switch {
+		case b == '\r' || b == '\n':
+			continue
+		case b >= 'A' && b <= 'Z':
+			if padStart >= 0 {
+				return 0, base64.CorruptInputError(cleanLen)
+			}
+		case b >= 'a' && b <= 'z':
+			if padStart >= 0 {
+				return 0, base64.CorruptInputError(cleanLen)
+			}
+		case b >= '0' && b <= '9':
+			if padStart >= 0 {
+				return 0, base64.CorruptInputError(cleanLen)
+			}
+		case b == '+' || b == '/':
+			if padStart >= 0 {
+				return 0, base64.CorruptInputError(cleanLen)
+			}
+		case b == '=':
+			if padStart < 0 {
+				padStart = cleanLen
+			}
+			padCount++
+			if padCount > 2 {
+				return 0, base64.CorruptInputError(cleanLen)
+			}
+		default:
+			return 0, base64.CorruptInputError(cleanLen)
+		}
+		cleanLen++
+	}
+
+	if cleanLen == 0 {
+		return 0, nil
+	}
+	if cleanLen%4 != 0 {
+		return 0, base64.CorruptInputError(cleanLen)
+	}
+	if padStart >= 0 && cleanLen-padStart > 2 {
+		return 0, base64.CorruptInputError(padStart)
+	}
+	return (cleanLen/4)*3 - padCount, nil
 }
 
 func normalizePath(path string) string {

--- a/runtime/request_test.go
+++ b/runtime/request_test.go
@@ -122,3 +122,53 @@ func TestNormalizeRequest_InvalidBase64ReturnsAppError(t *testing.T) {
 		t.Fatalf("expected code %q, got %q", errorCodeBadRequest, appErr.Code)
 	}
 }
+
+func TestNormalizeRequestWithMaxBytes_RejectsOversizedBase64(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("hello"))
+
+	req, err := normalizeRequestWithMaxBytes(Request{
+		Method:   " post ",
+		Path:     "foo",
+		Headers:  map[string][]string{"Cookie": {"a=b"}},
+		Body:     []byte(encoded),
+		IsBase64: true,
+	}, 4)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var appErr *AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != errorCodeTooLarge {
+		t.Fatalf("expected code %q, got %q", errorCodeTooLarge, appErr.Code)
+	}
+	if req.Method != "POST" || req.Path != "/foo" {
+		t.Fatalf("unexpected normalized request metadata: method=%q path=%q", req.Method, req.Path)
+	}
+	if req.Cookies["a"] != "b" {
+		t.Fatalf("unexpected cookies: %v", req.Cookies)
+	}
+	if len(req.Body) != len(encoded) {
+		t.Fatalf("expected encoded body to remain intact, got len=%d want=%d", len(req.Body), len(encoded))
+	}
+}
+
+func TestNormalizeRequestWithMaxBytes_InvalidBase64StillReturnsBadRequest(t *testing.T) {
+	_, err := normalizeRequestWithMaxBytes(Request{
+		Method:   "GET",
+		Path:     "/",
+		Body:     []byte("AAAA=AAA"),
+		IsBase64: true,
+	}, 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var appErr *AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != errorCodeBadRequest {
+		t.Fatalf("expected code %q, got %q", errorCodeBadRequest, appErr.Code)
+	}
+}

--- a/runtime/serve.go
+++ b/runtime/serve.go
@@ -272,10 +272,14 @@ func (a *App) servePortableCore(ctx context.Context, req Request, enableP2 bool,
 		return preflightResponse(headers)
 	}
 
-	normalized, err := normalizeRequest(req)
+	normalized, err := normalizeRequestWithMaxBytes(req, a.limits.MaxRequestBytes)
 	if err != nil {
 		state.errorCode = errorCodeForError(err)
-		return a.respondToServeError(opts, err, req, state.requestID)
+		errorReq := req
+		if state.errorCode == errorCodeTooLarge {
+			errorReq = normalized
+		}
+		return a.respondToServeError(opts, err, errorReq, state.requestID)
 	}
 
 	state.method = normalized.Method

--- a/runtime/serve.go
+++ b/runtime/serve.go
@@ -275,11 +275,7 @@ func (a *App) servePortableCore(ctx context.Context, req Request, enableP2 bool,
 	normalized, err := normalizeRequestWithMaxBytes(req, a.limits.MaxRequestBytes)
 	if err != nil {
 		state.errorCode = errorCodeForError(err)
-		errorReq := req
-		if state.errorCode == errorCodeTooLarge {
-			errorReq = normalized
-		}
-		return a.respondToServeError(opts, err, errorReq, state.requestID)
+		return a.respondToServeError(opts, err, requestForNormalizeError(req, normalized, state.errorCode), state.requestID)
 	}
 
 	state.method = normalized.Method
@@ -352,6 +348,13 @@ func (a *App) servePortableCore(ctx context.Context, req Request, enableP2 bool,
 	}
 
 	return resp
+}
+
+func requestForNormalizeError(fallback Request, normalized Request, errorCode string) Request {
+	if errorCode == errorCodeTooLarge {
+		return normalized
+	}
+	return fallback
 }
 
 func (a *App) resolvePortableRequestID(headers map[string][]string, opts serveOptions) string {

--- a/runtime/serve_test.go
+++ b/runtime/serve_test.go
@@ -2,6 +2,7 @@ package apptheory
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -154,6 +155,12 @@ func TestServePortable_PolicyAndLimits(t *testing.T) {
 	resp = app.Serve(context.Background(), Request{Method: "GET", Path: "/ok", Body: []byte("xx")})
 	if resp.Status != 413 {
 		t.Fatalf("expected 413 request too large, got %d", resp.Status)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("xx"))
+	resp = app.Serve(context.Background(), Request{Method: "GET", Path: "/ok", Body: []byte(encoded), IsBase64: true})
+	if resp.Status != 413 {
+		t.Fatalf("expected 413 base64 request too large, got %d", resp.Status)
 	}
 
 	app = New(WithTier(TierP2), WithLimits(Limits{MaxResponseBytes: 1}))

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -307,7 +307,7 @@ export class App {
         }
         let normalized;
         try {
-            normalized = normalizeRequest(request);
+            normalized = normalizeRequest(request, this._limits.maxRequestBytes);
         }
         catch (err) {
             const code = errorCodeFrom(err);

--- a/ts/dist/internal/request.d.ts
+++ b/ts/dist/internal/request.d.ts
@@ -9,4 +9,4 @@ export interface NormalizedRequest {
     body: Buffer;
     isBase64: boolean;
 }
-export declare function normalizeRequest(request: Request): NormalizedRequest;
+export declare function normalizeRequest(request: Request, maxRequestBytes?: number): NormalizedRequest;

--- a/ts/dist/internal/request.js
+++ b/ts/dist/internal/request.js
@@ -1,26 +1,26 @@
 import { Buffer } from "node:buffer";
 import { AppError } from "../errors.js";
 import { canonicalizeHeaders, cloneQuery, normalizeMethod, normalizePath, parseCookies, toBuffer, } from "./http.js";
-function isValidBase64String(value) {
+function decodedBase64Length(value) {
     if (value.length === 0)
-        return true;
+        return 0;
     if (value.length % 4 !== 0)
-        return false;
+        return -1;
     if (/[^A-Za-z0-9+/=]/.test(value))
-        return false;
+        return -1;
     const firstPad = value.indexOf("=");
     if (firstPad === -1)
-        return true;
+        return (value.length / 4) * 3;
     const padLen = value.length - firstPad;
     if (padLen > 2)
-        return false;
+        return -1;
     for (let i = firstPad; i < value.length; i += 1) {
         if (value[i] !== "=")
-            return false;
+            return -1;
     }
-    return true;
+    return (value.length / 4) * 3 - padLen;
 }
-export function normalizeRequest(request) {
+export function normalizeRequest(request, maxRequestBytes = 0) {
     const method = normalizeMethod(request.method);
     const path = normalizePath(request.path);
     const query = cloneQuery(request.query);
@@ -30,8 +30,12 @@ export function normalizeRequest(request) {
     let body;
     if (isBase64) {
         const asString = rawBody.toString("utf8");
-        if (!isValidBase64String(asString)) {
+        const decodedLength = decodedBase64Length(asString);
+        if (decodedLength < 0) {
             throw new AppError("app.bad_request", "invalid base64");
+        }
+        if (maxRequestBytes > 0 && decodedLength > maxRequestBytes) {
+            throw new AppError("app.too_large", "request too large");
         }
         body = Buffer.from(asString, "base64");
     }

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -643,7 +643,7 @@ export class App {
 
     let normalized: Context["request"];
     try {
-      normalized = normalizeRequest(request);
+      normalized = normalizeRequest(request, this._limits.maxRequestBytes);
     } catch (err) {
       const code = errorCodeFrom(err);
       return finish(respondToServeError(err, request, requestId), code);

--- a/ts/src/internal/request.ts
+++ b/ts/src/internal/request.ts
@@ -22,23 +22,26 @@ export interface NormalizedRequest {
   isBase64: boolean;
 }
 
-function isValidBase64String(value: string): boolean {
-  if (value.length === 0) return true;
-  if (value.length % 4 !== 0) return false;
-  if (/[^A-Za-z0-9+/=]/.test(value)) return false;
+function decodedBase64Length(value: string): number {
+  if (value.length === 0) return 0;
+  if (value.length % 4 !== 0) return -1;
+  if (/[^A-Za-z0-9+/=]/.test(value)) return -1;
 
   const firstPad = value.indexOf("=");
-  if (firstPad === -1) return true;
+  if (firstPad === -1) return (value.length / 4) * 3;
 
   const padLen = value.length - firstPad;
-  if (padLen > 2) return false;
+  if (padLen > 2) return -1;
   for (let i = firstPad; i < value.length; i += 1) {
-    if (value[i] !== "=") return false;
+    if (value[i] !== "=") return -1;
   }
-  return true;
+  return (value.length / 4) * 3 - padLen;
 }
 
-export function normalizeRequest(request: Request): NormalizedRequest {
+export function normalizeRequest(
+  request: Request,
+  maxRequestBytes = 0,
+): NormalizedRequest {
   const method = normalizeMethod(request.method);
   const path = normalizePath(request.path);
   const query = cloneQuery(request.query);
@@ -49,8 +52,12 @@ export function normalizeRequest(request: Request): NormalizedRequest {
   let body: Buffer;
   if (isBase64) {
     const asString = rawBody.toString("utf8");
-    if (!isValidBase64String(asString)) {
+    const decodedLength = decodedBase64Length(asString);
+    if (decodedLength < 0) {
       throw new AppError("app.bad_request", "invalid base64");
+    }
+    if (maxRequestBytes > 0 && decodedLength > maxRequestBytes) {
+      throw new AppError("app.too_large", "request too large");
     }
     body = Buffer.from(asString, "base64");
   } else {


### PR DESCRIPTION
## Milestone
request-size-hardening — reject oversized base64 requests before full decode allocation across Go, TypeScript, and Python.

## Linear
AppTheory v1.0.0 security-hardening foundation / request-size-hardening

## Tasks
- [x] THE-344 Short-circuit oversized base64 requests in Go before full decode allocation
- [x] THE-347 Short-circuit oversized base64 requests in TypeScript before full decode allocation
- [x] THE-350 Short-circuit oversized base64 requests in Python before full decode allocation

## Contract impact
internal-only

## Validation
Commands run on the final branch tip:
- `go test ./runtime`
- `cd ts && npm run check && npm run build`
- `python -m unittest discover -s py/tests`
- `make test-unit`
- `make rubric`

## Cross-repo notes
none
