### PR TITLE
fix(runtime): require allowlist for credentialed cors

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -25,6 +25,7 @@ Each fixture is a single JSON object.
   - `path` (string): route pattern (supports `{param}` segments).
   - `handler` (string): built-in handler name provided by each language runner.
 - `setup.middlewares` (array, optional): built-in middleware chain names applied in registration order.
+- `setup.cors` (object, optional): portable CORS configuration. When `allow_credentials` is `true`, fixtures require explicit `allowed_origins`; omitted allowlists must not reflect origins or emit credentialed CORS headers.
 - `setup.limits` (object, optional): guardrails configuration.
   - `max_request_bytes` (number): reject requests over this size with `app.too_large`. When `input.request.is_base64`
     is `true`, this limit applies to the decoded request body bytes.

--- a/contract-tests/fixtures/p1/cors-credentials-requires-allowlist.json
+++ b/contract-tests/fixtures/p1/cors-credentials-requires-allowlist.json
@@ -1,0 +1,31 @@
+{
+  "id": "p1.cors.credentials_requires_allowlist",
+  "tier": "p1",
+  "name": "Credentialed CORS requires an explicit allowlist",
+  "setup": {
+    "cors": { "allow_credentials": true },
+    "routes": [{ "method": "GET", "path": "/pong", "handler": "static_pong" }]
+  },
+  "input": {
+    "request": {
+      "method": "GET",
+      "path": "/pong",
+      "query": {},
+      "headers": { "origin": ["https://example.com"] },
+      "body": { "encoding": "utf8", "value": "" },
+      "is_base64": false
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": ["text/plain; charset=utf-8"],
+        "x-request-id": ["req_test_123"]
+      },
+      "cookies": [],
+      "body": { "encoding": "utf8", "value": "pong" },
+      "is_base64": false
+    }
+  }
+}

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -1679,7 +1679,7 @@ def _cors_origin_allowed(origin: str, cors: CORSConfig) -> bool:
         return False
 
     if cors.allowed_origins is None:
-        return True
+        return not cors.allow_credentials
     if not cors.allowed_origins:
         return False
 

--- a/py/tests/test_app.py
+++ b/py/tests/test_app.py
@@ -97,6 +97,25 @@ class TestApp(unittest.TestCase):
         with self.assertRaises(ValueError):
             app.handle_strict("GET", "/{proxy+}/x", _ok)
 
+    def test_credentialed_cors_requires_allowlist(self) -> None:
+        app: App = create_app(tier="p1", cors=CORSConfig(allow_credentials=True))
+        app.get("/", _ok)
+
+        resp = app.serve(
+            Request(
+                method="GET",
+                path="/",
+                headers={"origin": "https://example.com"},
+                body="",
+            )
+        )
+
+        self.assertEqual(resp.status, 200)
+        self.assertNotIn("access-control-allow-origin", resp.headers)
+        self.assertNotIn("access-control-allow-credentials", resp.headers)
+        self.assertNotIn("access-control-allow-headers", resp.headers)
+        self.assertIn("x-request-id", resp.headers)
+
     def test_tier_p2_preflight_policy_auth_and_limits(self) -> None:
         cors = CORSConfig(allowed_origins=["*"], allow_credentials=True, allow_headers=["X-One", " X-Two ", ""])
         app: App = create_app(

--- a/runtime/cors.go
+++ b/runtime/cors.go
@@ -56,7 +56,7 @@ func corsOriginAllowed(origin string, cfg CORSConfig) bool {
 		return false
 	}
 	if cfg.AllowedOrigins == nil {
-		return true
+		return !cfg.AllowCredentials
 	}
 	if len(cfg.AllowedOrigins) == 0 {
 		return false

--- a/runtime/cors_test.go
+++ b/runtime/cors_test.go
@@ -24,7 +24,10 @@ func TestCORSOriginAllowed(t *testing.T) {
 		t.Fatal("expected empty origin to be rejected")
 	}
 	if !corsOriginAllowed("https://x.example", CORSConfig{AllowedOrigins: nil}) {
-		t.Fatal("expected nil AllowedOrigins to allow all")
+		t.Fatal("expected nil AllowedOrigins without credentials to allow all")
+	}
+	if corsOriginAllowed("https://x.example", CORSConfig{AllowedOrigins: nil, AllowCredentials: true}) {
+		t.Fatal("expected credentials without explicit AllowedOrigins to deny all")
 	}
 	if corsOriginAllowed("https://x.example", CORSConfig{AllowedOrigins: []string{}}) {
 		t.Fatal("expected empty AllowedOrigins slice to deny all")

--- a/runtime/serve_test.go
+++ b/runtime/serve_test.go
@@ -55,6 +55,38 @@ func TestServeP0_HandlerErrors(t *testing.T) {
 	}
 }
 
+func TestServePortable_CredentialedCORSRequiresAllowlist(t *testing.T) {
+	app := New(
+		WithTier(TierP1),
+		WithIDGenerator(fixedIDGenerator("req_1")),
+		WithCORS(CORSConfig{AllowCredentials: true}),
+	)
+	app.Get("/ok", func(_ *Context) (*Response, error) { return Text(200, "ok"), nil })
+
+	resp := app.Serve(context.Background(), Request{
+		Method: "GET",
+		Path:   "/ok",
+		Headers: map[string][]string{
+			"Origin": {"https://a.example"},
+		},
+	})
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+	if got := resp.Headers["access-control-allow-origin"]; len(got) != 0 {
+		t.Fatalf("expected no allow-origin, got %v", got)
+	}
+	if got := resp.Headers["access-control-allow-credentials"]; len(got) != 0 {
+		t.Fatalf("expected no allow-credentials, got %v", got)
+	}
+	if got := resp.Headers["access-control-allow-headers"]; len(got) != 0 {
+		t.Fatalf("expected no allow-headers, got %v", got)
+	}
+	if got := resp.Headers["x-request-id"]; len(got) != 1 || got[0] != "req_1" {
+		t.Fatalf("unexpected x-request-id: %v", got)
+	}
+}
+
 func TestServePortable_AddsRequestIDAuthAndCORS(t *testing.T) {
 	app := New(
 		WithTier(TierP2),

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -994,7 +994,7 @@ function corsOriginAllowed(origin, cors) {
         return false;
     const allowed = cors.allowedOrigins;
     if (allowed === null) {
-        return true;
+        return !cors.allowCredentials;
     }
     if (!Array.isArray(allowed) || allowed.length === 0) {
         return false;

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -1635,7 +1635,7 @@ function corsOriginAllowed(
 
   const allowed = cors.allowedOrigins;
   if (allowed === null) {
-    return true;
+    return !cors.allowCredentials;
   }
   if (!Array.isArray(allowed) || allowed.length === 0) {
     return false;


### PR DESCRIPTION
## Milestone
credentialed-cors-allowlist-hardening — require explicit allowlists before credentialed CORS can reflect origins across Go, TypeScript, and Python.

## Linear
- THE-355
- THE-367
- THE-371
- THE-375

## Tasks
- [x] THE-355 Specify credentialed CORS allowlist requirements in contract fixtures
- [x] THE-367 Require explicit allowlists for credentialed CORS in the Go runtime
- [x] THE-371 Require explicit allowlists for credentialed CORS in the TypeScript runtime
- [x] THE-375 Close credentialed CORS allowlist parity in Python

## Contract impact
Fixture-first for the new P1 CORS contract, then internal-only runtime convergence in Go, TypeScript, and Python.

## Validation
Commands run on the final branch tip:
- `go test ./runtime`
- `go run ./contract-tests/runners/go --fixtures contract-tests/fixtures`
- `cd ts && npm run check && npm run build`
- `node contract-tests/runners/ts/run.cjs --fixtures contract-tests/fixtures`
- `python3 -m unittest discover -s py/tests`
- `./scripts/verify-contract-tests.sh`
- `make test-unit`
- `golangci-lint cache clean`
- `make rubric`

## Cross-repo notes
None.
