### PR TITLE
fix(jobs): bound semaphore acquisition limits

### DIFF
--- a/pkg/jobs/ledger.go
+++ b/pkg/jobs/ledger.go
@@ -16,6 +16,8 @@ type DynamoJobLedger struct {
 	clock  Clock
 }
 
+const maxSemaphoreAcquireLimit = 256
+
 var _ JobLedger = (*DynamoJobLedger)(nil)
 
 func NewDynamoJobLedger(db tablecore.DB, config *Config) *DynamoJobLedger {
@@ -312,8 +314,8 @@ func (l *DynamoJobLedger) AcquireSemaphoreSlot(ctx context.Context, in AcquireSe
 	if err := validateSemaphoreKey(in.Scope, in.Subject); err != nil {
 		return nil, err
 	}
-	if in.Limit <= 0 {
-		return nil, NewError(ErrorTypeInvalidInput, "limit must be > 0")
+	if err := validateSemaphoreLimit(in.Limit); err != nil {
+		return nil, err
 	}
 	if strings.TrimSpace(in.Owner) == "" {
 		return nil, NewError(ErrorTypeInvalidInput, "owner is required")
@@ -626,6 +628,16 @@ func validateSemaphoreKey(scope, subject string) error {
 func validateSemaphoreSlot(slot int) error {
 	if slot < 0 {
 		return NewError(ErrorTypeInvalidInput, "slot must be >= 0")
+	}
+	return nil
+}
+
+func validateSemaphoreLimit(limit int) error {
+	if limit <= 0 {
+		return NewError(ErrorTypeInvalidInput, "limit must be > 0")
+	}
+	if limit > maxSemaphoreAcquireLimit {
+		return NewError(ErrorTypeInvalidInput, "limit must be <= 256")
 	}
 	return nil
 }

--- a/pkg/jobs/ledger_test.go
+++ b/pkg/jobs/ledger_test.go
@@ -534,6 +534,25 @@ func TestDynamoJobLedger_AcquireSemaphoreSlot_Full(t *testing.T) {
 	require.Equal(t, ErrorTypeConflict, typed.Type)
 }
 
+func TestDynamoJobLedger_AcquireSemaphoreSlot_RejectsPathologicalLimit(t *testing.T) {
+	ledger := NewDynamoJobLedger(nil, DefaultConfig())
+
+	lease, err := ledger.AcquireSemaphoreSlot(context.Background(), AcquireSemaphoreSlotInput{
+		Scope:         "email",
+		Subject:       "customer_1",
+		Limit:         maxSemaphoreAcquireLimit + 1,
+		Owner:         "worker_a",
+		LeaseDuration: 2 * time.Minute,
+	})
+	require.Nil(t, lease)
+	require.Error(t, err)
+
+	var typed *Error
+	require.ErrorAs(t, err, &typed)
+	require.Equal(t, ErrorTypeInvalidInput, typed.Type)
+	require.Equal(t, "limit must be <= 256", typed.Message)
+}
+
 func TestDynamoJobLedger_RefreshSemaphoreSlot_Success(t *testing.T) {
 	now := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
 

--- a/py/src/apptheory/jobs.py
+++ b/py/src/apptheory/jobs.py
@@ -12,6 +12,7 @@ from apptheory.sanitization import sanitize_field_value, sanitize_log_string
 
 EnvJobsTableName = "APPTHEORY_JOBS_TABLE_NAME"
 DEFAULT_JOBS_TABLE_NAME = "apptheory-jobs"
+MAX_SEMAPHORE_ACQUIRE_LIMIT = 256
 
 JobStatus = Literal["PENDING", "RUNNING", "SUCCEEDED", "FAILED", "CANCELED"]
 RecordStatus = Literal["PENDING", "PROCESSING", "SUCCEEDED", "FAILED", "SKIPPED"]
@@ -71,6 +72,15 @@ def semaphore_partition_key(scope: str, subject: str) -> str:
 
 def semaphore_slot_sort_key(slot: int) -> str:
     return f"SLOT#{max(0, int(slot)):09d}"
+
+
+def validate_semaphore_limit(limit: int) -> int:
+    normalized = int(limit)
+    if normalized <= 0:
+        raise new_error("invalid_input", "limit must be > 0")
+    if normalized > MAX_SEMAPHORE_ACQUIRE_LIMIT:
+        raise new_error("invalid_input", f"limit must be <= {MAX_SEMAPHORE_ACQUIRE_LIMIT}")
+    return normalized
 
 
 def unix_seconds(value: dt.datetime) -> int:
@@ -586,8 +596,7 @@ class DynamoJobLedger:
             raise new_error("invalid_input", "scope is required")
         if not subject:
             raise new_error("invalid_input", "subject is required")
-        if int(limit) <= 0:
-            raise new_error("invalid_input", "limit must be > 0")
+        limit = validate_semaphore_limit(limit)
         if not owner:
             raise new_error("invalid_input", "owner is required")
 
@@ -602,7 +611,7 @@ class DynamoJobLedger:
         ttl_unix = _normalize_ttl_unix_seconds(now, ttl, dt.timedelta(0))
         pk = semaphore_partition_key(scope, subject)
 
-        for slot in range(int(limit)):
+        for slot in range(limit):
             sk = semaphore_slot_sort_key(slot)
             try:
                 return self.semaphore_table.update(

--- a/py/tests/test_jobs.py
+++ b/py/tests/test_jobs.py
@@ -385,6 +385,17 @@ class TestJobs(unittest.TestCase):
         self.assertEqual(ctx.exception.type, "invalid_input")
 
         with self.assertRaises(JobLedgerError) as ctx:
+            ledger.acquire_semaphore_slot(
+                scope="email",
+                subject="customer_1",
+                limit=10_000,
+                owner="w1",
+                lease_duration=dt.timedelta(minutes=2),
+            )
+        self.assertEqual(ctx.exception.type, "invalid_input")
+        self.assertEqual(ctx.exception.message, "limit must be <= 256")
+
+        with self.assertRaises(JobLedgerError) as ctx:
             ledger.refresh_semaphore_slot(
                 scope="email",
                 subject="customer_1",

--- a/ts/dist/jobs.js
+++ b/ts/dist/jobs.js
@@ -239,6 +239,7 @@ function toSemaphoreLease(item) {
             : {}),
     };
 }
+const maxSemaphoreAcquireLimit = 256;
 function requireNonEmpty(value, field) {
     const v = String(value ?? "").trim();
     if (!v)
@@ -250,6 +251,13 @@ function requirePositiveInt(value, field) {
     if (n <= 0)
         throw newJobLedgerError("invalid_input", `${field} must be > 0`);
     return n;
+}
+function requireSemaphoreLimit(value) {
+    const limit = requirePositiveInt(value, "limit");
+    if (limit > maxSemaphoreAcquireLimit) {
+        throw newJobLedgerError("invalid_input", `limit must be <= ${maxSemaphoreAcquireLimit}`);
+    }
+    return limit;
 }
 function requireNonNegativeInt(value, field) {
     const n = Math.floor(Number(value));
@@ -505,7 +513,7 @@ export class DynamoJobLedger {
     async acquireSemaphoreSlot(input) {
         const scope = requireNonEmpty(input?.scope, "scope");
         const subject = requireNonEmpty(input?.subject, "subject");
-        const limit = requirePositiveInt(input?.limit, "limit");
+        const limit = requireSemaphoreLimit(input?.limit);
         const owner = requireNonEmpty(input?.owner, "owner");
         const leaseDurationMs = Math.floor(Number(input?.leaseDurationMs ?? this._config.defaultLeaseDurationMs) ||
             0);

--- a/ts/src/jobs.ts
+++ b/ts/src/jobs.ts
@@ -536,6 +536,8 @@ export type CompleteIdempotencyRecordInput = {
   ttlSeconds?: number;
 };
 
+const maxSemaphoreAcquireLimit = 256;
+
 function requireNonEmpty(value: unknown, field: string): string {
   const v = String(value ?? "").trim();
   if (!v) throw newJobLedgerError("invalid_input", `${field} is required`);
@@ -546,6 +548,17 @@ function requirePositiveInt(value: unknown, field: string): number {
   const n = Math.floor(Number(value) || 0);
   if (n <= 0) throw newJobLedgerError("invalid_input", `${field} must be > 0`);
   return n;
+}
+
+function requireSemaphoreLimit(value: unknown): number {
+  const limit = requirePositiveInt(value, "limit");
+  if (limit > maxSemaphoreAcquireLimit) {
+    throw newJobLedgerError(
+      "invalid_input",
+      `limit must be <= ${maxSemaphoreAcquireLimit}`,
+    );
+  }
+  return limit;
 }
 
 function requireNonNegativeInt(value: unknown, field: string): number {
@@ -867,7 +880,7 @@ export class DynamoJobLedger {
   ): Promise<SemaphoreLease> {
     const scope = requireNonEmpty(input?.scope, "scope");
     const subject = requireNonEmpty(input?.subject, "subject");
-    const limit = requirePositiveInt(input?.limit, "limit");
+    const limit = requireSemaphoreLimit(input?.limit);
     const owner = requireNonEmpty(input?.owner, "owner");
 
     const leaseDurationMs = Math.floor(

--- a/ts/test/jobs.test.mjs
+++ b/ts/test/jobs.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DynamoJobLedger } from "../dist/index.js";
+
+test("DynamoJobLedger rejects pathological semaphore limits before attempting storage writes", async () => {
+  let registerCalls = 0;
+  const ledger = new DynamoJobLedger({
+    theorydb: {
+      register() {
+        registerCalls += 1;
+      },
+    },
+  });
+
+  await assert.rejects(
+    ledger.acquireSemaphoreSlot({
+      scope: "email",
+      subject: "customer_1",
+      limit: 10_000,
+      owner: "worker_a",
+      leaseDurationMs: 60_000,
+    }),
+    (err) => {
+      assert.equal(err?.type, "invalid_input");
+      assert.match(String(err?.message ?? ""), /limit must be <= 256/);
+      return true;
+    },
+  );
+
+  assert.equal(registerCalls, 1);
+});


### PR DESCRIPTION
## Milestone
semaphore-limit-bounds — reject pathological semaphore limits across Go, TypeScript, and Python

## Linear
AppTheory v1.0.0 security-hardening foundation
- THE-378
- THE-380
- THE-382

## Tasks
- [x] THE-378 — Enforce bounded semaphore acquisition limits in Go
- [x] THE-380 — Close bounded semaphore acquisition parity in TypeScript
- [x] THE-382 — Close bounded semaphore acquisition parity in Python

## Contract impact
internal-only

## Validation
Commands run on the final branch tip:
- `go test ./pkg/jobs`
- `cd ts && npm run check && npm run build && node --test test/jobs.test.mjs`
- `python3 -m unittest discover -s py/tests`
- `make rubric`

## Cross-repo notes
- This branch was created from `staging` after explicitly checking `main`; `git merge --no-ff origin/main` reported `Already up to date`, so the branch includes the current `main` line before milestone changes.
