### PR TITLE
fix(runtime): mask AppSync internal exceptions

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -38,6 +38,8 @@ Each fixture is a single JSON object.
   - `chunks` (array, optional): expected streamed response chunks (when using the streaming test harness).
   - `stream_error_code` (string, optional): expected error code when an error occurs after streaming begins.
 - `expect.output_json` (any, optional): expected output value for non-HTTP fixtures (for example: `m1`).
+  - For AppSync fixtures, portable AppTheory/AppError payloads retain their intended messages, while non-portable
+    exceptions must surface the generic `internal error` message.
 - `expect.error` (object, optional): expected thrown error (for example: fail-closed `m1` routing).
   - `message` (string): error message to match.
 - `expect.logs` (array, optional): expected structured log records (P2 portable envelope).

--- a/contract-tests/fixtures/p2/appsync-error-internal-masked.json
+++ b/contract-tests/fixtures/p2/appsync-error-internal-masked.json
@@ -1,0 +1,33 @@
+{
+  "id": "p2.appsync.error_internal_masked",
+  "tier": "p2",
+  "name": "AppSync non-portable errors are masked as internal error",
+  "setup": {
+    "routes": [
+      { "method": "POST", "path": "/createThing", "handler": "unexpected_error" }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "appsync",
+      "event": {
+        "arguments": {
+          "id": "thing_123"
+        },
+        "info": {
+          "fieldName": "createThing",
+          "parentTypeName": "Mutation"
+        }
+      }
+    }
+  },
+  "expect": {
+    "output_json": {
+      "pay_theory_error": true,
+      "error_message": "internal error",
+      "error_type": "SYSTEM_ERROR",
+      "error_data": {},
+      "error_info": {}
+    }
+  }
+}

--- a/contract-tests/runners/go/apptheory_p0.go
+++ b/contract-tests/runners/go/apptheory_p0.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -301,6 +302,9 @@ var builtInAppTheoryHandlers = map[string]apptheory.Handler{
 	},
 	"panic": func(_ *apptheory.Context) (*apptheory.Response, error) {
 		panic("boom")
+	},
+	"unexpected_error": func(_ *apptheory.Context) (*apptheory.Response, error) {
+		return nil, errors.New("boom")
 	},
 	"binary_body": func(_ *apptheory.Context) (*apptheory.Response, error) {
 		return apptheory.Binary(200, []byte{0x00, 0x01, 0x02}, "application/octet-stream"), nil

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -864,6 +864,12 @@ def _built_in_apptheory_handler(runtime: Any, name: str):
 
         return handler
 
+    if name == "unexpected_error":
+        def handler(_ctx):
+            raise RuntimeError("boom")
+
+        return handler
+
     if name == "binary_body":
         return lambda _ctx: runtime.binary(200, bytes([0, 1, 2]), content_type="application/octet-stream")
 

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -1962,6 +1962,10 @@ function builtInAppTheoryHandler(runtime, name) {
       return () => {
         throw new Error("boom");
       };
+    case "unexpected_error":
+      return () => {
+        throw new Error("boom");
+      };
     case "binary_body":
       return () => runtime.binary(200, Buffer.from([0x00, 0x01, 0x02]), "application/octet-stream");
     case "unauthorized":

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -332,6 +332,10 @@ function builtInHandler(name) {
       return () => {
         throw new Error("boom");
       };
+    case "unexpected_error":
+      return () => {
+        throw new Error("boom");
+      };
     case "binary_body":
       return () => ({
         status: 200,

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -1475,7 +1475,7 @@ def _appsync_error_payload(exc: Exception, request: Request, request_id: str) ->
 
     return {
         "pay_theory_error": True,
-        "error_message": str(exc or "internal error"),
+        "error_message": "internal error",
         "error_type": _APPSYNC_ERROR_TYPE_SYSTEM,
         "error_data": {},
         "error_info": {},

--- a/py/tests/test_app.py
+++ b/py/tests/test_app.py
@@ -562,7 +562,7 @@ class TestApp(unittest.TestCase):
             out,
             {
                 "pay_theory_error": True,
-                "error_message": "boom",
+                "error_message": "internal error",
                 "error_type": "SYSTEM_ERROR",
                 "error_data": {},
                 "error_info": {},

--- a/runtime/aws_appsync.go
+++ b/runtime/aws_appsync.go
@@ -300,13 +300,9 @@ func appSyncErrorPayload(err error, request Request, requestID string) map[strin
 		)
 	}
 
-	message := errorMessageInternal
-	if err != nil && strings.TrimSpace(err.Error()) != "" {
-		message = err.Error()
-	}
 	return map[string]any{
 		"pay_theory_error": true,
-		"error_message":    message,
+		"error_message":    errorMessageInternal,
 		"error_type":       appSyncErrorTypeSystem,
 		"error_data":       map[string]any{},
 		"error_info":       map[string]any{},

--- a/runtime/aws_appsync_test.go
+++ b/runtime/aws_appsync_test.go
@@ -436,7 +436,7 @@ func TestServeAppSync_FormatsUnexpectedErrors(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected appsync error payload, got %T", out)
 	}
-	if payload["pay_theory_error"] != true || payload["error_message"] != "boom" || payload["error_type"] != appSyncErrorTypeSystem {
+	if payload["pay_theory_error"] != true || payload["error_message"] != errorMessageInternal || payload["error_type"] != appSyncErrorTypeSystem {
 		t.Fatalf("unexpected appsync unexpected-error payload: %#v", payload)
 	}
 	if errorData, ok := payload["error_data"].(map[string]any); !ok || len(errorData) != 0 {

--- a/ts/dist/internal/aws-appsync.js
+++ b/ts/dist/internal/aws-appsync.js
@@ -271,10 +271,9 @@ export function appSyncErrorPayload(err, request, requestId) {
     if (err instanceof AppError) {
         return appSyncPortableErrorPayload(err.code, err.message, statusForErrorCode(err.code), undefined, String(requestId ?? "").trim(), "", "", request);
     }
-    const message = err instanceof Error ? err.message : String(err ?? "").trim();
     return {
         pay_theory_error: true,
-        error_message: message || "internal error",
+        error_message: "internal error",
         error_type: APPSYNC_ERROR_TYPE_SYSTEM,
         error_data: {},
         error_info: {},

--- a/ts/src/internal/aws-appsync.ts
+++ b/ts/src/internal/aws-appsync.ts
@@ -360,10 +360,9 @@ export function appSyncErrorPayload(
       request,
     );
   }
-  const message = err instanceof Error ? err.message : String(err ?? "").trim();
   return {
     pay_theory_error: true,
-    error_message: message || "internal error",
+    error_message: "internal error",
     error_type: APPSYNC_ERROR_TYPE_SYSTEM,
     error_data: {},
     error_info: {},

--- a/ts/test/appsync-errors.test.mjs
+++ b/ts/test/appsync-errors.test.mjs
@@ -87,7 +87,7 @@ test("serveAppSync preserves Lift-style generic unexpected errors", async () => 
 
   assert.deepEqual(out, {
     pay_theory_error: true,
-    error_message: "boom",
+    error_message: "internal error",
     error_type: "SYSTEM_ERROR",
     error_data: {},
     error_info: {},


### PR DESCRIPTION
## Milestone
appsync-error-masking-parity — mask non-portable AppSync exceptions to the generic internal error across Go, TypeScript, and Python.

## Linear
- THE-354
- THE-366
- THE-370
- THE-374

## Tasks
- [x] THE-354 Specify generic AppSync internal-error masking in contract fixtures
- [x] THE-366 Mask non-portable AppSync exceptions in the Go runtime
- [x] THE-370 Mask non-portable AppSync exceptions in the TypeScript runtime
- [x] THE-374 Close AppSync internal-error masking parity in Python

## Contract impact
Fixture-first for the new AppSync masking fixture, then internal-only runtime convergence in Go, TypeScript, and Python.

## Validation
Commands run on the final branch tip:
- `go test ./runtime`
- `go run ./contract-tests/runners/go --fixtures contract-tests/fixtures`
- `cd ts && npm run check && npm run build`
- `node contract-tests/runners/ts/run.cjs --fixtures contract-tests/fixtures`
- `python3 -m unittest discover -s py/tests`
- `./scripts/verify-contract-tests.sh`
- `make test-unit`
- `golangci-lint cache clean`
- `make rubric`

## Cross-repo notes
None.
