### PR TITLE
fix(ts): harden header canonicalization safety

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -35,6 +35,8 @@ Each fixture is a single JSON object.
     (`expect.response.chunks`), the already-committed status/headers remain intact and the stream terminates with
     `expect.response.stream_error_code = "app.too_large"` once the next streamed chunk would exceed the limit.
 - `input.request` (object): request presented to the runtime under test.
+  - `headers` keys are canonicalized to lowercase but otherwise treated as ordinary header names, including
+    prototype-like keys such as `constructor` and `__proto__`.
 - `input.context` (object, optional): synthetic invocation context (portable subset).
 - `setup.routes[].auth_required` (boolean, optional): whether the route requires auth.
 - `expect.response` (object): expected canonical response.

--- a/contract-tests/fixtures/p0/header-prototype-keys.json
+++ b/contract-tests/fixtures/p0/header-prototype-keys.json
@@ -1,0 +1,45 @@
+{
+  "id": "p0.request.header_prototype_keys",
+  "tier": "p0",
+  "name": "Prototype-like header names are treated as ordinary headers",
+  "setup": {
+    "routes": [
+      { "method": "GET", "path": "/echo", "handler": "echo_request" }
+    ]
+  },
+  "input": {
+    "request": {
+      "method": "GET",
+      "path": "/echo",
+      "query": {},
+      "headers": {
+        "__proto__": ["proto"],
+        "constructor": ["ctor"],
+        "X-Foo": ["A"]
+      },
+      "body": { "encoding": "utf8", "value": "" },
+      "is_base64": false
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": { "content-type": ["application/json; charset=utf-8"] },
+      "cookies": [],
+      "body_json": {
+        "method": "GET",
+        "path": "/echo",
+        "query": {},
+        "headers": {
+          "__proto__": ["proto"],
+          "constructor": ["ctor"],
+          "x-foo": ["A"]
+        },
+        "cookies": {},
+        "body_b64": "",
+        "is_base64": false
+      },
+      "is_base64": false
+    }
+  }
+}

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -83,7 +83,7 @@ function loadFixtures(fixturesRoot) {
 }
 
 function canonicalizeHeaders(headers) {
-  const out = {};
+  const out = Object.create(null);
   if (!headers) return out;
   const keys = Object.keys(headers).sort();
   for (const key of keys) {
@@ -91,7 +91,7 @@ function canonicalizeHeaders(headers) {
     if (!lower) continue;
     const values = Array.isArray(headers[key]) ? headers[key] : [headers[key]];
     if (!out[lower]) out[lower] = [];
-    out[lower].push(...values);
+    out[lower].push(...values.map((v) => String(v)));
   }
   return out;
 }

--- a/ts/dist/internal/http.js
+++ b/ts/dist/internal/http.js
@@ -1,5 +1,8 @@
 import { Buffer } from "node:buffer";
 import { AppError } from "../errors.js";
+function emptyHeaders() {
+    return Object.create(null);
+}
 export function normalizeMethod(method) {
     return String(method ?? "")
         .trim()
@@ -25,7 +28,7 @@ export function splitPath(path) {
     return value.split("/");
 }
 export function canonicalizeHeaders(headers) {
-    const out = {};
+    const out = emptyHeaders();
     if (headers === null ||
         headers === undefined ||
         typeof headers !== "object") {
@@ -105,7 +108,7 @@ export async function* normalizeBodyStream(bodyStream) {
     throw new TypeError("bodyStream must be an Iterable or AsyncIterable");
 }
 export function headersFromSingle(headers, ignoreCookieHeader) {
-    const out = {};
+    const out = emptyHeaders();
     if (!headers)
         return out;
     for (const [key, value] of Object.entries(headers)) {

--- a/ts/src/internal/http.ts
+++ b/ts/src/internal/http.ts
@@ -3,6 +3,10 @@ import { Buffer } from "node:buffer";
 import { AppError } from "../errors.js";
 import type { BodyStream, Headers, Query } from "../types.js";
 
+function emptyHeaders(): Headers {
+  return Object.create(null) as Headers;
+}
+
 export function normalizeMethod(method: unknown): string {
   return String(method ?? "")
     .trim()
@@ -26,7 +30,7 @@ export function splitPath(path: unknown): string[] {
 }
 
 export function canonicalizeHeaders(headers: unknown): Headers {
-  const out: Headers = {};
+  const out = emptyHeaders();
   if (
     headers === null ||
     headers === undefined ||
@@ -116,7 +120,7 @@ export function headersFromSingle(
   headers: Record<string, unknown> | null | undefined,
   ignoreCookieHeader: boolean,
 ): Headers {
-  const out: Headers = {};
+  const out = emptyHeaders();
   if (!headers) return out;
 
   for (const [key, value] of Object.entries(headers)) {

--- a/ts/test/header-canonicalization.test.mjs
+++ b/ts/test/header-canonicalization.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../dist/index.js";
+import { canonicalizeHeaders, headersFromSingle } from "../dist/internal/http.js";
+
+function prototypeLikeHeaders() {
+  return JSON.parse('{"__proto__":"proto","constructor":"ctor","X-Foo":"A"}');
+}
+
+test("canonicalizeHeaders treats prototype-like keys as ordinary headers", () => {
+  const headers = canonicalizeHeaders(prototypeLikeHeaders());
+
+  assert.equal(Object.getPrototypeOf(headers), null);
+  assert.deepEqual(headers["__proto__"], ["proto"]);
+  assert.deepEqual(headers.constructor, ["ctor"]);
+  assert.deepEqual(headers["x-foo"], ["A"]);
+});
+
+test("headersFromSingle preserves prototype-like keys before request normalization", () => {
+  const headers = headersFromSingle(prototypeLikeHeaders(), false);
+
+  assert.equal(Object.getPrototypeOf(headers), null);
+  assert.deepEqual(headers["__proto__"], ["proto"]);
+  assert.deepEqual(headers.constructor, ["ctor"]);
+  assert.deepEqual(headers["X-Foo"], ["A"]);
+});
+
+test("serveAPIGatewayV2 accepts prototype-like headers without returning app.internal", async () => {
+  const app = createApp({ tier: "p0" });
+  app.get("/echo", (ctx) => ({
+    status: 200,
+    headers: { "content-type": ["application/json; charset=utf-8"] },
+    cookies: [],
+    body: Buffer.from(JSON.stringify(ctx.request.headers), "utf8"),
+    isBase64: false,
+  }));
+
+  const resp = await app.serveAPIGatewayV2({
+    headers: prototypeLikeHeaders(),
+    rawPath: "/echo",
+    rawQueryString: "",
+    body: "",
+    isBase64Encoded: false,
+    requestContext: {
+      http: {
+        method: "GET",
+        path: "/echo",
+      },
+    },
+  });
+
+  assert.equal(resp.statusCode, 200);
+  assert.deepEqual(
+    JSON.parse(resp.body),
+    JSON.parse(
+      '{"__proto__":["proto"],"constructor":["ctor"],"x-foo":["A"]}',
+    ),
+  );
+});


### PR DESCRIPTION
## Milestone
header-canonicalization-safety — harden TypeScript header normalization against prototype-like header names

## Linear
- THE-379
- THE-381

## Tasks
- [x] THE-379 — Specify prototype-safe header canonicalization in contract fixtures
- [x] THE-381 — Make TypeScript header canonicalization prototype-safe

## Contract impact
Fixture-first for the new P0 header normalization case, with the TypeScript/runtime and TS contract runner hardened in the same milestone so parity stays green.

## Validation
Commands run on the final commit:
- `cd ts && npm run check && npm run build`
- `node --test ts/test/header-canonicalization.test.mjs`
- `./scripts/verify-contract-tests.sh`
- `golangci-lint cache clean`
- `make rubric`

## Cross-repo notes
- `main` was checked up front before implementation; `origin/main` was already up to date relative to the branch base, so there was no merge delta to carry.
