### PR TITLE
docs(migration): add v1.0 security guide

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,6 +29,11 @@ Verification command surface:
 - `./scripts/verify-docs-standard.sh`
 - `make rubric`
 
+Security migration note:
+
+- For consolidated v1.0 fail-closed migration guidance across the surfaces documented here, see
+  `docs/migration/v1-security.md`.
+
 ## Core runtime entrypoints
 
 | Concern | Go | TypeScript | Python |
@@ -157,6 +162,7 @@ AppTheory supports the standard AWS direct Lambda resolver event shape in all th
     `error_type`, `error_data`, and `error_info`
   - portable AppTheory/AppError payloads include `error_data.status_code` and may include `request_id`, `trace_id`,
     `timestamp`, plus `error_info.code`, `trigger_type`, `method`, `path`, and optional `details`
+  - non-portable exceptions now mask to `error_message: "internal error"` instead of echoing raw exception text
 
 Recipe:
 
@@ -199,6 +205,7 @@ Go runtime note:
 - `AuthIdentity`, `TenantID`, and explicit `ExtractIdentifier` overrides are unchanged.
 - This avoids storing raw credentials in rate-limit tables, but it also changes observed key values and resets any
   existing credential-backed buckets on first deploy.
+- For operator migration guidance, see `docs/migration/v1-security.md`.
 
 ### Sanitization
 
@@ -209,6 +216,11 @@ Safe logging helpers are exported in all three runtimes:
 - Python: `sanitize_log_string`, `sanitize_field_value`, `sanitize_json`, `sanitize_json_value`, `sanitize_xml`
 
 Guide: [Sanitization](./features/sanitization.md)
+
+Operational note:
+
+- Sanitization heuristics once again redact token-like unknown keys by default, including `authorization_id`. See
+  `docs/migration/v1-security.md` if you have log-processing workflows that depended on those values remaining visible.
 
 ### Jobs ledger
 

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -148,7 +148,8 @@ Important fail-closed rules:
 - The middleware no longer derives protected-resource metadata from `Host` / `X-Forwarded-Proto` request headers.
   Use `MCP_ENDPOINT` or pass `ResourceMetadataURL` explicitly.
 
-For migration notes, see `docs/migration/v1-security.md`.
+For migration notes covering Bearer validation, initial listener keepalive changes, and expired-session fail-closed
+behavior, see `docs/migration/v1-security.md`.
 
 ## Keepalive, replay, and origin guidance
 

--- a/docs/cdk/ssr-site.md
+++ b/docs/cdk/ssr-site.md
@@ -6,6 +6,9 @@ Use this guide when you want the canonical AppTheory deployment pattern for Face
 `examples/cdk/ssr-site/` is the canonical implementation to copy from; it is not a weaker helper path separate from
 the FaceTheory deployment contract.
 
+For v1.0 fail-closed migration notes covering Function URL auth defaults, tenant-header trust, and related cache-key
+changes, see `docs/migration/v1-security.md`.
+
 ## Preferred mode
 
 Prefer `mode: AppTheorySsrSiteMode.SSG_ISR` unless you are intentionally keeping a narrower compatibility path.

--- a/docs/features/sanitization.md
+++ b/docs/features/sanitization.md
@@ -5,6 +5,9 @@ PCI/PII-heavy services (including import pipelines).
 
 Sanitization is a **last line of defense**. Prefer not to log secrets at all, and treat any logged payload as user data.
 
+For v1.0 migration notes covering the restored token-like redaction heuristics and `authorization_id` redaction, see
+`docs/migration/v1-security.md`.
+
 ## What to sanitize
 
 - **Log strings**: strip control characters (`\r`, `\n`) to prevent log forging.

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -9,6 +9,10 @@ For the Claude-first Remote MCP deployment guide, see:
 
 - `docs/integrations/remote-mcp.md`
 
+For v1.0 fail-closed migration notes that affect MCP transport and session behavior, see:
+
+- `docs/migration/v1-security.md`
+
 OAuth helper surfaces used by Remote MCP deployments and Autheory are in:
 
 - `github.com/theory-cloud/apptheory/runtime/oauth`

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -84,7 +84,8 @@ Important fail-closed rules:
 When you deploy with `AppTheoryRemoteMcpServer`, the construct injects `MCP_ENDPOINT`. That is the canonical metadata
 source when you do not provide `ResourceMetadataURL` explicitly.
 
-For migration notes, see `docs/migration/v1-security.md`.
+For migration notes covering Bearer validation, initial listener keepalive changes, and expired-session fail-closed
+behavior, see `docs/migration/v1-security.md`.
 
 ## 3) Deploy on AWS (REST API v1 response streaming)
 

--- a/docs/migration/appsync-lambda-resolvers.md
+++ b/docs/migration/appsync-lambda-resolvers.md
@@ -7,6 +7,9 @@ request mapping template rewrites to use the runtime adapters documented here.
 
 If you also need the infrastructure side, see [CDK AppSync Lambda Resolvers](../cdk/appsync-lambda-resolvers.md).
 
+For v1.0 migration notes covering AppSync internal-error masking and other fail-closed changes, see
+`docs/migration/v1-security.md`.
+
 ## Choose the entrypoint
 
 Use the explicit AppSync entrypoint when the Lambda is dedicated to AppSync:
@@ -184,6 +187,9 @@ Portable AppTheory/AppError values also carry deterministic metadata:
 
 Binary and streaming response bodies are intentionally out of scope for AppSync and fail closed with deterministic
 system-error envelopes.
+
+Non-portable exceptions now mask to `error_message: "internal error"` instead of echoing raw exception text. If you
+need a caller-visible message, return a portable AppTheory/AppError instead.
 
 ## Local tests
 

--- a/docs/migration/from-lift.md
+++ b/docs/migration/from-lift.md
@@ -7,6 +7,7 @@ functionality remains available for Go users** (portable subset + documented Go-
 
 ## Start Here
 
+- Consolidated v1.0 security migration notes: `docs/migration/v1-security.md`
 - Representative migration notes: `docs/migration/g4-representative-migration.md`
 - Canonical interface map: `docs/api-reference.md`
 - Canonical runtime patterns: `docs/core-patterns.md`
@@ -459,6 +460,8 @@ Planned:
 
 ## Validation Checklist
 
+- Review `docs/migration/v1-security.md` before cutover for fail-closed changes that affect auth hooks, CORS, AppSync
+  error masking, SSR/CDK defaults, MCP transport, and logging expectations.
 - Service builds and passes its unit/integration tests.
 - End-to-end HTTP behavior matches expected client contracts (error codes/envelopes, CORS/auth behavior).
 - Rate limiting behavior matches `limited` semantics where used.

--- a/docs/migration/v1-security.md
+++ b/docs/migration/v1-security.md
@@ -1,13 +1,41 @@
 # AppTheory v1.0 Security Migration Guide
 
-This guide tracks security-hardening changes that are intentionally moving AppTheory toward the v1.0 fail-closed
+This guide consolidates the security-hardening changes that intentionally move AppTheory to the v1.0 fail-closed
 baseline.
+
+Read this guide before promoting a pre-v1 deployment that relied on previous permissive behavior in AppTheory’s
+runtime, MCP transport, or CDK constructs. Not every hardening item needs a migration action, but the ones below are
+the surfaces most likely to affect operator configuration, dashboards, tests, or integration expectations.
+
+## Auth hooks now reject empty principal identities
+
+Affected surface:
+
+- Go runtime `WithAuthPrincipalHook(...)` + protected routes using `RequireAuth()`
+
+What changed:
+
+- Returning a non-nil principal with an empty `Identity` no longer satisfies `RequireAuth()`.
+- Empty or whitespace-only identities are now treated as unauthenticated and return `401`.
+
+What you need to do:
+
+1. Ensure your principal hook returns:
+   - `nil` / unauthenticated when identity cannot be established, or
+   - a principal with a non-empty `Identity` when authentication succeeds.
+2. If you previously used an empty identity as a sentinel value, replace that with explicit hook-local state instead.
+
+Why this changed:
+
+- Empty identities were a fail-open ambiguity in the protected-route contract.
 
 ## Remote MCP bearer protection now fails closed
 
 Affected surface:
 
 - `runtime/oauth.RequireBearerTokenMiddleware(...)`
+- `runtime/mcp.Server` initial `GET /mcp` listener behavior
+- `runtime/mcp` session lifecycle on durable stores
 
 What changed:
 
@@ -15,6 +43,11 @@ What changed:
   accepting any syntactically valid `Authorization: Bearer ...` token.
 - The `WWW-Authenticate` `resource_metadata` challenge is derived only from an explicit `ResourceMetadataURL` or from
   `MCP_ENDPOINT`. It is no longer derived from `Host` / `X-Forwarded-Proto` request headers.
+- `GET /mcp` without `Last-Event-ID` now emits a short-lived keepalive SSE response and closes by default instead of
+  staying open indefinitely.
+- Expired MCP sessions now fail closed instead of being refreshed back to life when a durable session record still
+  exists.
+- Panics in streaming tool execution are recovered into internal-error output instead of terminating the Go process.
 
 What you need to do:
 
@@ -24,11 +57,105 @@ What you need to do:
    - set `ResourceMetadataURL`, or
    - deploy through `AppTheoryRemoteMcpServer` so `MCP_ENDPOINT` is injected.
 3. If you previously depended on request-header-derived metadata discovery, replace that with explicit configuration.
+4. If your client depended on an indefinitely open initial `GET /mcp` listener with no `Last-Event-ID`, either:
+   - move to resumable stream replay, or
+   - opt in explicitly with `mcp.WithInitialSessionListenerBudget(...)` for a bounded open-listener window.
+5. Do not rely on expired session IDs remaining usable until DynamoDB TTL cleanup eventually runs; expired sessions now
+   return `404`.
 
 Why this changed:
 
 - Accepting arbitrary Bearer tokens when no validator was configured was not fail-closed.
 - Deriving protected-resource metadata from request headers trusted attacker-influenced inputs in proxy setups.
+- Indefinitely open initial listeners and session resurrection both undermined the intended MCP transport and session
+  boundaries.
+
+## Credentialed CORS now requires an explicit allowlist
+
+Affected surface:
+
+- portable CORS config in Go / TypeScript / Python when `allow_credentials` / `allowCredentials` is enabled
+
+What changed:
+
+- Non-credentialed CORS still treats an omitted allowlist as allow-all.
+- Credentialed CORS now fails closed unless you configure explicit `allowed_origins`.
+- When credentials are enabled and no allowlist is configured, AppTheory no longer reflects the request origin or emits
+  `Access-Control-Allow-Credentials`.
+
+What you need to do:
+
+1. Whenever you enable credentialed CORS, set an explicit allowlist for the exact origins that should receive browser
+   credentials.
+2. Update tests that previously expected origin reflection with `AllowCredentials` but no allowlist.
+
+Why this changed:
+
+- Credentialed origin reflection without an allowlist is a browser-facing fail-open footgun.
+
+## Streamed responses now honor `max_response_bytes`
+
+Affected surface:
+
+- Go / TypeScript / Python response streaming when `max_response_bytes` / `maxResponseBytes` is configured
+
+What changed:
+
+- Streamed responses are now subject to the same response-size guardrail as buffered responses.
+- Once a stream would exceed the configured limit, the already-committed status and headers stay intact and the stream
+  terminates with `app.too_large`.
+
+What you need to do:
+
+1. Review any streaming endpoints that relied on `max_response_bytes` being ignored for streamed bodies.
+2. Increase the configured limit, split the stream into smaller responses, or remove the limit for that handler if the
+   larger output is intentional.
+
+Why this changed:
+
+- Streaming previously bypassed the configured response-size guardrail entirely.
+
+## AppSync unexpected exceptions now mask to `internal error`
+
+Affected surface:
+
+- Go / TypeScript / Python AppSync resolver adapters when handlers throw non-portable exceptions
+
+What changed:
+
+- Non-portable AppSync exceptions no longer echo raw exception text to clients.
+- AppTheory/AppError values still preserve their intended portable messages and metadata.
+
+What you need to do:
+
+1. If you want a client-visible AppSync message, throw a portable AppTheory/AppError instead of a generic exception.
+2. Update tests that previously matched raw exception strings in AppSync responses.
+
+Why this changed:
+
+- Leaking raw exception text from AppSync created an avoidable information-disclosure path.
+
+## Timeout middleware is cooperative cancellation, not hard preemption
+
+Affected surface:
+
+- Go / TypeScript / Python timeout middleware
+
+What changed:
+
+- Timeout middleware now documents and tests a cooperative cancellation contract across runtimes.
+- A timed-out request returns `app.timeout`, but user code must observe cancellation (`ctx.Done()`, `AbortSignal`, or
+  equivalent cooperative checks) if it needs to stop work before side effects commit.
+
+What you need to do:
+
+1. Update long-running handlers to observe cancellation rather than assuming the middleware can forcibly stop execution.
+2. Treat timeout middleware as a response contract plus cancellation signal, not as a hard kill switch.
+
+Why this changed:
+
+- Force-killing goroutines, promises, or threads is not portable across the three runtimes; the contract needed to make
+  the cooperative model explicit and deterministic.
 
 ## Go rate-limit middleware now hashes credential-derived identifiers by default
 
@@ -55,6 +182,28 @@ Why this changed:
 
 - Raw API keys and Bearer tokens should not be stored in rate-limit tables by default.
 - Hashing keeps default limiter behavior deterministic while reducing credential exposure in storage and diagnostics.
+
+## Sanitization once again redacts token-like keys by default
+
+Affected surface:
+
+- Go / TypeScript / Python sanitization helpers
+
+What changed:
+
+- Segment-based secret redaction heuristics were restored for token-like field names.
+- `authorization_id` is no longer treated as an allowlisted clear-text identifier; it now redacts as a secret alias.
+- Business keys that merely contain those substrings as part of a larger identifier (for example
+  `authorizationCode` or `tokenization_method`) remain readable.
+
+What you need to do:
+
+1. Expect some log fields to become redacted again, including `authorization_id`.
+2. Update dashboards or support tooling that depended on reading those values directly from logs.
+
+Why this changed:
+
+- The previous allowlist/substring behavior let token-like fields fall through to clear-text logging too easily.
 
 ## AppTheorySsrSite now fails closed on Function URL access and tenant-header trust
 
@@ -99,3 +248,62 @@ Why this changed:
   enforcement.
 - Forwarding viewer-supplied tenant headers without a trust contract let clients influence origin tenant context and
   `ssg-isr` HTML cache partitioning.
+
+## WAF `ipWhitelist` now behaves like a real allowlist
+
+Affected surface:
+
+- `AppTheoryEnhancedSecurity` with `wafConfig.ipWhitelist`
+
+What changed:
+
+- Configuring `ipWhitelist` now synthesizes default-deny WebACL behavior instead of an allow rule layered on top of a
+  default-allow ACL.
+
+What you need to do:
+
+1. Re-check any smoke tests or operational expectations that assumed non-whitelisted traffic would still pass through.
+2. If you were relying on the previous ineffective behavior, replace it with an intentional blacklist or no whitelist
+   at all.
+
+Why this changed:
+
+- An allowlist that does not deny non-matching traffic is not an allowlist.
+
+## Jobs and EventBus hardening now reject permissive edge cases earlier
+
+Affected surface:
+
+- Go / TypeScript / Python jobs semaphore acquisition
+- Go EventBus publish/query behavior
+- Go batch event middleware context usage
+
+What changed:
+
+- Semaphore acquisition now rejects pathological `limit` values above `256` before entering the per-slot storage loop.
+- EventBus publish always derives persisted partition/sort keys from validated event data instead of honoring
+  caller-supplied storage keys.
+- Batch event handlers receive isolated per-record `EventContext` values so `ctx.Set(...)` state does not leak across
+  records.
+
+What you need to do:
+
+1. Clamp any user-facing semaphore limit knobs to `256` or below.
+2. Do not rely on caller-supplied EventBus storage keys; only `TenantID`, `EventType`, `PublishedAt`, and `ID` define
+   persisted keys now.
+3. If you intentionally shared per-record batch state through `EventContext`, move that state into your own batch-level
+   coordinator instead of `ctx.Set(...)`.
+
+Why this changed:
+
+- These edge cases created avoidable write amplification, tenant-boundary confusion, or cross-record state leakage.
+
+## Internal-only hardening with no operator migration action
+
+The v1.0 foundation also included low-level fixes that should not require configuration changes:
+
+- prototype-safe TypeScript header canonicalization for `constructor` / `__proto__`
+- earlier oversized base64 request rejection before full decode allocation
+- explicit preservation of legacy `queueProps` security settings in `AppTheoryQueueProcessor`
+
+You should not need to change configuration for these items, but they are part of the same fail-closed baseline reset.

--- a/examples/cdk/ssr-site/README.md
+++ b/examples/cdk/ssr-site/README.md
@@ -2,6 +2,8 @@
 
 Canonical operator guide: `docs/cdk/ssr-site.md`
 
+Consolidated v1.0 security migration notes: `docs/migration/v1-security.md`
+
 This example synthesizes an opinionated **SSR site** deployment pattern:
 
 - S3 bucket for immutable assets under `/assets/*`

--- a/examples/migration/rate-limited-http/README.md
+++ b/examples/migration/rate-limited-http/README.md
@@ -41,6 +41,8 @@ That means:
 
 If your service needs a different key shape, set `ExtractIdentifier` explicitly instead of relying on the default.
 
+For the broader v1.0 fail-closed migration checklist, see `docs/migration/v1-security.md`.
+
 ## Running (optional)
 
 This is a minimal demo server; it requires AWS credentials unless you point TableTheory at DynamoDB Local.


### PR DESCRIPTION
## Milestone
v1-security-migration — publish the consolidated AppTheory v1.0 security migration guide and cross-link the changed surfaces

## Linear
- THE-352

## Tasks
- [x] THE-352 — Publish the consolidated v1.0 security migration guide and cross-link the changed surfaces

## Contract impact
Doc-only. This milestone consolidates the fail-closed migration guidance and links the affected docs/examples back to the guide.

## Validation
Commands run on the final commit:
- `make test-unit`
- `golangci-lint cache clean`
- `make rubric`

## Cross-repo notes
- `origin/main` was checked up front before implementation and was already up to date relative to the branch base, so there was no merge delta to carry into this milestone branch.
