### PR TITLE
fix(mcp): harden session lifecycle and streaming

### DIFF
--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -20,7 +20,8 @@ OAuth helper surfaces used by Remote MCP deployments and Autheory are in:
 AppTheory implements MCP Streamable HTTP on a single path:
 
 - `POST /mcp`: JSON-RPC requests, notifications, and client responses
-- `GET /mcp`: resumable SSE replay via `Last-Event-ID`, or a keepalive listener when `Last-Event-ID` is absent
+- `GET /mcp`: resumable SSE replay via `Last-Event-ID`, or a short-lived keepalive SSE response when `Last-Event-ID`
+  is absent
 - `DELETE /mcp`: session termination
 
 Header names are case-insensitive on the wire. The examples in this doc use lowercase HTTP headers.
@@ -195,12 +196,15 @@ For streaming tool calls, AppTheory assigns SSE event ids and persists them in t
 
 - `GET /mcp` with `last-event-id: <id>` resumes or replays that stream
 - clients must reuse the same `mcp-session-id`
-- `GET /mcp` without `last-event-id` opens a session listener that stays alive with keepalive comments so reconnecting
-  clients do not hit immediate EOF loops
+- `GET /mcp` without `last-event-id` emits one keepalive comment and closes by default so idle callers do not hold
+  Lambda concurrency indefinitely
+- if you want that path to stay open for a bounded window before EOF, opt in with
+  `WithInitialSessionListenerBudget(...)`
 
-### Budgeting the initial keepalive listener on Lambda
+### Keeping the initial keepalive path open for a bounded window on Lambda
 
-If you want that initial `GET /mcp` keepalive listener to end before the Lambda deadline, opt in explicitly:
+If you want that initial `GET /mcp` keepalive path to stay open for a bounded window before the Lambda deadline, opt in
+explicitly:
 
 ```go
 srv := mcp.NewServer("my-mcp-server", "dev",
@@ -213,12 +217,13 @@ srv := mcp.NewServer("my-mcp-server", "dev",
 
 Important scope notes:
 
-- this is explicit opt-in; without the option, the keepalive listener behavior is unchanged
+- this is explicit opt-in; without the option, AppTheory emits one keepalive comment and closes
 - it applies only to `GET /mcp` without `last-event-id`
 - replay/resume `GET /mcp` requests with `last-event-id` keep their existing behavior
 - when Lambda `RemainingMS` is available, AppTheory subtracts `SafetyBuffer` from the remaining time and caps the
   listener with `MaxDuration`
-- when `RemainingMS` is unavailable, the keepalive listener continues unchanged even if the option is configured
+- when `RemainingMS` is unavailable, the configured budget does not cap the listener; use this option only on
+  Lambda-backed deployments where `RemainingMS` is available
 - early termination simply ends the listener; AppTheory does not emit a special final SSE event or comment
 
 ---

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -52,7 +52,9 @@ Important behaviors for Claude compatibility:
 - `tools/call` may stream with SSE when the client includes `Accept: text/event-stream`.
 - SSE frames stay on `event: message`; progress is emitted as JSON-RPC `notifications/progress`, not custom SSE event names.
 - Disconnections are not cancellation; resumability uses `GET /mcp` + `Last-Event-ID`.
-- `GET /mcp` without `Last-Event-ID` stays open as a keepalive listener for the current session.
+- `GET /mcp` without `Last-Event-ID` emits a short-lived keepalive SSE response by default.
+- If you want that path to stay open for a bounded window on Lambda, use
+  `mcp.WithInitialSessionListenerBudget(...)`.
 - If the request includes an `Origin` header, the default runtime allowlist is Claude-oriented (`https://claude.ai`,
   `https://claude.com`); use `mcp.WithOriginValidator(...)` for other browser origins.
 
@@ -138,10 +140,11 @@ API Gateway REST response streaming connections are time-bounded and can disconn
   persistent `StreamStore`
 - execute long work asynchronously (worker Lambdas) and append progress/results into the event log
 
-If you want the initial `GET /mcp` keepalive listener to end before the Lambda deadline, opt in with
-`mcp.WithInitialSessionListenerBudget(...)`. This applies only to the initial listener path with no `Last-Event-ID`;
-resume/replay `GET /mcp` requests keep their existing behavior. The example in `examples/mcp/resumable-sse` uses the
-default budget values (`SafetyBuffer: 5s`, `MaxDuration: 25s`) explicitly so the Lambda behavior is visible in code.
+If you want the initial `GET /mcp` keepalive path to stay open for a bounded window before the Lambda deadline, opt in
+with `mcp.WithInitialSessionListenerBudget(...)`. This applies only to the initial listener path with no
+`Last-Event-ID`; resume/replay `GET /mcp` requests keep their existing behavior. The example in
+`examples/mcp/resumable-sse` uses the default budget values (`SafetyBuffer: 5s`, `MaxDuration: 25s`) explicitly so the
+Lambda behavior is visible in code.
 
 Detailed compatibility notes and HTTP transcripts are maintained in non-canonical planning docs and intentionally kept
 out of this user-facing guide.

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -897,6 +897,12 @@ func (s *Server) getSession(ctx context.Context, sessionID string) (*Session, er
 	if err != nil {
 		return nil, err
 	}
+	if sessionExpiredAt(now, sess) {
+		if deleteErr := s.sessionStore.Delete(ctx, sessionID); deleteErr != nil && !errors.Is(deleteErr, ErrSessionNotFound) {
+			s.logger.WarnContext(ctx, "failed to delete expired session", "sessionId", sessionID, "error", deleteErr)
+		}
+		return nil, ErrSessionNotFound
+	}
 
 	// Refresh session TTL on access (sliding window).
 	sess.ExpiresAt = now.Add(ttl)

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -363,6 +363,15 @@ func (s *Server) openSessionListener(ctx context.Context, sessionID string, rema
 			return
 		}
 
+		// By default this initial GET /mcp path emits one keepalive comment and
+		// closes so idle callers do not hold Lambda concurrency indefinitely.
+		// Operators can opt into a bounded keepalive window with
+		// WithInitialSessionListenerBudget when they need to avoid immediate EOF
+		// reconnect loops.
+		if s == nil || s.initialSessionListenerBudget == nil {
+			return
+		}
+
 		// Keepalives prevent API Gateway idle timeouts (Regional endpoints idle out
 		// after ~5 minutes without data).
 		ticker := time.NewTicker(2 * time.Minute)

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -1050,6 +1050,14 @@ func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID strin
 			s.logger.ErrorContext(ctx, "stream store close error", "sessionId", sessionID, "streamId", streamID, "error", err)
 		}
 	}()
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(ctx, "streaming tool panic", "sessionId", sessionID, "streamId", streamID, "panic", r)
+			if err := s.appendStreamResponse(ctx, sessionID, streamID, NewErrorResponse(req.ID, CodeInternalError, "internal error")); err != nil {
+				s.logger.ErrorContext(ctx, "stream store append error", "sessionId", sessionID, "streamId", streamID, "error", err)
+			}
+		}
+	}()
 
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {

--- a/runtime/mcp/server_coverage_more_test.go
+++ b/runtime/mcp/server_coverage_more_test.go
@@ -166,6 +166,38 @@ func TestRequireSession_Errors(t *testing.T) {
 	}
 }
 
+func TestRequireSession_RejectsExpiredSessionBeforeRefresh(t *testing.T) {
+	s := NewServer("test", "dev")
+	ctx := context.Background()
+
+	putCalled := false
+	deleteCalled := false
+	s.sessionStore = stubSessionStore{
+		get: func(context.Context, string) (*Session, error) {
+			return &Session{ID: "expired", ExpiresAt: time.Now().Add(-time.Minute)}, nil
+		},
+		put: func(context.Context, *Session) error {
+			putCalled = true
+			return nil
+		},
+		delete: func(context.Context, string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+
+	_, _, resp := s.requireSession(ctx, map[string][]string{"mcp-session-id": {"expired"}})
+	if resp == nil || resp.Status != 404 {
+		t.Fatalf("expected expired session to return 404, got %+v", resp)
+	}
+	if putCalled {
+		t.Fatalf("expected expired session to skip refresh put")
+	}
+	if !deleteCalled {
+		t.Fatalf("expected expired session cleanup delete to run")
+	}
+}
+
 func TestHandleGET_EventNotFound_AndStoreErrors(t *testing.T) {
 	s := NewServer("test", "dev")
 	sessionID := initializeSession(t, s)

--- a/runtime/mcp/session.go
+++ b/runtime/mcp/session.go
@@ -17,6 +17,13 @@ type Session struct {
 	Data      map[string]string `json:"data,omitempty"`
 }
 
+func sessionExpiredAt(now time.Time, sess *Session) bool {
+	if sess == nil || sess.ExpiresAt.IsZero() {
+		return false
+	}
+	return !sess.ExpiresAt.After(now)
+}
+
 // SessionStore is the interface for session persistence backends.
 type SessionStore interface {
 	Get(ctx context.Context, id string) (*Session, error)
@@ -68,7 +75,7 @@ func (m *MemorySessionStore) Get(_ context.Context, id string) (*Session, error)
 	}
 
 	// Check TTL expiration.
-	if !sess.ExpiresAt.IsZero() && m.clock.Now().After(sess.ExpiresAt) {
+	if sessionExpiredAt(m.clock.Now(), sess) {
 		// Lazily remove expired session.
 		m.mu.Lock()
 		delete(m.store, id)

--- a/runtime/mcp/session_dynamo.go
+++ b/runtime/mcp/session_dynamo.go
@@ -50,7 +50,11 @@ func (d *DynamoSessionStore) Get(ctx context.Context, id string) (*Session, erro
 		return nil, err
 	}
 
-	return recordToSession(&record), nil
+	sess := recordToSession(&record)
+	if sessionExpiredAt(time.Now().UTC(), sess) {
+		return nil, ErrSessionNotFound
+	}
+	return sess, nil
 }
 
 // Put stores a session. Overwrites any existing session with the same ID.

--- a/runtime/mcp/session_dynamo_test.go
+++ b/runtime/mcp/session_dynamo_test.go
@@ -24,8 +24,8 @@ func TestDynamoSessionStore_Get_Success(t *testing.T) {
 		out, ok := args.Get(0).(*sessionRecord)
 		require.True(t, ok)
 		out.SessionID = "sess-123"
-		out.CreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		out.ExpiresAt = time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC).Unix()
+		out.CreatedAt = time.Now().Add(-time.Minute).UTC()
+		out.ExpiresAt = time.Now().Add(time.Hour).UTC().Unix()
 		out.Data = map[string]string{"key": "value"}
 	}).Return(nil)
 
@@ -33,7 +33,6 @@ func TestDynamoSessionStore_Get_Success(t *testing.T) {
 	sess, err := store.Get(context.Background(), "sess-123")
 	require.NoError(t, err)
 	require.Equal(t, "sess-123", sess.ID)
-	require.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), sess.CreatedAt)
 	require.Equal(t, "value", sess.Data["key"])
 }
 
@@ -48,6 +47,26 @@ func TestDynamoSessionStore_Get_NotFound(t *testing.T) {
 
 	store := NewDynamoSessionStore(db)
 	_, err := store.Get(context.Background(), "missing")
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestDynamoSessionStore_Get_Expired(t *testing.T) {
+	db := new(tablemocks.MockDB)
+	q := new(tablemocks.MockQuery)
+
+	db.On("Model", mock.Anything).Return(q)
+	q.On("WithContext", mock.Anything).Return(q)
+	q.On("Where", "SessionID", "=", "expired").Return(q)
+	q.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		out, ok := args.Get(0).(*sessionRecord)
+		require.True(t, ok)
+		out.SessionID = "expired"
+		out.CreatedAt = time.Now().Add(-2 * time.Hour).UTC()
+		out.ExpiresAt = time.Now().Add(-1 * time.Minute).UTC().Unix()
+	}).Return(nil)
+
+	store := NewDynamoSessionStore(db)
+	_, err := store.Get(context.Background(), "expired")
 	require.ErrorIs(t, err, ErrSessionNotFound)
 }
 

--- a/runtime/mcp/streaming_test.go
+++ b/runtime/mcp/streaming_test.go
@@ -399,3 +399,48 @@ func TestGET_NoLastEventID_ReturnsShortKeepaliveResponse(t *testing.T) {
 		t.Fatalf("expected no extra listener frames after initial keepalive, got %q", string(rest))
 	}
 }
+
+func TestToolsCallStreaming_PanicReturnsInternalError(t *testing.T) {
+	s := NewServer("test-server", "1.0.0")
+	sessionID := initializeSession(t, s)
+
+	if err := s.registry.RegisterStreamingTool(
+		ToolDef{
+			Name:        "panic_tool",
+			Description: "Panics during streaming execution",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		func(context.Context, json.RawMessage, func(SSEEvent)) (*ToolResult, error) {
+			panic("boom")
+		},
+	); err != nil {
+		t.Fatalf("register streaming tool: %v", err)
+	}
+
+	params := toolsCallParams{Name: "panic_tool", Arguments: json.RawMessage(`{}`)}
+	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
+
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"text/event-stream"}
+
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if resp.BodyReader == nil {
+		t.Fatalf("expected streaming response BodyReader to be set")
+	}
+
+	b, err := io.ReadAll(resp.BodyReader)
+	if err != nil {
+		t.Fatalf("read panic SSE stream: %v", err)
+	}
+
+	all := string(b)
+	if !strings.Contains(all, `"error":{"code":-32603,"message":"internal error"}`) {
+		t.Fatalf("expected internal error payload, got:\n%s", all)
+	}
+	if strings.Contains(all, "boom") {
+		t.Fatalf("panic text leaked into stream:\n%s", all)
+	}
+}

--- a/runtime/mcp/streaming_test.go
+++ b/runtime/mcp/streaming_test.go
@@ -337,7 +337,7 @@ func TestToolsCallStreaming_CanResumeViaGETWithLastEventID(t *testing.T) {
 	}
 }
 
-func TestGET_NoLastEventID_OpensSessionListenerAndKeepsAlive(t *testing.T) {
+func TestGET_NoLastEventID_ReturnsShortKeepaliveResponse(t *testing.T) {
 	s := NewServer("test-server", "1.0.0")
 	sessionID := initializeSession(t, s)
 
@@ -375,5 +375,27 @@ func TestGET_NoLastEventID_OpensSessionListenerAndKeepsAlive(t *testing.T) {
 	}
 	if !strings.HasPrefix(frame, ":") || !strings.Contains(frame, "keepalive") {
 		t.Fatalf("expected keepalive comment frame, got:\n%s", frame)
+	}
+
+	var (
+		rest    []byte
+		restErr error
+	)
+	restDone := make(chan struct{})
+	go func() {
+		defer close(restDone)
+		rest, restErr = io.ReadAll(reader)
+	}()
+
+	select {
+	case <-restDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for short keepalive response to close")
+	}
+	if restErr != nil {
+		t.Fatalf("read short keepalive response: %v", restErr)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("expected no extra listener frames after initial keepalive, got %q", string(rest))
 	}
 }


### PR DESCRIPTION
## Milestone
batched MCP hardening — bound idle session listeners, reject expired sessions before refresh, and recover streaming tool panics.

## Linear
AppTheory v1.0.0 security-hardening foundation / THE-358 / THE-359 / THE-360

## Tasks
- [x] THE-358 Bound idle session-level GET listeners in the MCP server
- [x] THE-359 Reject expired MCP sessions before TTL refresh
- [x] THE-360 Recover panics in streaming MCP tool execution

## Contract impact
internal-only

## Validation
Commands run on the final branch tip:
- `go test ./runtime/mcp`
- `golangci-lint cache clean`
- `make rubric`

## Cross-repo notes
none
