### PR TITLE
fix(rate-limit): identifier hygiene hardening

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -191,6 +191,15 @@ The `limited` feature set provides DynamoDB-backed cross-instance rate limiting.
 - TypeScript: exports in `api-snapshots/ts.txt` including `DynamoRateLimiter`, `FixedWindowStrategy`, `SlidingWindowStrategy`, and `MultiWindowStrategy`
 - Python: exports in `api-snapshots/py.txt` under `apptheory.limited`
 
+Go runtime note:
+
+- `runtime.RateLimitMiddleware(...)` hashes default credential-derived identifiers before they reach limiter backends:
+  - `x-api-key` → `api_key:sha256:<hex>`
+  - `Authorization: Bearer ...` → `bearer:sha256:<hex>`
+- `AuthIdentity`, `TenantID`, and explicit `ExtractIdentifier` overrides are unchanged.
+- This avoids storing raw credentials in rate-limit tables, but it also changes observed key values and resets any
+  existing credential-backed buckets on first deploy.
+
 ### Sanitization
 
 Safe logging helpers are exported in all three runtimes:

--- a/docs/migration/from-lift.md
+++ b/docs/migration/from-lift.md
@@ -462,6 +462,10 @@ Planned:
 - Service builds and passes its unit/integration tests.
 - End-to-end HTTP behavior matches expected client contracts (error codes/envelopes, CORS/auth behavior).
 - Rate limiting behavior matches `limited` semantics where used.
+- If your Go HTTP service relied on raw API keys or Bearer tokens appearing in rate-limit tables or dashboards,
+  update those expectations before cutover. AppTheory’s default `RateLimitMiddleware(...)` now hashes
+  credential-derived identifiers (`api_key:sha256:...` / `bearer:sha256:...`), which intentionally resets those
+  buckets and changes the observable identifier values.
 - Deploy templates updated (CDK/examples as needed).
 
 ## Representative Migration (G4)

--- a/docs/migration/v1-security.md
+++ b/docs/migration/v1-security.md
@@ -29,3 +29,29 @@ Why this changed:
 
 - Accepting arbitrary Bearer tokens when no validator was configured was not fail-closed.
 - Deriving protected-resource metadata from request headers trusted attacker-influenced inputs in proxy setups.
+
+## Go rate-limit middleware now hashes credential-derived identifiers by default
+
+Affected surface:
+
+- `runtime.RateLimitMiddleware(...)` when you rely on the default `ExtractIdentifier`
+
+What changed:
+
+- The Go runtime no longer stores raw credential material as the default limiter identifier.
+- Requests identified by `x-api-key` now use `api_key:sha256:<hex>`.
+- Requests identified by `Authorization: Bearer ...` now use `bearer:sha256:<hex>`.
+- `AuthIdentity`, `TenantID`, and explicit `ExtractIdentifier` overrides are unchanged.
+
+What you need to do:
+
+1. Expect a one-time bucket reset for any deployment that previously keyed limits directly on API keys or Bearer tokens.
+2. Update dashboards, operational tooling, or table inspection workflows that expected raw credential values in limiter
+   keys.
+3. If you need a different identifier shape, provide an explicit `ExtractIdentifier` instead of depending on the
+   default.
+
+Why this changed:
+
+- Raw API keys and Bearer tokens should not be stored in rate-limit tables by default.
+- Hashing keeps default limiter behavior deterministic while reducing credential exposure in storage and diagnostics.

--- a/examples/migration/rate-limited-http/README.md
+++ b/examples/migration/rate-limited-http/README.md
@@ -25,6 +25,22 @@ The goal is to demonstrate an **end-to-end migration** of rate limiting to AppTh
 3. Ensure the rate limit table name is configured once (recommended via env):
    - `APPTHEORY_RATE_LIMIT_TABLE_NAME=rate-limits` (default is `rate-limits`)
 
+## v1 security note
+
+The Go runtime’s default `RateLimitMiddleware(...)` identifier extraction now hashes credential-derived identifiers
+before they reach the limiter backend:
+
+- `x-api-key` → `api_key:sha256:<hex>`
+- `Authorization: Bearer ...` → `bearer:sha256:<hex>`
+
+That means:
+
+- raw credentials are no longer stored in rate-limit keys or Dynamo rows by default
+- any existing credential-backed buckets reset on first deploy of the new default
+- dashboards or operational tooling that previously inspected raw identifier values must be updated
+
+If your service needs a different key shape, set `ExtractIdentifier` explicitly instead of relying on the default.
+
 ## Running (optional)
 
 This is a minimal demo server; it requires AWS credentials unless you point TableTheory at DynamoDB Local.
@@ -44,4 +60,3 @@ Then request:
 ```bash
 curl -i http://localhost:8080/hello
 ```
-

--- a/runtime/rate_limit_middleware.go
+++ b/runtime/rate_limit_middleware.go
@@ -12,6 +12,8 @@ import (
 // RateLimitDecisionKey is the Context key used by RateLimitMiddleware to store the last LimitDecision.
 const RateLimitDecisionKey = "rate_limit_decision"
 
+const anonymousRateLimitIdentifier = "anonymous"
+
 type RateLimitConfig struct {
 	// Limiter is required. If nil, RateLimitMiddleware is a no-op.
 	Limiter limited.RateLimiter
@@ -119,7 +121,7 @@ func checkRateLimit(ctx context.Context, limiter limited.RateLimiter, key limite
 
 func defaultRateLimitIdentifier(ctx *Context) string {
 	if ctx == nil {
-		return "anonymous"
+		return anonymousRateLimitIdentifier
 	}
 
 	if apiKey := firstHeaderValue(ctx.Request.Headers, "x-api-key"); apiKey != "" {
@@ -141,7 +143,7 @@ func defaultRateLimitIdentifier(ctx *Context) string {
 		return tenant
 	}
 
-	return "anonymous"
+	return anonymousRateLimitIdentifier
 }
 
 func hashRateLimitCredentialIdentifier(kind, raw string) string {

--- a/runtime/rate_limit_middleware.go
+++ b/runtime/rate_limit_middleware.go
@@ -2,6 +2,8 @@ package apptheory
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 
 	"github.com/theory-cloud/apptheory/pkg/limited"
@@ -121,13 +123,13 @@ func defaultRateLimitIdentifier(ctx *Context) string {
 	}
 
 	if apiKey := firstHeaderValue(ctx.Request.Headers, "x-api-key"); apiKey != "" {
-		return apiKey
+		return hashRateLimitCredentialIdentifier("api_key", apiKey)
 	}
 
 	auth := firstHeaderValue(ctx.Request.Headers, "authorization")
 	if strings.HasPrefix(auth, "Bearer ") {
 		if token := strings.TrimSpace(strings.TrimPrefix(auth, "Bearer ")); token != "" {
-			return token
+			return hashRateLimitCredentialIdentifier("bearer", token)
 		}
 	}
 
@@ -140,6 +142,17 @@ func defaultRateLimitIdentifier(ctx *Context) string {
 	}
 
 	return "anonymous"
+}
+
+func hashRateLimitCredentialIdentifier(kind, raw string) string {
+	kind = strings.TrimSpace(kind)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	sum := sha256.Sum256([]byte(kind + ":" + raw))
+	return kind + ":sha256:" + hex.EncodeToString(sum[:])
 }
 
 func defaultRateLimitResource(ctx *Context) string {

--- a/runtime/rate_limit_middleware_test.go
+++ b/runtime/rate_limit_middleware_test.go
@@ -2,6 +2,7 @@ package apptheory
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,9 +14,11 @@ type stubRateLimiter struct {
 	err      error
 
 	recordCalls int
+	lastKey     limited.RateLimitKey
 }
 
-func (s *stubRateLimiter) CheckLimit(_ context.Context, _ limited.RateLimitKey) (*limited.LimitDecision, error) {
+func (s *stubRateLimiter) CheckLimit(_ context.Context, key limited.RateLimitKey) (*limited.LimitDecision, error) {
+	s.lastKey = key
 	return s.decision, s.err
 }
 
@@ -95,5 +98,81 @@ func TestRateLimitMiddleware_FailOpenOnLimiterError(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("expected handler to be called")
+	}
+}
+
+func TestDefaultRateLimitIdentifier_HashesCredentialHeaders(t *testing.T) {
+	apiKeyCtx := &Context{
+		Request: Request{
+			Headers: map[string][]string{
+				"x-api-key": {"k_secret"},
+			},
+		},
+	}
+	if got := defaultRateLimitIdentifier(apiKeyCtx); got == "k_secret" {
+		t.Fatalf("expected api key identifier to be hashed, got raw value")
+	} else if want := hashRateLimitCredentialIdentifier("api_key", "k_secret"); got != want {
+		t.Fatalf("expected hashed api key identifier %q, got %q", want, got)
+	}
+
+	bearerCtx := &Context{
+		Request: Request{
+			Headers: map[string][]string{
+				"authorization": {"Bearer tok_secret"},
+			},
+		},
+	}
+	if got := defaultRateLimitIdentifier(bearerCtx); got == "tok_secret" {
+		t.Fatalf("expected bearer identifier to be hashed, got raw value")
+	} else if want := hashRateLimitCredentialIdentifier("bearer", "tok_secret"); got != want {
+		t.Fatalf("expected hashed bearer identifier %q, got %q", want, got)
+	}
+}
+
+func TestDefaultRateLimitIdentifier_FallbacksRemainStable(t *testing.T) {
+	authIdentityCtx := &Context{AuthIdentity: "user_123"}
+	if got := defaultRateLimitIdentifier(authIdentityCtx); got != "user_123" {
+		t.Fatalf("expected auth identity fallback, got %q", got)
+	}
+
+	tenantCtx := &Context{TenantID: "tenant_123"}
+	if got := defaultRateLimitIdentifier(tenantCtx); got != "tenant_123" {
+		t.Fatalf("expected tenant fallback, got %q", got)
+	}
+
+	if got := defaultRateLimitIdentifier(&Context{}); got != "anonymous" {
+		t.Fatalf("expected anonymous fallback, got %q", got)
+	}
+}
+
+func TestRateLimitMiddleware_DefaultIdentifierStoredInLimiterIsHashed(t *testing.T) {
+	limiter := &stubRateLimiter{
+		decision: &limited.LimitDecision{Allowed: true, CurrentCount: 0, Limit: 10, ResetsAt: time.Now()},
+	}
+
+	app := New(WithTier(TierP0))
+	app.Use(RateLimitMiddleware(RateLimitConfig{Limiter: limiter}))
+	app.Get("/ok", func(_ *Context) (*Response, error) {
+		return Text(200, "ok"), nil
+	})
+
+	resp := app.Serve(context.Background(), Request{
+		Method: "GET",
+		Path:   "/ok",
+		Headers: map[string][]string{
+			"x-api-key": {"k_secret"},
+		},
+	})
+	if resp.Status != 200 {
+		t.Fatalf("expected status 200, got %d", resp.Status)
+	}
+	if limiter.lastKey.Identifier == "" {
+		t.Fatalf("expected limiter identifier to be recorded")
+	}
+	if strings.Contains(limiter.lastKey.Identifier, "k_secret") {
+		t.Fatalf("expected hashed limiter identifier, got %q", limiter.lastKey.Identifier)
+	}
+	if want := hashRateLimitCredentialIdentifier("api_key", "k_secret"); limiter.lastKey.Identifier != want {
+		t.Fatalf("expected hashed limiter identifier %q, got %q", want, limiter.lastKey.Identifier)
 	}
 }


### PR DESCRIPTION
## Milestone
rate-limit-identifier-hygiene — hash default credential-derived rate-limit identifiers and document the migration impact.

## Linear
AppTheory v1.0.0 security-hardening foundation / rate-limit-identifier-hygiene

## Tasks
- [x] THE-346 Hash default Go rate-limit middleware identifiers and document the migration impact

## Contract impact
internal-only

## Validation
Commands run on the final branch tip:
- `go test ./runtime`
- `make test-unit`
- `make rubric`

## Cross-repo notes
None.
