### PR TITLE
fix(deps): update TableTheory and xmldom pins

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -38,7 +38,7 @@
   "overrides": {
     "ajv": "8.18.0",
     "flatted": "3.4.2",
-    "@xmldom/xmldom": "0.9.9",
+    "@xmldom/xmldom": "0.9.10",
     "picomatch": "2.3.2",
     "aws-cdk-lib": {
       "minimatch": "10.2.4"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/jsii-runtime-go v1.127.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/stretchr/testify v1.11.1
-	github.com/theory-cloud/tabletheory v1.6.0
+	github.com/theory-cloud/tabletheory v1.6.1
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/theory-cloud/tabletheory v1.5.5 h1:XW4TTHqMLUGN7NXvKlSFMUodnL7UIp0Beg
 github.com/theory-cloud/tabletheory v1.5.5/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 github.com/theory-cloud/tabletheory v1.6.0 h1:n/LqQIb0IftotMnd5d5x1rDawkmmH2XkYo+NmtxN/dg=
 github.com/theory-cloud/tabletheory v1.6.0/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/tabletheory v1.6.1 h1:5yDLFqQ0xcXj5GieyHEY69DQ/FWhvDwyHt3pmrIocBE=
+github.com/theory-cloud/tabletheory v1.6.1/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
-  "tabletheory-py @ https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/tabletheory_py-1.6.0-py3-none-any.whl",
+  "tabletheory-py @ https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/tabletheory_py-1.6.1-py3-none-any.whl",
 ]
 
 [tool.setuptools]

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/theory-cloud-tabletheory-ts-1.6.0.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "1.6.0",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/theory-cloud-tabletheory-ts-1.6.0.tgz",
-      "integrity": "sha512-ki/b8DKN9nRSvQ3/QABU3SuDEiXHS5BQhPe51iseZZkpKj2qOhIHWwj5kn/p8d25QdsNveszRbYrsoOLJmKIoQ==",
+      "version": "1.6.1",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
+      "integrity": "sha512-yPZkY1GN+quQ27SSJpqpVXdEzawKr4Pbt3xDlQ94Wm7FZr5OmjVc90hFv4pDnqNrVWOGF06gW9yKemkM01qClQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1002.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.0/theory-cloud-tabletheory-ts-1.6.0.tgz"
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
   },
   "overrides": {
     "@typescript-eslint/typescript-estree": {


### PR DESCRIPTION
## Summary
- update Go / TypeScript / Python TableTheory references to `v1.6.1`
- bump the CDK `@xmldom/xmldom` override and lockfile to `0.9.10`
- close Dependabot alerts 27-29 in `cdk/package-lock.json`

## Validation
- `make rubric`

## Notes
- branched from green `staging`
- checked `origin/main` up front before implementation; it was already up to date relative to the branch base
