### PR TITLE
fix(sanitization): restore token-like key redaction

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -939,9 +939,8 @@ var AllowedFields = map[string]bool{
 	"card_brand": true,
 	"card_type":  true,
 
-	"transaction_id":   true,
-	"authorization_id": true,
-	"merchant_uid":     true,
+	"transaction_id": true,
+	"merchant_uid":   true,
 
 	"mid":         true,
 	"merchant_id": true,
@@ -1046,6 +1045,7 @@ var SensitiveFields = map[string]SanitizationType{
 	"api_key":              FullyRedact,
 	"api_token":            FullyRedact,
 	"api_key_id":           PartialMask,
+	"authorization_id":     FullyRedact,
 	"authorization":        FullyRedact,
 	"authorization_header": FullyRedact,
 }

--- a/docs/features/sanitization.md
+++ b/docs/features/sanitization.md
@@ -40,8 +40,12 @@ Sanitization is key-name driven:
   `pan_value`, `pan`, `primary_account_number`.
 
 Unknown keys fall back to safe string sanitization (strip `\r`/`\n`) and recursive sanitization for nested objects.
-AppTheory intentionally avoids substring-based redaction rules because they can over-redact non-secret business fields
-(for example GraphQL response fields that contain `"authorization"` in the name).
+AppTheory uses **segment-based secret heuristics** for otherwise-unknown keys:
+
+- exact segments like `token`, `secret`, and `password` trigger full redaction
+- explicit sensitive aliases like `authorization_id` are treated as secrets
+- business keys that merely contain those strings as part of a larger identifier (for example
+  `authorizationCode` or `tokenization_method`) remain readable
 
 ### Context-aware `accountNumber`
 

--- a/pkg/sanitization/sanitization.go
+++ b/pkg/sanitization/sanitization.go
@@ -20,9 +20,8 @@ var AllowedFields = map[string]bool{
 	"card_type":  true,
 
 	// Common system identifiers that are safe/necessary for debugging and correlation.
-	"transaction_id":   true,
-	"authorization_id": true,
-	"merchant_uid":     true,
+	"transaction_id": true,
+	"merchant_uid":   true,
 
 	// External system identifiers (MIDs, acceptor IDs, terminal IDs, etc.).
 	"mid":         true,
@@ -79,6 +78,7 @@ var SensitiveFields = map[string]SanitizationType{
 	"api_key":              FullyRedact,
 	"api_token":            FullyRedact,
 	"api_key_id":           PartialMask,
+	"authorization_id":     FullyRedact,
 	"authorization":        FullyRedact,
 	"authorization_header": FullyRedact,
 }
@@ -195,6 +195,10 @@ func sanitizeFieldValueWithParent(parentKey string, key string, value any) any {
 		return sanitizeSensitiveFieldValue(parentKey, keyLower, keyCanonical, value, typ)
 	}
 
+	if shouldHeuristicallyRedactKey(key) {
+		return redactedValue
+	}
+
 	return sanitizeValueWithParent(keyLower, value)
 }
 
@@ -235,6 +239,66 @@ func sanitizePartialMaskedValue(parentKey, keyLower, keyCanonical string, value 
 		return maskRestrictedValue(value)
 	}
 	return maskRestrictedValue(value)
+}
+
+func shouldHeuristicallyRedactKey(key string) bool {
+	segments := sanitizationKeySegments(key)
+	if len(segments) == 0 {
+		return false
+	}
+
+	for i, segment := range segments {
+		switch segment {
+		case "token", "secret", "password":
+			return true
+		case "key":
+			if i > 0 {
+				switch segments[i-1] {
+				case "api", "private", "secret":
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func sanitizationKeySegments(key string) []string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+
+	segments := make([]string, 0, 4)
+	var b strings.Builder
+
+	flush := func() {
+		if b.Len() == 0 {
+			return
+		}
+		segments = append(segments, b.String())
+		b.Reset()
+	}
+
+	var prev rune
+	for _, r := range key {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			flush()
+			prev = 0
+			continue
+		}
+
+		if unicode.IsUpper(r) && prev != 0 && (unicode.IsLower(prev) || unicode.IsDigit(prev)) {
+			flush()
+		}
+
+		b.WriteRune(unicode.ToLower(r))
+		prev = r
+	}
+
+	flush()
+	return segments
 }
 
 func isCardNumberKey(keyCanonical string) bool {

--- a/pkg/sanitization/sanitization_additional_test.go
+++ b/pkg/sanitization/sanitization_additional_test.go
@@ -146,18 +146,35 @@ func TestSanitizeXML_RapidConnectFixture(t *testing.T) {
 	}
 }
 
-func TestSanitizeFieldValue_AllowsAuthorizationID_AndAliases(t *testing.T) {
+func TestSanitizeFieldValue_RedactsAuthorizationID_AndAliases(t *testing.T) {
 	t.Parallel()
 
-	if got := SanitizeFieldValue("authorization_id", "auth_123"); got != "auth_123" {
-		t.Fatalf("expected authorization_id to be preserved, got %#v", got)
+	if got := SanitizeFieldValue("authorization_id", "auth_123"); got != redactedValue {
+		t.Fatalf("expected authorization_id to be redacted, got %#v", got)
 	}
-	if got := SanitizeFieldValue("authorizationId", "auth_123"); got != "auth_123" {
-		t.Fatalf("expected authorizationId alias to be preserved, got %#v", got)
+	if got := SanitizeFieldValue("authorizationId", "auth_123"); got != redactedValue {
+		t.Fatalf("expected authorizationId alias to be redacted, got %#v", got)
 	}
 }
 
-func TestSanitizeFieldValue_DoesNotSubstringRedactBusinessKeys(t *testing.T) {
+func TestSanitizeFieldValue_HeuristicallyRedactsTokenLikeKeys(t *testing.T) {
+	t.Parallel()
+
+	if got := SanitizeFieldValue("session_token", "tok_123"); got != redactedValue {
+		t.Fatalf("expected session_token to be redacted, got %#v", got)
+	}
+	if got := SanitizeFieldValue("csrfToken", "tok_123"); got != redactedValue {
+		t.Fatalf("expected csrfToken to be redacted, got %#v", got)
+	}
+	if got := SanitizeFieldValue("authorizationToken", "tok_123"); got != redactedValue {
+		t.Fatalf("expected authorizationToken to be redacted, got %#v", got)
+	}
+	if got := SanitizeFieldValue("sessionSecret", "sec_123"); got != redactedValue {
+		t.Fatalf("expected sessionSecret to be redacted, got %#v", got)
+	}
+}
+
+func TestSanitizeFieldValue_PreservesBusinessKeys(t *testing.T) {
 	t.Parallel()
 
 	if got := SanitizeFieldValue("authorizationCode", "ok_1"); got != "ok_1" {
@@ -215,8 +232,8 @@ func TestSanitizeFieldValue_TesouroGraphQLFixture(t *testing.T) {
 		t.Fatalf("expected transaction to be map, got %T (%#v)", data["transaction"], data["transaction"])
 	}
 
-	if tx["authorizationId"] != "auth_123" {
-		t.Fatalf("expected transaction.authorizationId to be preserved, got %#v", tx["authorizationId"])
+	if tx["authorizationId"] != redactedValue {
+		t.Fatalf("expected transaction.authorizationId to be redacted, got %#v", tx["authorizationId"])
 	}
 	if tx["authorizationCode"] != "ok_1" {
 		t.Fatalf("expected transaction.authorizationCode to be preserved, got %#v", tx["authorizationCode"])

--- a/py/src/apptheory/sanitization.py
+++ b/py/src/apptheory/sanitization.py
@@ -16,7 +16,6 @@ _ALLOWED_FIELDS: set[str] = {
     "card_type",
     # Common system identifiers that are safe/necessary for debugging and correlation.
     "transaction_id",
-    "authorization_id",
     "merchant_uid",
     # External system identifiers (MIDs, acceptor IDs, terminal IDs, etc.).
     "mid",
@@ -57,6 +56,7 @@ _SENSITIVE_FIELDS: dict[str, str] = {
     "api_key": "fully",
     "api_token": "fully",
     "api_key_id": "partial",
+    "authorization_id": "fully",
     "authorization": "fully",
     "authorization_header": "fully",
 }
@@ -180,7 +180,56 @@ def _sanitize_field_value_with_parent(parent_key: str, key: str, value: Any) -> 
             return _mask_restricted_string(str(value or ""))
         return _mask_restricted_string(str(value or ""))
 
+    if _should_heuristically_redact_key(key):
+        return _REDACTED_VALUE
+
     return _sanitize_value_with_parent(k, value)
+
+
+def _should_heuristically_redact_key(key: str) -> bool:
+    segments = _sanitization_key_segments(key)
+    if not segments:
+        return False
+
+    for index, segment in enumerate(segments):
+        if segment in {"token", "secret", "password"}:
+            return True
+        if segment == "key" and index > 0 and segments[index - 1] in {"api", "private", "secret"}:
+            return True
+
+    return False
+
+
+def _sanitization_key_segments(key: str) -> list[str]:
+    value = str(key or "").strip()
+    if not value:
+        return []
+
+    segments: list[str] = []
+    current: list[str] = []
+    previous = ""
+
+    def flush() -> None:
+        nonlocal current
+        if not current:
+            return
+        segments.append("".join(current))
+        current = []
+
+    for char in value:
+        if not char.isalnum():
+            flush()
+            previous = ""
+            continue
+
+        if previous and char.isupper() and (previous.islower() or previous.isdigit()):
+            flush()
+
+        current.append(char.lower())
+        previous = char
+
+    flush()
+    return segments
 
 
 def _sanitize_value(value: Any) -> Any:

--- a/py/tests/test_sanitization.py
+++ b/py/tests/test_sanitization.py
@@ -101,8 +101,12 @@ class TestSanitization(unittest.TestCase):
         self.assertEqual(sanitize_field_value("api_key", "x"), "[REDACTED]")
         self.assertEqual(sanitize_field_value("root", b"a\nb"), "ab")
 
-        self.assertEqual(sanitize_field_value("authorization_id", "auth_123"), "auth_123")
-        self.assertEqual(sanitize_field_value("authorizationId", "auth_123"), "auth_123")
+        self.assertEqual(sanitize_field_value("authorization_id", "auth_123"), "[REDACTED]")
+        self.assertEqual(sanitize_field_value("authorizationId", "auth_123"), "[REDACTED]")
+        self.assertEqual(sanitize_field_value("session_token", "tok_123"), "[REDACTED]")
+        self.assertEqual(sanitize_field_value("csrfToken", "tok_123"), "[REDACTED]")
+        self.assertEqual(sanitize_field_value("authorizationToken", "tok_123"), "[REDACTED]")
+        self.assertEqual(sanitize_field_value("sessionSecret", "sec_123"), "[REDACTED]")
         self.assertEqual(sanitize_field_value("authorizationCode", "ok_1"), "ok_1")
         self.assertEqual(sanitize_field_value("tokenization_method", "apple_pay"), "apple_pay")
         self.assertEqual(sanitize_field_value("merchantId", "m_123"), "m_123")
@@ -158,7 +162,7 @@ class TestSanitization(unittest.TestCase):
                 }
             },
         )
-        self.assertEqual(out["data"]["transaction"]["authorizationId"], "auth_123")
+        self.assertEqual(out["data"]["transaction"]["authorizationId"], "[REDACTED]")
         self.assertEqual(out["data"]["transaction"]["authorizationCode"], "ok_1")
         self.assertEqual(out["data"]["transaction"]["tokenization_method"], "apple_pay")
         self.assertEqual(out["data"]["transaction"]["accessToken"], "[REDACTED]")

--- a/ts/dist/sanitization.js
+++ b/ts/dist/sanitization.js
@@ -9,7 +9,6 @@ const allowedSanitizeFields = new Set([
     "card_type",
     // Common system identifiers that are safe/necessary for debugging and correlation.
     "transaction_id",
-    "authorization_id",
     "merchant_uid",
     // External system identifiers (MIDs, acceptor IDs, terminal IDs, etc.).
     "mid",
@@ -49,6 +48,7 @@ const sensitiveSanitizeFields = new Map([
     ["api_key", "fully"],
     ["api_token", "fully"],
     ["api_key_id", "partial"],
+    ["authorization_id", "fully"],
     ["authorization", "fully"],
     ["authorization_header", "fully"],
 ]);
@@ -191,7 +191,59 @@ function sanitizeFieldValueWithParent(parentKey, key, value) {
         }
         return maskRestrictedString(value);
     }
+    if (shouldHeuristicallyRedactKey(key))
+        return REDACTED_VALUE;
     return sanitizeValueWithParent(k, value);
+}
+function shouldHeuristicallyRedactKey(key) {
+    const segments = sanitizationKeySegments(key);
+    if (segments.length === 0)
+        return false;
+    for (let i = 0; i < segments.length; i += 1) {
+        const segment = segments[i];
+        if (segment === "token" || segment === "secret" || segment === "password") {
+            return true;
+        }
+        if (segment === "key" &&
+            i > 0 &&
+            (segments[i - 1] === "api" ||
+                segments[i - 1] === "private" ||
+                segments[i - 1] === "secret")) {
+            return true;
+        }
+    }
+    return false;
+}
+function sanitizationKeySegments(key) {
+    const value = String(key ?? "").trim();
+    if (!value)
+        return [];
+    const segments = [];
+    let current = "";
+    let previous = "";
+    const flush = () => {
+        if (!current)
+            return;
+        segments.push(current);
+        current = "";
+    };
+    for (const char of value) {
+        const isAlphaNumeric = /[\p{L}\p{N}]/u.test(char);
+        if (!isAlphaNumeric) {
+            flush();
+            previous = "";
+            continue;
+        }
+        if (previous &&
+            /[\p{Lu}]/u.test(char) &&
+            (/[\p{Ll}]/u.test(previous) || /[\p{N}]/u.test(previous))) {
+            flush();
+        }
+        current += char.toLowerCase();
+        previous = char;
+    }
+    flush();
+    return segments;
 }
 export function sanitizeJSON(jsonBytes) {
     const buf = typeof jsonBytes === "string"

--- a/ts/src/sanitization.ts
+++ b/ts/src/sanitization.ts
@@ -13,7 +13,6 @@ const allowedSanitizeFields = new Set([
 
   // Common system identifiers that are safe/necessary for debugging and correlation.
   "transaction_id",
-  "authorization_id",
   "merchant_uid",
 
   // External system identifiers (MIDs, acceptor IDs, terminal IDs, etc.).
@@ -60,6 +59,7 @@ const sensitiveSanitizeFields = new Map<string, "fully" | "partial">([
   ["api_key", "fully"],
   ["api_token", "fully"],
   ["api_key_id", "partial"],
+  ["authorization_id", "fully"],
   ["authorization", "fully"],
   ["authorization_header", "fully"],
 ]);
@@ -227,7 +227,70 @@ function sanitizeFieldValueWithParent(
     return maskRestrictedString(value);
   }
 
+  if (shouldHeuristicallyRedactKey(key)) return REDACTED_VALUE;
+
   return sanitizeValueWithParent(k, value);
+}
+
+function shouldHeuristicallyRedactKey(key: string): boolean {
+  const segments = sanitizationKeySegments(key);
+  if (segments.length === 0) return false;
+
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (segment === "token" || segment === "secret" || segment === "password") {
+      return true;
+    }
+    if (
+      segment === "key" &&
+      i > 0 &&
+      (segments[i - 1] === "api" ||
+        segments[i - 1] === "private" ||
+        segments[i - 1] === "secret")
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function sanitizationKeySegments(key: string): string[] {
+  const value = String(key ?? "").trim();
+  if (!value) return [];
+
+  const segments: string[] = [];
+  let current = "";
+  let previous = "";
+
+  const flush = (): void => {
+    if (!current) return;
+    segments.push(current);
+    current = "";
+  };
+
+  for (const char of value) {
+    const isAlphaNumeric = /[\p{L}\p{N}]/u.test(char);
+    if (!isAlphaNumeric) {
+      flush();
+      previous = "";
+      continue;
+    }
+
+    if (
+      previous &&
+      /[\p{Lu}]/u.test(char) &&
+      (/[\p{Ll}]/u.test(previous) || /[\p{N}]/u.test(previous))
+    ) {
+      flush();
+    }
+
+    current += char.toLowerCase();
+    previous = char;
+  }
+
+  flush();
+  return segments;
 }
 
 export function sanitizeJSON(jsonBytes: Uint8Array | string): string {

--- a/ts/test/sanitization.test.mjs
+++ b/ts/test/sanitization.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitizeFieldValue } from "../dist/index.js";
+
+test("sanitizeFieldValue redacts authorization identifiers and token-like keys", () => {
+  assert.equal(sanitizeFieldValue("authorization_id", "auth_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("authorizationId", "auth_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("session_token", "tok_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("csrfToken", "tok_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("authorizationToken", "tok_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("sessionSecret", "sec_123"), "[REDACTED]");
+});
+
+test("sanitizeFieldValue preserves business keys while masking known sensitive aliases", () => {
+  assert.equal(sanitizeFieldValue("authorizationCode", "ok_1"), "ok_1");
+  assert.equal(sanitizeFieldValue("tokenization_method", "apple_pay"), "apple_pay");
+  assert.equal(sanitizeFieldValue("mid", "mid_1"), "mid_1");
+  assert.equal(sanitizeFieldValue("acceptorId", "acceptor_1"), "acceptor_1");
+});
+


### PR DESCRIPTION
## Milestone
sanitization-secret-key-heuristics — restore token-like secret redaction heuristics and remove unsafe `authorization_id` allowlisting across sanitizers.

## Linear
https://linear.app/theorycloud/project/apptheory-v100-security-hardening-foundation-569d0d9a77d6 / sanitization-secret-key-heuristics

## Tasks
- [x] THE-357 Restore token-like secret redaction heuristics and redact authorization_id in the Go sanitizer
- [x] THE-369 Restore token-like secret redaction heuristics and redact authorization_id in the TypeScript sanitizer
- [x] THE-373 Close sanitizer parity in Python, redact authorization_id, and document restored secret-key heuristics

## Contract impact
internal-only

## Validation
Commands run on the final commit:
- `go test ./pkg/sanitization`
- `cd ts && npm run check && npm run build`
- `node --test ts/test/*.test.mjs`
- `python3 -m unittest discover -s py/tests`
- `make test-unit`
- `golangci-lint cache clean`
- `make rubric`

## Cross-repo notes
none
