### PR TITLE
fix(runtime): propagate cooperative timeout cancellation

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -25,6 +25,8 @@ Each fixture is a single JSON object.
   - `path` (string): route pattern (supports `{param}` segments).
   - `handler` (string): built-in handler name provided by each language runner.
 - `setup.middlewares` (array, optional): built-in middleware chain names applied in registration order.
+  - Timeout fixtures may use cooperative handlers that must observe middleware cancellation before committing
+    post-timeout side effects.
 - `setup.cors` (object, optional): portable CORS configuration. When `allow_credentials` is `true`, fixtures require explicit `allowed_origins`; omitted allowlists must not reflect origins or emit credentialed CORS headers.
 - `setup.limits` (object, optional): guardrails configuration.
   - `max_request_bytes` (number): reject requests over this size with `app.too_large`. When `input.request.is_base64`

--- a/contract-tests/fixtures/m12/timeout-middleware-cooperative-cancel.json
+++ b/contract-tests/fixtures/m12/timeout-middleware-cooperative-cancel.json
@@ -1,0 +1,38 @@
+{
+  "id": "m12.middleware.timeout_cooperative_cancel",
+  "tier": "m12",
+  "name": "Middleware: timeout propagates cooperative cancellation before post-timeout side effects commit",
+  "setup": {
+    "middlewares": ["timeout_5ms"],
+    "routes": [{ "method": "GET", "path": "/slow", "handler": "cooperative_cancel_side_effect" }]
+  },
+  "input": {
+    "request": {
+      "method": "GET",
+      "path": "/slow",
+      "query": {},
+      "headers": {},
+      "body": { "encoding": "utf8", "value": "" },
+      "is_base64": false
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 408,
+      "headers": {
+        "content-type": ["application/json; charset=utf-8"],
+        "x-request-id": ["req_test_123"]
+      },
+      "cookies": [],
+      "body_json": {
+        "error": {
+          "code": "app.timeout",
+          "message": "request timeout",
+          "request_id": "req_test_123"
+        }
+      },
+      "is_base64": false
+    },
+    "metrics": []
+  }
+}

--- a/contract-tests/runners/go/apptheory_m12.go
+++ b/contract-tests/runners/go/apptheory_m12.go
@@ -11,6 +11,7 @@ import (
 func runFixtureM12(f Fixture) error {
 	now := time.Unix(0, 0).UTC()
 	app := newAppTheoryFixtureAppP1(now, f.Setup.Limits, f.Setup.CORS, f.Setup.HTTPErrorFormat)
+	var metrics []FixtureMetricRecord
 
 	for _, name := range f.Setup.Middlewares {
 		mw := builtInM12Middleware(name)
@@ -21,7 +22,7 @@ func runFixtureM12(f Fixture) error {
 	}
 
 	for _, r := range f.Setup.Routes {
-		handler := builtInAppTheoryHandler(r.Handler)
+		handler := builtInM12Handler(r.Handler, &metrics)
 		if handler == nil {
 			return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 		}
@@ -65,7 +66,9 @@ func runFixtureM12(f Fixture) error {
 		actual.BodyReader = nil
 	}
 
-	return compareFixtureResponse(f, actual, nil, nil, nil)
+	time.Sleep(30 * time.Millisecond)
+
+	return compareFixtureResponse(f, actual, nil, metrics, nil)
 }
 
 func builtInM12Middleware(name string) apptheory.Middleware {
@@ -99,5 +102,29 @@ func builtInM12Middleware(name string) apptheory.Middleware {
 		return apptheory.TimeoutMiddleware(apptheory.TimeoutConfig{DefaultTimeout: 5 * time.Millisecond})
 	default:
 		return nil
+	}
+}
+
+func builtInM12Handler(name string, metrics *[]FixtureMetricRecord) apptheory.Handler {
+	if strings.TrimSpace(name) != "cooperative_cancel_side_effect" {
+		return builtInAppTheoryHandler(name)
+	}
+
+	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		select {
+		case <-ctx.Context().Done():
+			return apptheory.Text(200, "cancelled"), nil
+		case <-time.After(20 * time.Millisecond):
+			if metrics != nil {
+				*metrics = append(*metrics, FixtureMetricRecord{
+					Name:  "timeout.side_effect_committed",
+					Value: 1,
+					Tags: map[string]string{
+						"handler": "cooperative_cancel_side_effect",
+					},
+				})
+			}
+			return apptheory.Text(200, "late"), nil
+		}
 	}
 }

--- a/contract-tests/runners/go/apptheory_m12.go
+++ b/contract-tests/runners/go/apptheory_m12.go
@@ -116,7 +116,7 @@ func builtInM12Handler(name string, metrics *[]FixtureMetricRecord) apptheory.Ha
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
 		select {
 		case <-ctx.Context().Done():
-			return apptheory.Text(200, "cancelled"), nil
+			return apptheory.Text(200, "canceled"), nil
 		case <-time.After(20 * time.Millisecond):
 			if metrics != nil {
 				*metrics = append(*metrics, FixtureMetricRecord{

--- a/contract-tests/runners/go/apptheory_m12.go
+++ b/contract-tests/runners/go/apptheory_m12.go
@@ -67,6 +67,9 @@ func runFixtureM12(f Fixture) error {
 	}
 
 	time.Sleep(30 * time.Millisecond)
+	if f.Expect.Metrics != nil && metrics == nil {
+		metrics = []FixtureMetricRecord{}
+	}
 
 	return compareFixtureResponse(f, actual, nil, metrics, nil)
 }

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -6,6 +6,8 @@ import argparse
 import base64
 import json
 import sys
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -795,7 +797,18 @@ def _load_apptheory_runtime():
     return apptheory
 
 
-def _built_in_apptheory_handler(runtime: Any, name: str):
+def _cooperative_cancelled(value: Any) -> bool:
+    if isinstance(value, threading.Event):
+        return value.is_set()
+
+    event = getattr(value, "cancelled", None)
+    if isinstance(event, threading.Event):
+        return event.is_set()
+
+    return False
+
+
+def _built_in_apptheory_handler(runtime: Any, name: str, effects: Any | None = None):
     if name == "static_pong":
         return lambda _ctx: runtime.text(200, "pong")
 
@@ -805,6 +818,25 @@ def _built_in_apptheory_handler(runtime: Any, name: str):
 
             time.sleep(0.05)
             return runtime.text(200, "done")
+
+        return handler
+
+    if name == "cooperative_cancel_side_effect":
+        def handler(ctx):
+            deadline = time.monotonic() + 0.02
+            while time.monotonic() < deadline:
+                if _cooperative_cancelled(getattr(ctx, "ctx", None)):
+                    return runtime.text(200, "cancelled")
+                time.sleep(0.001)
+            if effects is not None:
+                effects.metrics.append(
+                    {
+                        "name": "timeout.side_effect_committed",
+                        "value": 1,
+                        "tags": {"handler": "cooperative_cancel_side_effect"},
+                    }
+                )
+            return runtime.text(200, "late")
 
         return handler
 
@@ -1647,6 +1679,7 @@ def run_fixture_m12(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalRespon
     runtime = _load_apptheory_runtime()
     ids = runtime.ManualIdGenerator()
     ids.push("req_test_123")
+    effects = _DummyEffectsApp()
 
     setup = fixture.get("setup", {})
     limits = setup.get("limits", {}) or {}
@@ -1669,7 +1702,7 @@ def run_fixture_m12(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalRespon
 
     for route in setup.get("routes", []) or []:
         name = str(route.get("handler", ""))
-        handler = _built_in_apptheory_handler(runtime, name)
+        handler = _built_in_apptheory_handler(runtime, name, effects)
         if handler is None:
             raise RuntimeError(f"unknown handler {name!r}")
         app.handle(
@@ -1701,7 +1734,8 @@ def run_fixture_m12(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalRespon
     )
 
     expected = fixture.get("expect", {}).get("response", {})
-    return run_fixture_compare(fixture, actual, expected, _DummyEffectsApp())
+    time.sleep(0.03)
+    return run_fixture_compare(fixture, actual, expected, effects)
 
 
 def run_fixture_m14(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, dict[str, Any], FixtureApp]:

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -643,8 +643,8 @@ async function runFixture(fixture) {
     return compareFixture(fixture, actual, { logs: [], metrics: [], spans: [] });
   }
   if (tier === "m12") {
-    const { actual } = await runFixtureM12(fixture);
-    return compareFixture(fixture, actual, { logs: [], metrics: [], spans: [] });
+    const { actual, effects } = await runFixtureM12(fixture);
+    return compareFixture(fixture, actual, effects);
   }
   if (tier === "m14") {
     const { actual } = await runFixtureM14(fixture);
@@ -1321,6 +1321,7 @@ async function runFixtureM3(fixture) {
 
 async function runFixtureM12(fixture) {
   const runtime = await loadAppTheoryRuntime();
+  const effects = { logs: [], metrics: [], spans: [] };
 
   const ids = new runtime.ManualIdGenerator();
   ids.queue("req_test_123");
@@ -1367,7 +1368,7 @@ async function runFixtureM12(fixture) {
   }
 
   for (const route of fixture.setup?.routes ?? []) {
-    const handler = builtInAppTheoryHandler(runtime, route.handler);
+    const handler = builtInAppTheoryHandler(runtime, route.handler, effects);
     if (!handler) {
       throw new Error(`unknown handler ${JSON.stringify(route.handler)}`);
     }
@@ -1395,7 +1396,9 @@ async function runFixtureM12(fixture) {
     is_base64: resp.isBase64 ?? false,
   };
 
-  return { actual };
+  await sleepMs(30);
+
+  return { actual, effects };
 }
 
 async function runFixtureM14(fixture) {
@@ -1632,6 +1635,42 @@ function canonicalResponseFromAPIGatewayProxyResponse(resp) {
     body,
     is_base64: isBase64Encoded,
   };
+}
+
+function sleepMs(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function abortSignalFromContextCarrier(value) {
+  if (typeof AbortSignal !== "undefined" && value instanceof AbortSignal) {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    const signal = value.signal;
+    if (typeof AbortSignal !== "undefined" && signal instanceof AbortSignal) {
+      return signal;
+    }
+  }
+  return null;
+}
+
+async function waitForAbort(signal, timeoutMs) {
+  if (!signal) return false;
+  if (signal.aborted) return true;
+
+  return await new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(false);
+    }, timeoutMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 async function runFixtureP1(fixture) {
@@ -1912,16 +1951,27 @@ async function runFixtureP2Output(fixture) {
   return { actualOutput, actualError, effects };
 }
 
-function builtInAppTheoryHandler(runtime, name) {
+function builtInAppTheoryHandler(runtime, name, effects) {
   switch (name) {
     case "static_pong":
       return () => runtime.text(200, "pong");
     case "sleep_50ms":
       return async () => {
-        await new Promise((resolve) => {
-          setTimeout(resolve, 50);
-        });
+        await sleepMs(50);
         return runtime.text(200, "done");
+      };
+    case "cooperative_cancel_side_effect":
+      return async (ctx) => {
+        const signal = abortSignalFromContextCarrier(ctx?.ctx ?? null);
+        if (await waitForAbort(signal, 20)) {
+          return runtime.text(200, "cancelled");
+        }
+        effects?.metrics?.push({
+          name: "timeout.side_effect_committed",
+          value: 1,
+          tags: { handler: "cooperative_cancel_side_effect" },
+        });
+        return runtime.text(200, "late");
       };
     case "echo_path_params":
       return (ctx) => runtime.json(200, { params: ctx.params ?? {} });

--- a/py/src/apptheory/middleware.py
+++ b/py/src/apptheory/middleware.py
@@ -16,6 +16,31 @@ class TimeoutConfig:
     timeout_message: str = "request timeout"
 
 
+@dataclass(slots=True)
+class _TimeoutCancellationCarrier:
+    parent: Any | None
+    cancelled: threading.Event
+
+
+def _clone_context_with_timeout_ctx(ctx: Context, carrier: Any) -> Context:
+    clone = Context(
+        request=ctx.request,
+        params=ctx.params,
+        clock=ctx.clock,
+        id_generator=ctx.id_generator,
+        ctx=carrier,
+        request_id=ctx.request_id,
+        tenant_id=ctx.tenant_id,
+        auth_identity=ctx.auth_identity,
+        remaining_ms=ctx.remaining_ms,
+        middleware_trace=ctx.middleware_trace,
+        websocket=ctx.websocket,
+        appsync=ctx.appsync,
+    )
+    clone._values = ctx._values
+    return clone
+
+
 def timeout_middleware(config: TimeoutConfig) -> Middleware:
     cfg = _normalize_timeout_config(config)
 
@@ -26,10 +51,15 @@ def timeout_middleware(config: TimeoutConfig) -> Middleware:
 
         result: dict[str, Any] = {}
         done = threading.Event()
+        cancelled = threading.Event()
+        handler_ctx = _clone_context_with_timeout_ctx(
+            ctx,
+            _TimeoutCancellationCarrier(getattr(ctx, "ctx", None), cancelled),
+        )
 
         def run() -> None:
             try:
-                result["resp"] = next_handler(ctx)
+                result["resp"] = next_handler(handler_ctx)
             except Exception as exc:  # noqa: BLE001
                 result["exc"] = exc
             finally:
@@ -39,6 +69,7 @@ def timeout_middleware(config: TimeoutConfig) -> Middleware:
         thread.start()
 
         if not done.wait(timeout=float(timeout_ms) / 1000.0):
+            cancelled.set()
             raise AppError("app.timeout", cfg.timeout_message)
 
         if "exc" in result:

--- a/py/tests/test_middleware.py
+++ b/py/tests/test_middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 import sys
+import time
 import unittest
 from pathlib import Path
 
@@ -84,3 +85,25 @@ class TestMiddleware(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "bad"):
             mw(ctx, boom)
 
+    def test_timeout_middleware_propagates_cooperative_cancellation_before_side_effects(self) -> None:
+        mw = timeout_middleware(TimeoutConfig(default_timeout_ms=5, timeout_message="too slow"))
+        ctx = Context(request=Request(method="GET", path="/"))
+        side_effect = threading.Event()
+
+        def cooperative(handler_ctx: Context):
+            deadline = time.monotonic() + 0.02
+            while time.monotonic() < deadline:
+                carrier = getattr(handler_ctx, "ctx", None)
+                cancelled = getattr(carrier, "cancelled", None)
+                if isinstance(cancelled, threading.Event) and cancelled.is_set():
+                    return "cancelled"
+                time.sleep(0.001)
+            side_effect.set()
+            return "late"
+
+        with self.assertRaises(AppError) as cm:
+            mw(ctx, cooperative)
+
+        self.assertEqual(cm.exception.code, "app.timeout")
+        time.sleep(0.03)
+        self.assertFalse(side_effect.is_set())

--- a/runtime/timeout_middleware.go
+++ b/runtime/timeout_middleware.go
@@ -1,6 +1,7 @@
 package apptheory
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -25,6 +26,11 @@ func TimeoutMiddleware(config TimeoutConfig) Middleware {
 				return next(ctx)
 			}
 
+			timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
+			defer cancel()
+
+			handlerCtx := withDerivedTimeoutContext(ctx, timeoutCtx)
+
 			type result struct {
 				resp *Response
 				err  error
@@ -37,21 +43,28 @@ func TimeoutMiddleware(config TimeoutConfig) Middleware {
 						ch <- result{resp: nil, err: &AppError{Code: errorCodeInternal, Message: errorMessageInternal}}
 					}
 				}()
-				resp, err := next(ctx)
+				resp, err := next(handlerCtx)
 				ch <- result{resp: resp, err: err}
 			}()
-
-			timer := time.NewTimer(timeout)
-			defer timer.Stop()
 
 			select {
 			case res := <-ch:
 				return res.resp, res.err
-			case <-timer.C:
+			case <-timeoutCtx.Done():
 				return nil, &AppError{Code: errorCodeTimeout, Message: cfg.TimeoutMessage}
 			}
 		}
 	}
+}
+
+func withDerivedTimeoutContext(ctx *Context, derived context.Context) *Context {
+	if ctx == nil {
+		return &Context{ctx: derived}
+	}
+
+	cloned := *ctx
+	cloned.ctx = derived
+	return &cloned
 }
 
 func normalizeTimeoutConfig(in TimeoutConfig) TimeoutConfig {

--- a/runtime/timeout_middleware.go
+++ b/runtime/timeout_middleware.go
@@ -29,7 +29,7 @@ func TimeoutMiddleware(config TimeoutConfig) Middleware {
 			timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
 			defer cancel()
 
-			handlerCtx := withDerivedTimeoutContext(ctx, timeoutCtx)
+			handlerCtx := withDerivedTimeoutContext(timeoutCtx, ctx)
 
 			type result struct {
 				resp *Response
@@ -57,7 +57,7 @@ func TimeoutMiddleware(config TimeoutConfig) Middleware {
 	}
 }
 
-func withDerivedTimeoutContext(ctx *Context, derived context.Context) *Context {
+func withDerivedTimeoutContext(derived context.Context, ctx *Context) *Context {
 	if ctx == nil {
 		return &Context{ctx: derived}
 	}

--- a/runtime/timeout_middleware_test.go
+++ b/runtime/timeout_middleware_test.go
@@ -82,7 +82,7 @@ func TestTimeoutMiddleware_PropagatesCooperativeCancellation(t *testing.T) {
 	app.Get("/cooperative", func(ctx *Context) (*Response, error) {
 		select {
 		case <-ctx.Context().Done():
-			return Text(200, "cancelled"), nil
+			return Text(200, "canceled"), nil
 		case <-time.After(20 * time.Millisecond):
 			sideEffect <- struct{}{}
 			return Text(200, "late"), nil

--- a/runtime/timeout_middleware_test.go
+++ b/runtime/timeout_middleware_test.go
@@ -73,3 +73,32 @@ func TestTimeoutMiddleware_TimeoutAndPanicRecovery(t *testing.T) {
 		t.Fatalf("expected internal error response for panic, got %d", resp.Status)
 	}
 }
+
+func TestTimeoutMiddleware_PropagatesCooperativeCancellation(t *testing.T) {
+	app := New(WithTier(TierP0))
+	app.Use(TimeoutMiddleware(TimeoutConfig{DefaultTimeout: 5 * time.Millisecond}))
+
+	sideEffect := make(chan struct{}, 1)
+	app.Get("/cooperative", func(ctx *Context) (*Response, error) {
+		select {
+		case <-ctx.Context().Done():
+			return Text(200, "cancelled"), nil
+		case <-time.After(20 * time.Millisecond):
+			sideEffect <- struct{}{}
+			return Text(200, "late"), nil
+		}
+	})
+
+	resp := app.Serve(context.Background(), Request{Method: "GET", Path: "/cooperative"})
+	if resp.Status != 408 {
+		t.Fatalf("expected timeout response (408), got %d", resp.Status)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	select {
+	case <-sideEffect:
+		t.Fatal("cooperative handler committed a post-timeout side effect")
+	default:
+	}
+}

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -863,6 +863,50 @@ export function createLambdaFunctionURLStreamingHandler(app) {
     }
     return async (event, ctx) => app.serveLambdaFunctionURL(event, ctx);
 }
+function isAbortSignalLike(value) {
+    return typeof AbortSignal !== "undefined" && value instanceof AbortSignal;
+}
+function abortSignalFromTimeoutCarrier(value) {
+    if (isAbortSignalLike(value)) {
+        return value;
+    }
+    if (value && typeof value === "object") {
+        const signal = value.signal;
+        if (isAbortSignalLike(signal)) {
+            return signal;
+        }
+    }
+    return null;
+}
+function timeoutContextCarrier(parent, signal) {
+    if (parent == null) {
+        return signal;
+    }
+    if (typeof parent === "object") {
+        return { ...parent, signal };
+    }
+    return { parent, signal };
+}
+function cloneContextWithTimeoutCarrier(ctx, carrier) {
+    const ctxInternal = ctx;
+    const clone = new Context({
+        request: ctx.request,
+        params: ctx.params,
+        clock: ctxInternal._clock,
+        ids: ctxInternal._ids,
+        ctx: carrier,
+        requestId: ctx.requestId,
+        tenantId: ctx.tenantId,
+        authIdentity: ctx.authIdentity,
+        remainingMs: ctx.remainingMs,
+        middlewareTrace: ctx.middlewareTrace,
+        webSocket: ctx.asWebSocket(),
+        appSync: ctx.asAppSync(),
+    });
+    const cloneInternal = clone;
+    cloneInternal._values = ctxInternal._values;
+    return clone;
+}
 function normalizeTimeoutConfig(config) {
     let defaultTimeoutMs = Number(config?.defaultTimeoutMs ?? 0);
     if (!Number.isFinite(defaultTimeoutMs))
@@ -923,19 +967,45 @@ export function timeoutMiddleware(config = {}) {
         if (timeoutMs <= 0) {
             return next(ctx);
         }
-        let timer = null;
+        const controller = new AbortController();
+        const parentSignal = abortSignalFromTimeoutCarrier(ctx?.ctx ?? null);
+        let removeParentAbortListener = () => { };
+        if (parentSignal) {
+            if (parentSignal.aborted) {
+                controller.abort(parentSignal.reason);
+            }
+            else {
+                const onParentAbort = () => controller.abort(parentSignal.reason);
+                parentSignal.addEventListener("abort", onParentAbort, { once: true });
+                removeParentAbortListener = () => parentSignal.removeEventListener("abort", onParentAbort);
+            }
+        }
+        const handlerCtx = cloneContextWithTimeoutCarrier(ctx, timeoutContextCarrier(ctx?.ctx ?? null, controller.signal));
+        let timer = setTimeout(() => {
+            controller.abort(cfg.timeoutMessage);
+        }, timeoutMs);
+        let removeTimeoutAbortListener = () => { };
         const timeoutPromise = new Promise((_resolve, reject) => {
             void _resolve;
-            timer = setTimeout(() => reject(new AppError("app.timeout", cfg.timeoutMessage)), timeoutMs);
+            const onAbort = () => reject(new AppError("app.timeout", cfg.timeoutMessage));
+            if (controller.signal.aborted) {
+                onAbort();
+                return;
+            }
+            controller.signal.addEventListener("abort", onAbort, { once: true });
+            removeTimeoutAbortListener = () => controller.signal.removeEventListener("abort", onAbort);
         });
         try {
-            const run = Promise.resolve().then(() => next(ctx));
+            const run = Promise.resolve().then(() => next(handlerCtx));
             return await Promise.race([run, timeoutPromise]);
         }
         finally {
             if (timer) {
                 clearTimeout(timer);
+                timer = null;
             }
+            removeTimeoutAbortListener();
+            removeParentAbortListener();
         }
     };
 }

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -1472,6 +1472,61 @@ type NormalizedTimeoutConfig = {
   timeoutMessage: string;
 };
 
+function isAbortSignalLike(value: unknown): value is AbortSignal {
+  return typeof AbortSignal !== "undefined" && value instanceof AbortSignal;
+}
+
+function abortSignalFromTimeoutCarrier(value: unknown): AbortSignal | null {
+  if (isAbortSignalLike(value)) {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    const signal = (value as { signal?: unknown }).signal;
+    if (isAbortSignalLike(signal)) {
+      return signal;
+    }
+  }
+  return null;
+}
+
+function timeoutContextCarrier(parent: unknown, signal: AbortSignal): unknown {
+  if (parent == null) {
+    return signal;
+  }
+  if (typeof parent === "object") {
+    return { ...parent, signal };
+  }
+  return { parent, signal };
+}
+
+function cloneContextWithTimeoutCarrier(
+  ctx: Context,
+  carrier: unknown,
+): Context {
+  const ctxInternal = ctx as unknown as {
+    _clock: Clock;
+    _ids: IdGenerator;
+    _values: Map<string, unknown>;
+  };
+  const clone = new Context({
+    request: ctx.request,
+    params: ctx.params,
+    clock: ctxInternal._clock,
+    ids: ctxInternal._ids,
+    ctx: carrier,
+    requestId: ctx.requestId,
+    tenantId: ctx.tenantId,
+    authIdentity: ctx.authIdentity,
+    remainingMs: ctx.remainingMs,
+    middlewareTrace: ctx.middlewareTrace,
+    webSocket: ctx.asWebSocket(),
+    appSync: ctx.asAppSync(),
+  });
+  const cloneInternal = clone as unknown as { _values: Map<string, unknown> };
+  cloneInternal._values = ctxInternal._values;
+  return clone;
+}
+
 function normalizeTimeoutConfig(
   config: TimeoutConfig,
 ): NormalizedTimeoutConfig {
@@ -1550,22 +1605,53 @@ export function timeoutMiddleware(config: TimeoutConfig = {}): Middleware {
       return next(ctx);
     }
 
-    let timer: ReturnType<typeof setTimeout> | null = null;
+    const controller = new AbortController();
+    const parentSignal = abortSignalFromTimeoutCarrier(ctx?.ctx ?? null);
+    let removeParentAbortListener = () => {};
+    if (parentSignal) {
+      if (parentSignal.aborted) {
+        controller.abort(parentSignal.reason);
+      } else {
+        const onParentAbort = () => controller.abort(parentSignal.reason);
+        parentSignal.addEventListener("abort", onParentAbort, { once: true });
+        removeParentAbortListener = () =>
+          parentSignal.removeEventListener("abort", onParentAbort);
+      }
+    }
+
+    const handlerCtx = cloneContextWithTimeoutCarrier(
+      ctx,
+      timeoutContextCarrier(ctx?.ctx ?? null, controller.signal),
+    );
+
+    let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      controller.abort(cfg.timeoutMessage);
+    }, timeoutMs);
+
+    let removeTimeoutAbortListener = () => {};
     const timeoutPromise = new Promise<Response>((_resolve, reject) => {
       void _resolve;
-      timer = setTimeout(
-        () => reject(new AppError("app.timeout", cfg.timeoutMessage)),
-        timeoutMs,
-      );
+      const onAbort = () =>
+        reject(new AppError("app.timeout", cfg.timeoutMessage));
+      if (controller.signal.aborted) {
+        onAbort();
+        return;
+      }
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+      removeTimeoutAbortListener = () =>
+        controller.signal.removeEventListener("abort", onAbort);
     });
 
     try {
-      const run = Promise.resolve().then(() => next(ctx));
+      const run = Promise.resolve().then(() => next(handlerCtx));
       return await Promise.race([run, timeoutPromise]);
     } finally {
       if (timer) {
         clearTimeout(timer);
+        timer = null;
       }
+      removeTimeoutAbortListener();
+      removeParentAbortListener();
     }
   };
 }

--- a/ts/test/timeout-middleware.test.mjs
+++ b/ts/test/timeout-middleware.test.mjs
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp, timeoutMiddleware } from "../dist/app.js";
+
+function request(path) {
+  return {
+    method: "GET",
+    path,
+    query: {},
+    headers: {},
+    cookies: {},
+    body: Buffer.alloc(0),
+    isBase64: false,
+  };
+}
+
+function abortSignalFromContextCarrier(value) {
+  if (typeof AbortSignal !== "undefined" && value instanceof AbortSignal) {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    const signal = value.signal;
+    if (typeof AbortSignal !== "undefined" && signal instanceof AbortSignal) {
+      return signal;
+    }
+  }
+  return null;
+}
+
+test("timeoutMiddleware returns app.timeout for slow handlers", async () => {
+  const app = createApp({ tier: "p0" });
+  app.use(timeoutMiddleware({ defaultTimeoutMs: 5 }));
+  app.get("/sleep", async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    return {
+      status: 200,
+      headers: { "content-type": ["text/plain; charset=utf-8"] },
+      cookies: [],
+      body: Buffer.from("done", "utf8"),
+      isBase64: false,
+    };
+  });
+
+  const resp = await app.serve(request("/sleep"));
+  const body = JSON.parse(Buffer.from(resp.body).toString("utf8"));
+
+  assert.equal(resp.status, 408);
+  assert.equal(body.error.code, "app.timeout");
+});
+
+test("timeoutMiddleware propagates cooperative cancellation before side effects", async () => {
+  const app = createApp({ tier: "p0" });
+  app.use(timeoutMiddleware({ defaultTimeoutMs: 5 }));
+
+  let committedSideEffect = false;
+  app.get("/cooperative", async (ctx) => {
+    const signal = abortSignalFromContextCarrier(ctx?.ctx ?? null);
+    const cancelled = await new Promise((resolve) => {
+      if (signal?.aborted) {
+        resolve(true);
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        committedSideEffect = true;
+        resolve(false);
+      }, 20);
+
+      signal?.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          resolve(true);
+        },
+        { once: true },
+      );
+    });
+
+    return {
+      status: 200,
+      headers: { "content-type": ["text/plain; charset=utf-8"] },
+      cookies: [],
+      body: Buffer.from(cancelled ? "cancelled" : "late", "utf8"),
+      isBase64: false,
+    };
+  });
+
+  const resp = await app.serve(request("/cooperative"));
+  assert.equal(resp.status, 408);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 30);
+  });
+  assert.equal(committedSideEffect, false);
+});


### PR DESCRIPTION
## Milestone
`timeout-cancellation-contract` — propagate cooperative timeout cancellation so handlers that honor cancellation stop before post-timeout side effects commit.

## Linear
- THE-356
- THE-368
- THE-372
- THE-376

## Tasks
- [x] THE-356 — Specify cooperative timeout cancellation semantics in contract fixtures
- [x] THE-368 — Propagate cooperative timeout cancellation in the Go runtime
- [x] THE-372 — Propagate cooperative timeout cancellation in the TypeScript runtime
- [x] THE-376 — Close cooperative timeout cancellation parity in Python

## Contract impact
Fixture-first for the m12 cooperative timeout contract, followed by internal-only runtime convergence in Go, TypeScript, and Python.

## Validation
Commands run on the final branch tip:
- `golangci-lint cache clean`
- `go test ./runtime`
- `go run ./contract-tests/runners/go --fixtures contract-tests/fixtures`
- `cd ts && npm run check && npm run build && node --test test/*.test.mjs`
- `node contract-tests/runners/ts/run.cjs --fixtures contract-tests/fixtures`
- `python3 -m unittest discover -s py/tests`
- `python3 contract-tests/runners/py/run.py --fixtures contract-tests/fixtures`
- `make rubric`

## Cross-repo notes
None.
