### PR TITLE
fix(runtime): stream-response hardening

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -28,7 +28,9 @@ Each fixture is a single JSON object.
 - `setup.limits` (object, optional): guardrails configuration.
   - `max_request_bytes` (number): reject requests over this size with `app.too_large`. When `input.request.is_base64`
     is `true`, this limit applies to the decoded request body bytes.
-  - `max_response_bytes` (number): reject responses over this size with `app.too_large`.
+  - `max_response_bytes` (number): reject responses over this size with `app.too_large`. For streamed responses
+    (`expect.response.chunks`), the already-committed status/headers remain intact and the stream terminates with
+    `expect.response.stream_error_code = "app.too_large"` once the next streamed chunk would exceed the limit.
 - `input.request` (object): request presented to the runtime under test.
 - `input.context` (object, optional): synthetic invocation context (portable subset).
 - `setup.routes[].auth_required` (boolean, optional): whether the route requires auth.

--- a/contract-tests/fixtures/m14/streaming-response-too-large.json
+++ b/contract-tests/fixtures/m14/streaming-response-too-large.json
@@ -1,0 +1,36 @@
+{
+  "id": "m14.streaming.response_too_large",
+  "tier": "m14",
+  "name": "Streaming: max_response_bytes terminates the stream with app.too_large",
+  "setup": {
+    "limits": { "max_response_bytes": 5 },
+    "routes": [
+      { "method": "GET", "path": "/html-stream", "handler": "html_stream_two_chunks" }
+    ]
+  },
+  "input": {
+    "request": {
+      "method": "GET",
+      "path": "/html-stream",
+      "query": {},
+      "headers": {},
+      "body": { "encoding": "utf8", "value": "" },
+      "is_base64": false
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": ["text/html; charset=utf-8"],
+        "x-request-id": ["req_test_123"]
+      },
+      "cookies": [],
+      "chunks": [
+        { "encoding": "utf8", "value": "<h1>" }
+      ],
+      "stream_error_code": "app.too_large",
+      "is_base64": false
+    }
+  }
+}

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -702,7 +702,6 @@ class App:
         resp = normalize_response(resp)
         if (
             self._limits.max_response_bytes > 0
-            and resp.body_stream is None
             and len(resp.body) > self._limits.max_response_bytes
         ):
             if error_responder is not None:
@@ -717,6 +716,13 @@ class App:
                     request_id=request_id,
                 ),
                 "app.too_large",
+            )
+
+        if self._limits.max_response_bytes > 0 and resp.body_stream is not None:
+            resp.body_stream = _limit_response_stream(
+                resp.body_stream,
+                len(resp.body),
+                self._limits.max_response_bytes,
             )
 
         return finish(resp)
@@ -1751,3 +1757,21 @@ def _default_policy_message(code: str) -> str:
             return "overloaded"
         case _:
             return "internal error"
+
+
+def _limit_response_stream(body_stream: Any, initial_bytes: int, max_response_bytes: int):
+    emitted = max(0, int(initial_bytes or 0))
+
+    def gen():
+        nonlocal emitted
+        for chunk in body_stream:
+            data = bytes(chunk or b"")
+            if not data:
+                yield data
+                continue
+            if emitted + len(data) > max_response_bytes:
+                raise AppError("app.too_large", "response too large")
+            emitted += len(data)
+            yield data
+
+    return gen()

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -700,10 +700,7 @@ class App:
             )
 
         resp = normalize_response(resp)
-        if (
-            self._limits.max_response_bytes > 0
-            and len(resp.body) > self._limits.max_response_bytes
-        ):
+        if self._limits.max_response_bytes > 0 and len(resp.body) > self._limits.max_response_bytes:
             if error_responder is not None:
                 return finish(
                     respond_to_error(AppError("app.too_large", "response too large"), normalized, request_id),

--- a/py/tests/test_app.py
+++ b/py/tests/test_app.py
@@ -31,6 +31,7 @@ from apptheory.app import (  # noqa: E402
 from apptheory.errors import AppError, AppTheoryError  # noqa: E402
 from apptheory.request import Request, normalize_request_with_max_bytes  # noqa: E402
 from apptheory.response import Response  # noqa: E402
+from apptheory.testkit import create_test_env  # noqa: E402
 
 
 def _ok(_ctx) -> Response:
@@ -174,6 +175,28 @@ class TestApp(unittest.TestCase):
         limited_resp.get("/", big)
         too_large_resp = limited_resp.serve(Request(method="GET", path="/", body=""))
         self.assertEqual(too_large_resp.status, 413)
+
+        limited_stream_resp: App = create_app(tier="p2", limits=Limits(max_response_bytes=5))
+        limited_stream_resp.get(
+            "/stream",
+            lambda _ctx: Response(
+                status=200,
+                headers={"content-type": ["text/html; charset=utf-8"]},
+                cookies=[],
+                body=b"",
+                is_base64=False,
+                body_stream=iter([b"<h1>", b"Hello</h1>"]),
+            ),
+        )
+        stream_env = create_test_env()
+        stream_out = stream_env.invoke_streaming(
+            limited_stream_resp,
+            Request(method="GET", path="/stream", body=""),
+        )
+        self.assertEqual(stream_out.status, 200)
+        self.assertEqual(stream_out.body, b"<h1>")
+        self.assertEqual(stream_out.chunks, [b"<h1>"])
+        self.assertEqual(stream_out.stream_error_code, "app.too_large")
 
         bad_norm = limited_resp.serve(Request(method="GET", path="/", body={"bad": True}))
         self.assertEqual(bad_norm.status, 500)

--- a/runtime/response_limits.go
+++ b/runtime/response_limits.go
@@ -15,7 +15,7 @@ func limitStreamedResponse(resp Response, maxBytes int) Response {
 		emitted: len(resp.Body),
 	}
 	if resp.BodyReader != nil {
-		resp.BodyReader = &limitedResponseReader{reader: resp.BodyReader, limiter: limiter}
+		resp.BodyReader = limitBodyReader(resp.BodyReader, limiter)
 	}
 	if resp.BodyStream != nil {
 		resp.BodyStream = limitBodyStream(resp.BodyStream, limiter)
@@ -46,21 +46,6 @@ func (l *responseSizeLimiter) allowChunk(size int) bool {
 	}
 	l.emitted += size
 	return true
-}
-
-func (l *responseSizeLimiter) remaining() int {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	if l.tripped {
-		return 0
-	}
-	remaining := l.max - l.emitted
-	if remaining <= 0 {
-		l.tripped = true
-		return 0
-	}
-	return remaining
 }
 
 func (l *responseSizeLimiter) consumeReader(size int) (int, bool) {
@@ -115,52 +100,67 @@ func limitBodyStream(stream BodyStream, limiter *responseSizeLimiter) BodyStream
 	return out
 }
 
-type limitedResponseReader struct {
-	reader     io.Reader
-	limiter    *responseSizeLimiter
-	pendingErr error
+func limitBodyReader(reader io.Reader, limiter *responseSizeLimiter) io.Reader {
+	if reader == nil || limiter == nil {
+		return reader
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := reader.Read(buf)
+			if writeLimitedReaderChunk(pw, limiter, buf[:n]) {
+				return
+			}
+			if err == nil {
+				continue
+			}
+			if err == io.EOF {
+				closeResponseLimitPipeWriter(pw)
+				return
+			}
+			closeResponseLimitPipeWriterWithError(pw, err)
+			return
+		}
+	}()
+
+	return pr
 }
 
-func (r *limitedResponseReader) Read(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	if r.pendingErr != nil {
-		err := r.pendingErr
-		r.pendingErr = nil
-		return 0, err
+func writeLimitedReaderChunk(pw *io.PipeWriter, limiter *responseSizeLimiter, chunk []byte) bool {
+	if len(chunk) == 0 {
+		return false
 	}
 
-	remaining := r.limiter.remaining()
-	if remaining <= 0 {
-		return 0, r.limiter.limitErr()
-	}
-
-	readSize := len(p)
-	if readSize > remaining {
-		readSize = remaining + 1
-	}
-
-	target := p
-	if readSize != len(p) {
-		target = make([]byte, readSize)
-	}
-
-	n, err := r.reader.Read(target)
-	if n == 0 {
-		return 0, err
-	}
-
-	emit, overflow := r.limiter.consumeReader(n)
-	copy(p, target[:emit])
-	if overflow {
-		r.pendingErr = r.limiter.limitErr()
-		if emit > 0 {
-			return emit, nil
+	emit, overflow := limiter.consumeReader(len(chunk))
+	if emit > 0 {
+		if _, err := pw.Write(chunk[:emit]); err != nil {
+			return true
 		}
-		err := r.pendingErr
-		r.pendingErr = nil
-		return 0, err
 	}
-	return emit, err
+	if !overflow {
+		return false
+	}
+
+	closeResponseLimitPipeWriterWithError(pw, limiter.limitErr())
+	return true
+}
+
+func closeResponseLimitPipeWriter(pw *io.PipeWriter) {
+	if pw == nil {
+		return
+	}
+	if err := pw.Close(); err != nil {
+		return
+	}
+}
+
+func closeResponseLimitPipeWriterWithError(pw *io.PipeWriter, err error) {
+	if pw == nil {
+		return
+	}
+	if closeErr := pw.CloseWithError(err); closeErr != nil {
+		return
+	}
 }

--- a/runtime/response_limits.go
+++ b/runtime/response_limits.go
@@ -1,0 +1,166 @@
+package apptheory
+
+import (
+	"io"
+	"sync"
+)
+
+func limitStreamedResponse(resp Response, maxBytes int) Response {
+	if maxBytes <= 0 || (resp.BodyReader == nil && resp.BodyStream == nil) {
+		return resp
+	}
+
+	limiter := &responseSizeLimiter{
+		max:     maxBytes,
+		emitted: len(resp.Body),
+	}
+	if resp.BodyReader != nil {
+		resp.BodyReader = &limitedResponseReader{reader: resp.BodyReader, limiter: limiter}
+	}
+	if resp.BodyStream != nil {
+		resp.BodyStream = limitBodyStream(resp.BodyStream, limiter)
+	}
+	return resp
+}
+
+type responseSizeLimiter struct {
+	max     int
+	emitted int
+	tripped bool
+	mu      sync.Mutex
+}
+
+func (l *responseSizeLimiter) allowChunk(size int) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.tripped {
+		return false
+	}
+	if size <= 0 {
+		return true
+	}
+	if l.emitted+size > l.max {
+		l.tripped = true
+		return false
+	}
+	l.emitted += size
+	return true
+}
+
+func (l *responseSizeLimiter) remaining() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.tripped {
+		return 0
+	}
+	remaining := l.max - l.emitted
+	if remaining <= 0 {
+		l.tripped = true
+		return 0
+	}
+	return remaining
+}
+
+func (l *responseSizeLimiter) consumeReader(size int) (int, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.tripped {
+		return 0, true
+	}
+	remaining := l.max - l.emitted
+	if remaining <= 0 {
+		l.tripped = true
+		return 0, true
+	}
+	if size > remaining {
+		l.emitted = l.max
+		l.tripped = true
+		return remaining, true
+	}
+	l.emitted += size
+	return size, false
+}
+
+func (l *responseSizeLimiter) limitErr() error {
+	return &AppError{Code: errorCodeTooLarge, Message: errorMessageResponseTooLarge}
+}
+
+func limitBodyStream(stream BodyStream, limiter *responseSizeLimiter) BodyStream {
+	if stream == nil || limiter == nil {
+		return stream
+	}
+
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range stream {
+			if chunk.Err != nil {
+				out <- chunk
+				return
+			}
+			if len(chunk.Bytes) == 0 {
+				out <- StreamChunk{Bytes: []byte{}}
+				continue
+			}
+			if !limiter.allowChunk(len(chunk.Bytes)) {
+				out <- StreamChunk{Err: limiter.limitErr()}
+				return
+			}
+			out <- StreamChunk{Bytes: append([]byte(nil), chunk.Bytes...)}
+		}
+	}()
+	return out
+}
+
+type limitedResponseReader struct {
+	reader     io.Reader
+	limiter    *responseSizeLimiter
+	pendingErr error
+}
+
+func (r *limitedResponseReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.pendingErr != nil {
+		err := r.pendingErr
+		r.pendingErr = nil
+		return 0, err
+	}
+
+	remaining := r.limiter.remaining()
+	if remaining <= 0 {
+		return 0, r.limiter.limitErr()
+	}
+
+	readSize := len(p)
+	if readSize > remaining {
+		readSize = remaining + 1
+	}
+
+	target := p
+	if readSize != len(p) {
+		target = make([]byte, readSize)
+	}
+
+	n, err := r.reader.Read(target)
+	if n == 0 {
+		return 0, err
+	}
+
+	emit, overflow := r.limiter.consumeReader(n)
+	copy(p, target[:emit])
+	if overflow {
+		r.pendingErr = r.limiter.limitErr()
+		if emit > 0 {
+			return emit, nil
+		}
+		err := r.pendingErr
+		r.pendingErr = nil
+		return 0, err
+	}
+	return emit, err
+}

--- a/runtime/response_limits_test.go
+++ b/runtime/response_limits_test.go
@@ -1,0 +1,76 @@
+package apptheory
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestServePortable_MaxResponseBytesTerminatesBodyStreamLate(t *testing.T) {
+	app := New(
+		WithTier(TierP1),
+		WithIDGenerator(fixedIDGenerator("req_1")),
+		WithLimits(Limits{MaxResponseBytes: 5}),
+	)
+	app.Get("/html-stream", func(_ *Context) (*Response, error) {
+		return HTMLStream(200, StreamBytes([]byte("<h1>"), []byte("Hello</h1>"))), nil
+	})
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/html-stream"})
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+	if got := resp.Headers["x-request-id"]; len(got) != 1 || got[0] != "req_1" {
+		t.Fatalf("unexpected request id header: %v", got)
+	}
+
+	chunks, body, err := CaptureBodyStream(context.Background(), resp.BodyStream)
+	if err == nil {
+		t.Fatal("expected stream error")
+	}
+	var appErr *AppError
+	if !errors.As(err, &appErr) || appErr.Code != errorCodeTooLarge {
+		t.Fatalf("expected app.too_large, got %v", err)
+	}
+	if len(chunks) != 1 || string(chunks[0]) != "<h1>" {
+		t.Fatalf("unexpected chunks: %q", chunks)
+	}
+	if string(body) != "<h1>" {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+}
+
+func TestServePortable_MaxResponseBytesTerminatesBodyReaderLate(t *testing.T) {
+	app := New(
+		WithTier(TierP1),
+		WithIDGenerator(fixedIDGenerator("req_1")),
+		WithLimits(Limits{MaxResponseBytes: 5}),
+	)
+	app.Get("/reader-stream", func(_ *Context) (*Response, error) {
+		return &Response{
+			Status: 200,
+			Headers: map[string][]string{
+				"content-type": {"text/plain; charset=utf-8"},
+			},
+			BodyReader: bytes.NewReader([]byte("abcdef")),
+		}, nil
+	})
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/reader-stream"})
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+	body, err := io.ReadAll(resp.BodyReader)
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+	var appErr *AppError
+	if !errors.As(err, &appErr) || appErr.Code != errorCodeTooLarge {
+		t.Fatalf("expected app.too_large, got %v", err)
+	}
+	if string(body) != "abcde" {
+		t.Fatalf("unexpected limited reader body: %q", string(body))
+	}
+}

--- a/runtime/serve.go
+++ b/runtime/serve.go
@@ -346,6 +346,7 @@ func (a *App) servePortableCore(ctx context.Context, req Request, enableP2 bool,
 		state.errorCode = errorCodeTooLarge
 		return a.respondToServeError(opts, &AppError{Code: errorCodeTooLarge, Message: errorMessageResponseTooLarge}, normalized, state.requestID)
 	}
+	resp = limitStreamedResponse(resp, a.limits.MaxResponseBytes)
 
 	return resp
 }

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -8,7 +8,7 @@ import { applyAppSyncContextValues, appSyncErrorResponse, appSyncPayloadFromResp
 import { albTargetGroupResponseFromResponse, apigatewayProxyResponseFromResponse, apigatewayV2ResponseFromResponse, lambdaFunctionURLResponseFromResponse, requestFromALBTargetGroup, requestFromAPIGatewayProxy, requestFromAPIGatewayV2, requestFromLambdaFunctionURL, requestFromWebSocketEvent, } from "./internal/aws-http.js";
 import { serveLambdaFunctionURLStreaming, } from "./internal/aws-lambda-streaming.js";
 import { dynamoDBTableNameFromStreamArn, eventBridgeRuleNameFromArn, kinesisStreamNameFromArn, snsTopicNameFromArn, sqsQueueNameFromArn, webSocketManagementEndpoint, } from "./internal/aws-names.js";
-import { canonicalizeHeaders, cloneQuery, firstHeaderValue, normalizeMethod, normalizePath, } from "./internal/http.js";
+import { canonicalizeHeaders, cloneQuery, firstHeaderValue, normalizeBodyStream, normalizeMethod, normalizePath, } from "./internal/http.js";
 import { normalizeRequest } from "./internal/request.js";
 import { errorResponse, errorResponseWithFormat, errorResponseWithRequestId, errorResponseWithRequestIdAndFormat, normalizeResponse, responseForError, responseForErrorWithFormat, responseForErrorWithRequestId, responseForErrorWithRequestIdAndFormat, } from "./internal/response.js";
 import { Router } from "./internal/router.js";
@@ -406,11 +406,17 @@ export class App {
             return finish(respondToServeError(err, normalized, requestId), code);
         }
         if (this._limits.maxResponseBytes > 0 &&
-            Buffer.from(resp.body).length > this._limits.maxResponseBytes) {
+            resp.body.length > this._limits.maxResponseBytes) {
             if (typeof contextOptions?.errorResponder === "function") {
                 return finish(respondToServeError(new AppError("app.too_large", "response too large"), normalized, requestId), "app.too_large");
             }
             return finish(this._httpErrorResponseWithRequestId("app.too_large", "response too large", {}, requestId), "app.too_large");
+        }
+        if (this._limits.maxResponseBytes > 0 && resp.bodyStream) {
+            resp = {
+                ...resp,
+                bodyStream: limitResponseBodyStream(resp.bodyStream, resp.body.length, this._limits.maxResponseBytes),
+            };
         }
         return finish(resp, "");
     }
@@ -1032,6 +1038,23 @@ function defaultPolicyMessage(code) {
         default:
             return "internal error";
     }
+}
+function limitResponseBodyStream(bodyStream, initialBytes, maxResponseBytes) {
+    return (async function* () {
+        let emitted = Math.max(0, Number(initialBytes) || 0);
+        for await (const chunk of normalizeBodyStream(bodyStream)) {
+            const bytes = Buffer.from(chunk ?? []);
+            if (bytes.length === 0) {
+                yield bytes;
+                continue;
+            }
+            if (emitted + bytes.length > maxResponseBytes) {
+                throw new AppError("app.too_large", "response too large");
+            }
+            emitted += bytes.length;
+            yield bytes;
+        }
+    })();
 }
 function extractRemainingMs(ctx) {
     if (ctx && typeof ctx === "object") {

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -77,6 +77,7 @@ import {
   canonicalizeHeaders,
   cloneQuery,
   firstHeaderValue,
+  normalizeBodyStream,
   normalizeMethod,
   normalizePath,
 } from "./internal/http.js";
@@ -94,7 +95,7 @@ import {
 } from "./internal/response.js";
 import { Router } from "./internal/router.js";
 import { vary } from "./response.js";
-import type { Headers, Query, Request, Response } from "./types.js";
+import type { BodyStream, Headers, Query, Request, Response } from "./types.js";
 import { WebSocketManagementClient } from "./websocket-management.js";
 
 export type Tier = "p0" | "p1" | "p2";
@@ -823,7 +824,7 @@ export class App {
 
     if (
       this._limits.maxResponseBytes > 0 &&
-      Buffer.from(resp.body).length > this._limits.maxResponseBytes
+      resp.body.length > this._limits.maxResponseBytes
     ) {
       if (typeof contextOptions?.errorResponder === "function") {
         return finish(
@@ -844,6 +845,17 @@ export class App {
         ),
         "app.too_large",
       );
+    }
+
+    if (this._limits.maxResponseBytes > 0 && resp.bodyStream) {
+      resp = {
+        ...resp,
+        bodyStream: limitResponseBodyStream(
+          resp.bodyStream,
+          resp.body.length,
+          this._limits.maxResponseBytes,
+        ),
+      };
     }
 
     return finish(resp, "");
@@ -1675,6 +1687,28 @@ function defaultPolicyMessage(code: string): string {
     default:
       return "internal error";
   }
+}
+
+function limitResponseBodyStream(
+  bodyStream: BodyStream,
+  initialBytes: number,
+  maxResponseBytes: number,
+): AsyncIterable<Uint8Array> {
+  return (async function* () {
+    let emitted = Math.max(0, Number(initialBytes) || 0);
+    for await (const chunk of normalizeBodyStream(bodyStream)) {
+      const bytes = Buffer.from(chunk ?? []);
+      if (bytes.length === 0) {
+        yield bytes;
+        continue;
+      }
+      if (emitted + bytes.length > maxResponseBytes) {
+        throw new AppError("app.too_large", "response too large");
+      }
+      emitted += bytes.length;
+      yield bytes;
+    }
+  })();
 }
 
 function extractRemainingMs(ctx: unknown): number {


### PR DESCRIPTION
## Milestone
stream-response-contract + stream-response-hardening — define streamed `max_response_bytes` semantics and enforce them across Go, TypeScript, and Python.

## Linear
AppTheory v1.0.0 security-hardening foundation / stream-response-contract + stream-response-hardening

## Tasks
- [x] THE-345 Specify streamed response size limits in contract fixtures
- [x] THE-348 Enforce streamed response size limits in Go
- [x] THE-349 Enforce streamed response size limits in TypeScript
- [x] THE-351 Enforce streamed response size limits in Python and close parity

## Contract impact
fixture-first

## Validation
Commands run on the final branch tip:
- `go test ./runtime`
- `cd ts && npm run check && npm run build`
- `python -m unittest discover -s py/tests`
- `./scripts/verify-contract-tests.sh`
- `make test-unit`
- `make rubric`

## Cross-repo notes
Combined PR because the fixture-only milestone would knowingly redline `staging` until the runtime implementations landed.
