### PR TITLE
feat(runtime): add go event workload helpers

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1410,6 +1410,19 @@ type EventBridgeSelector struct {
 	DetailType string
 }
 
+type EventBridgeWorkloadEnvelope struct {
+	Account           string   `json:"account"`
+	CorrelationID     string   `json:"correlation_id"`
+	CorrelationSource string   `json:"correlation_source"`
+	DetailType        string   `json:"detail_type"`
+	EventID           string   `json:"event_id"`
+	Region            string   `json:"region"`
+	RequestID         string   `json:"request_id"`
+	Resources         []string `json:"resources"`
+	Source            string   `json:"source"`
+	Time              string   `json:"time"`
+}
+
 type EventContext struct {
 	ctx context.Context
 
@@ -1419,7 +1432,8 @@ type EventContext struct {
 	RequestID   string
 	RemainingMS int
 
-	values map[string]any
+	rawEvent json.RawMessage
+	values   map[string]any
 }
 
 type EventHandler func(*EventContext, any) (any, error)
@@ -1635,6 +1649,11 @@ func NewAppTheoryError(string, string) *AppTheoryError
 
 func NoContent() *Response
 
+func NormalizeEventBridgeWorkloadEnvelope(
+	*EventContext,
+	events.EventBridgeEvent,
+) EventBridgeWorkloadEnvelope
+
 func OptionalAuth() RouteOption
 
 func OriginURL(map[string][]string) string
@@ -1648,6 +1667,11 @@ func RateLimitMiddleware(RateLimitConfig) Middleware
 func RequireAnyScope(...string) RouteOption
 
 func RequireAuth() RouteOption
+
+func RequireEventBridgeWorkloadEnvelope(
+	*EventContext,
+	events.EventBridgeEvent,
+) (EventBridgeWorkloadEnvelope, error)
 
 func RequireScope(...string) RouteOption
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1498,6 +1498,14 @@ type LogRecord struct {
 	Path      string
 	Status    int
 	ErrorCode string
+
+	Trigger       string
+	CorrelationID string
+	Source        string
+	DetailType    string
+	TableName     string
+	EventID       string
+	EventName     string
 }
 
 type MetricRecord struct {
@@ -1899,6 +1907,8 @@ func (*WebSocketContext) SendMessage([]byte) error
 func (RandomIDGenerator) NewID() string
 
 func (RealClock) Now() time.Time
+
+func (safeEventError) Error() string
 
 ## github.com/theory-cloud/apptheory/runtime/mcp
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1402,6 +1402,17 @@ type Context struct {
 
 type DynamoDBStreamHandler func(*EventContext, events.DynamoDBEventRecord) error
 
+type DynamoDBStreamRecordSummary struct {
+	AWSRegion      string `json:"aws_region"`
+	EventID        string `json:"event_id"`
+	EventName      string `json:"event_name"`
+	SafeLog        string `json:"safe_log"`
+	SequenceNumber string `json:"sequence_number"`
+	SizeBytes      int64  `json:"size_bytes"`
+	StreamViewType string `json:"stream_view_type"`
+	TableName      string `json:"table_name"`
+}
+
 type EventBridgeHandler func(*EventContext, events.EventBridgeEvent) (any, error)
 
 type EventBridgeScheduledWorkloadResultSummary struct {
@@ -1669,6 +1680,8 @@ func New(...Option) *App
 func NewAppTheoryError(string, string) *AppTheoryError
 
 func NoContent() *Response
+
+func NormalizeDynamoDBStreamRecord(events.DynamoDBEventRecord) DynamoDBStreamRecordSummary
 
 func NormalizeEventBridgeScheduledWorkload(
 	*EventContext,

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1404,6 +1404,27 @@ type DynamoDBStreamHandler func(*EventContext, events.DynamoDBEventRecord) error
 
 type EventBridgeHandler func(*EventContext, events.EventBridgeEvent) (any, error)
 
+type EventBridgeScheduledWorkloadResultSummary struct {
+	Failed    int    `json:"failed"`
+	Processed int    `json:"processed"`
+	Status    string `json:"status"`
+}
+
+type EventBridgeScheduledWorkloadSummary struct {
+	CorrelationID     string                                    `json:"correlation_id"`
+	CorrelationSource string                                    `json:"correlation_source"`
+	DeadlineUnixMS    int64                                     `json:"deadline_unix_ms"`
+	DetailType        string                                    `json:"detail_type"`
+	EventID           string                                    `json:"event_id"`
+	IdempotencyKey    string                                    `json:"idempotency_key"`
+	Kind              string                                    `json:"kind"`
+	RemainingMS       int                                       `json:"remaining_ms"`
+	Result            EventBridgeScheduledWorkloadResultSummary `json:"result"`
+	RunID             string                                    `json:"run_id"`
+	ScheduledTime     string                                    `json:"scheduled_time"`
+	Source            string                                    `json:"source"`
+}
+
 type EventBridgeSelector struct {
 	RuleName   string
 	Source     string
@@ -1648,6 +1669,11 @@ func New(...Option) *App
 func NewAppTheoryError(string, string) *AppTheoryError
 
 func NoContent() *Response
+
+func NormalizeEventBridgeScheduledWorkload(
+	*EventContext,
+	events.EventBridgeEvent,
+) EventBridgeScheduledWorkloadSummary
 
 func NormalizeEventBridgeWorkloadEnvelope(
 	*EventContext,

--- a/contract-tests/runners/go/apptheory_m1.go
+++ b/contract-tests/runners/go/apptheory_m1.go
@@ -401,7 +401,7 @@ func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBrid
 		}
 	case "eventbridge_scheduled_summary":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
-			return eventBridgeScheduledSummary(ctx, event, raw), nil
+			return apptheory.NormalizeEventBridgeScheduledWorkload(ctx, event), nil
 		}
 	case "eventbridge_observed_success":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
@@ -570,70 +570,6 @@ func eventBridgeWorkloadEnvelopeSummary(
 	}
 }
 
-func eventBridgeScheduledSummary(
-	ctx *apptheory.EventContext,
-	event events.EventBridgeEvent,
-	raw json.RawMessage,
-) map[string]any {
-	rawObject := rawJSONObject(raw)
-	envelope := eventBridgeWorkloadEnvelopeSummary(ctx, event, raw)
-	detail := rawObjectField(rawObject, "detail")
-	result := rawObjectField(detail, "result")
-
-	runID := rawString(detail, "run_id")
-	if runID == "" {
-		runID = strings.TrimSpace(event.ID)
-	}
-	if runID == "" {
-		runID = ctxLambdaAWSRequestID(ctx)
-	}
-
-	idempotencyKey := rawString(detail, "idempotency_key")
-	if idempotencyKey == "" {
-		if eventID := strings.TrimSpace(event.ID); eventID != "" {
-			idempotencyKey = "eventbridge:" + eventID
-		} else if requestID := ctxLambdaAWSRequestID(ctx); requestID != "" {
-			idempotencyKey = "lambda:" + requestID
-		}
-	}
-
-	status := rawString(result, "status")
-	if status == "" {
-		status = rawString(detail, "status")
-	}
-	if status == "" {
-		status = "ok"
-	}
-
-	remainingMS := 0
-	var deadlineUnixMS int64
-	if ctx != nil {
-		remainingMS = ctx.RemainingMS
-		if remainingMS > 0 {
-			deadlineUnixMS = ctx.Now().UnixMilli() + int64(remainingMS)
-		}
-	}
-
-	return map[string]any{
-		"correlation_id":     envelope["correlation_id"],
-		"correlation_source": envelope["correlation_source"],
-		"deadline_unix_ms":   deadlineUnixMS,
-		"detail_type":        envelope["detail_type"],
-		"event_id":           envelope["event_id"],
-		"idempotency_key":    idempotencyKey,
-		"kind":               "scheduled",
-		"remaining_ms":       remainingMS,
-		"result": map[string]any{
-			"failed":    rawInt(result, "failed"),
-			"processed": rawInt(result, "processed"),
-			"status":    status,
-		},
-		"run_id":         runID,
-		"scheduled_time": envelope["time"],
-		"source":         envelope["source"],
-	}
-}
-
 func eventBridgeCorrelationID(
 	ctx *apptheory.EventContext,
 	event events.EventBridgeEvent,
@@ -689,32 +625,6 @@ func rawString(object map[string]any, key string) string {
 		return ""
 	}
 	return asString(value)
-}
-
-func rawInt(object map[string]any, key string) int {
-	if object == nil {
-		return 0
-	}
-	value, ok := object[key]
-	if !ok {
-		return 0
-	}
-	switch typed := value.(type) {
-	case int:
-		return typed
-	case int64:
-		return int(typed)
-	case float64:
-		return int(typed)
-	case json.Number:
-		parsed, err := typed.Int64()
-		if err != nil {
-			return 0
-		}
-		return int(parsed)
-	default:
-		return 0
-	}
 }
 
 func rawHeaderString(headers map[string]any, key string) string {

--- a/contract-tests/runners/go/apptheory_m1.go
+++ b/contract-tests/runners/go/apptheory_m1.go
@@ -397,7 +397,7 @@ func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBrid
 	switch strings.TrimSpace(name) {
 	case "eventbridge_workload_envelope":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
-			return eventBridgeWorkloadEnvelopeSummary(ctx, event, raw), nil
+			return apptheory.NormalizeEventBridgeWorkloadEnvelope(ctx, event), nil
 		}
 	case "eventbridge_scheduled_summary":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
@@ -417,13 +417,7 @@ func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBrid
 		}
 	case "eventbridge_require_workload_envelope":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
-			summary := eventBridgeWorkloadEnvelopeSummary(ctx, event, raw)
-			if strings.TrimSpace(asString(summary["source"])) == "" ||
-				strings.TrimSpace(asString(summary["detail_type"])) == "" ||
-				strings.TrimSpace(asString(summary["correlation_id"])) == "" {
-				return nil, errors.New("apptheory: eventbridge workload envelope invalid")
-			}
-			return summary, nil
+			return apptheory.RequireEventBridgeWorkloadEnvelope(ctx, event)
 		}
 	default:
 		handler := builtInOutputHandler[events.EventBridgeEvent](name, "eventbridge")

--- a/contract-tests/runners/go/apptheory_m1.go
+++ b/contract-tests/runners/go/apptheory_m1.go
@@ -23,6 +23,40 @@ func runFixtureM1(f Fixture) error {
 		apptheory.WithTier(apptheory.TierP0),
 		apptheory.WithClock(fixedClock{now: now}),
 		apptheory.WithIDGenerator(fixedIDGenerator{id: "req_test_123"}),
+		apptheory.WithObservability(apptheory.ObservabilityHooks{
+			Log: func(r apptheory.LogRecord) {
+				effects.logs = append(effects.logs, FixtureLogRecord{
+					Level:         r.Level,
+					Event:         r.Event,
+					RequestID:     r.RequestID,
+					TenantID:      r.TenantID,
+					Method:        r.Method,
+					Path:          r.Path,
+					Status:        r.Status,
+					ErrorCode:     r.ErrorCode,
+					Trigger:       r.Trigger,
+					CorrelationID: r.CorrelationID,
+					Source:        r.Source,
+					DetailType:    r.DetailType,
+					TableName:     r.TableName,
+					EventID:       r.EventID,
+					EventName:     r.EventName,
+				})
+			},
+			Metric: func(r apptheory.MetricRecord) {
+				effects.metrics = append(effects.metrics, FixtureMetricRecord{
+					Name:  r.Name,
+					Value: r.Value,
+					Tags:  r.Tags,
+				})
+			},
+			Span: func(r apptheory.SpanRecord) {
+				effects.spans = append(effects.spans, FixtureSpanRecord{
+					Name:       r.Name,
+					Attributes: r.Attributes,
+				})
+			},
+		}),
 	)
 
 	for _, name := range f.Setup.Middlewares {
@@ -62,7 +96,7 @@ func runFixtureM1(f Fixture) error {
 
 	for _, r := range f.Setup.DynamoDB {
 		table := strings.TrimSpace(r.Table)
-		handler := builtInDynamoDBStreamHandler(r.Handler, effects)
+		handler := builtInDynamoDBStreamHandler(r.Handler)
 		if handler == nil {
 			return fmt.Errorf("unknown dynamodb handler %q", r.Handler)
 		}
@@ -70,7 +104,7 @@ func runFixtureM1(f Fixture) error {
 	}
 
 	for _, r := range f.Setup.EventBridge {
-		handler := builtInEventBridgeHandler(r.Handler, f.Input.AWSEvent.Event, effects)
+		handler := builtInEventBridgeHandler(r.Handler)
 		if handler == nil {
 			return fmt.Errorf("unknown eventbridge handler %q", r.Handler)
 		}
@@ -287,8 +321,7 @@ func builtInSNSHandler(name string) apptheory.SNSHandler {
 	return apptheory.SNSHandler(handler)
 }
 
-func builtInDynamoDBStreamHandler(name string, effectsInput ...*fixtureM1Effects) apptheory.DynamoDBStreamHandler {
-	effects := firstM1Effects(effectsInput...)
+func builtInDynamoDBStreamHandler(name string) apptheory.DynamoDBStreamHandler {
 	switch strings.TrimSpace(name) {
 	case "ddb_requires_event_middleware":
 		return func(ctx *apptheory.EventContext, _ events.DynamoDBEventRecord) error {
@@ -303,15 +336,13 @@ func builtInDynamoDBStreamHandler(name string, effectsInput ...*fixtureM1Effects
 			return requireDynamoDBSafeSummary(record, true)
 		}
 	case "ddb_observed_fail_on_remove":
-		return func(ctx *apptheory.EventContext, record events.DynamoDBEventRecord) error {
+		return func(_ *apptheory.EventContext, record events.DynamoDBEventRecord) error {
 			if err := requireDynamoDBSafeSummary(record, false); err != nil {
 				return err
 			}
 			if strings.TrimSpace(record.EventName) == dynamoDBEventNameRemove {
-				recordDynamoDBEffects(effects, ctx, record, "error", "error", "app.internal")
-				return errors.New("fail")
+				return errors.New("raw dynamodb remove failure: do-not-log")
 			}
-			recordDynamoDBEffects(effects, ctx, record, "info", "success", "")
 			return nil
 		}
 	}
@@ -365,19 +396,7 @@ func dynamoDBSafeSummary(record events.DynamoDBEventRecord) map[string]any {
 	}
 }
 
-func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBridgeHandler {
-	var raw json.RawMessage
-	effects := &fixtureM1Effects{}
-	if len(rawInput) > 0 {
-		if value, ok := rawInput[0].(json.RawMessage); ok {
-			raw = value
-		}
-	}
-	if len(rawInput) > 1 {
-		if value, ok := rawInput[1].(*fixtureM1Effects); ok && value != nil {
-			effects = value
-		}
-	}
+func builtInEventBridgeHandler(name string) apptheory.EventBridgeHandler {
 	switch strings.TrimSpace(name) {
 	case "eventbridge_workload_envelope":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
@@ -389,15 +408,11 @@ func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBrid
 		}
 	case "eventbridge_observed_success":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
-			summary := eventBridgeWorkloadEnvelopeSummary(ctx, event, raw)
-			recordEventBridgeEffects(effects, ctx, summary, "info", "success", "")
-			return summary, nil
+			return apptheory.NormalizeEventBridgeWorkloadEnvelope(ctx, event), nil
 		}
 	case "eventbridge_observed_panic":
-		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
-			summary := eventBridgeWorkloadEnvelopeSummary(ctx, event, raw)
-			recordEventBridgeEffects(effects, ctx, summary, "error", "error", "app.internal")
-			return nil, errors.New("apptheory: event workload failed")
+		return func(_ *apptheory.EventContext, _ events.EventBridgeEvent) (any, error) {
+			panic("raw eventbridge panic: do-not-log")
 		}
 	case "eventbridge_require_workload_envelope":
 		return func(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
@@ -412,114 +427,6 @@ func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBrid
 	}
 }
 
-func firstM1Effects(inputs ...*fixtureM1Effects) *fixtureM1Effects {
-	if len(inputs) > 0 && inputs[0] != nil {
-		return inputs[0]
-	}
-	return &fixtureM1Effects{}
-}
-
-func recordEventBridgeEffects(
-	effects *fixtureM1Effects,
-	ctx *apptheory.EventContext,
-	summary map[string]any,
-	level string,
-	outcome string,
-	errorCode string,
-) {
-	if effects == nil {
-		return
-	}
-	correlationID := asString(summary["correlation_id"])
-	source := asString(summary["source"])
-	detailType := asString(summary["detail_type"])
-	effects.logs = append(effects.logs, FixtureLogRecord{
-		Level:         level,
-		Event:         "event.completed",
-		RequestID:     ctxRequestID(ctx),
-		ErrorCode:     errorCode,
-		Trigger:       "eventbridge",
-		CorrelationID: correlationID,
-		Source:        source,
-		DetailType:    detailType,
-	})
-	effects.metrics = append(effects.metrics, FixtureMetricRecord{
-		Name:  "apptheory.event",
-		Value: 1,
-		Tags: map[string]string{
-			"correlation_id": correlationID,
-			"detail_type":    detailType,
-			"error_code":     errorCode,
-			"outcome":        outcome,
-			"source":         source,
-			"trigger":        "eventbridge",
-		},
-	})
-	effects.spans = append(effects.spans, FixtureSpanRecord{
-		Name: "eventbridge " + source + " " + detailType,
-		Attributes: map[string]string{
-			"correlation.id":    correlationID,
-			"event.detail_type": detailType,
-			"event.source":      source,
-			"error.code":        errorCode,
-			"outcome":           outcome,
-			"trigger":           "eventbridge",
-		},
-	})
-}
-
-func recordDynamoDBEffects(
-	effects *fixtureM1Effects,
-	ctx *apptheory.EventContext,
-	record events.DynamoDBEventRecord,
-	level string,
-	outcome string,
-	errorCode string,
-) {
-	if effects == nil {
-		return
-	}
-	summary := dynamoDBSafeSummary(record)
-	tableName := asString(summary["table_name"])
-	eventID := asString(summary["event_id"])
-	eventName := asString(summary["event_name"])
-	effects.logs = append(effects.logs, FixtureLogRecord{
-		Level:         level,
-		Event:         "event.completed",
-		RequestID:     ctxRequestID(ctx),
-		ErrorCode:     errorCode,
-		Trigger:       "dynamodb_stream",
-		CorrelationID: eventID,
-		TableName:     tableName,
-		EventID:       eventID,
-		EventName:     eventName,
-	})
-	effects.metrics = append(effects.metrics, FixtureMetricRecord{
-		Name:  "apptheory.event",
-		Value: 1,
-		Tags: map[string]string{
-			"correlation_id": eventID,
-			"error_code":     errorCode,
-			"event_name":     eventName,
-			"outcome":        outcome,
-			"table_name":     tableName,
-			"trigger":        "dynamodb_stream",
-		},
-	})
-	effects.spans = append(effects.spans, FixtureSpanRecord{
-		Name: "dynamodb_stream " + tableName + " " + eventName,
-		Attributes: map[string]string{
-			"correlation.id":      eventID,
-			"dynamodb.event_id":   eventID,
-			"dynamodb.event_name": eventName,
-			"dynamodb.table_name": tableName,
-			"error.code":          errorCode,
-			"outcome":             outcome,
-			"trigger":             "dynamodb_stream",
-		},
-	})
-}
-
 func fixtureM1LambdaContext(now time.Time, input FixtureContext) (context.Context, context.CancelFunc) {
 	ctx := context.Background()
 	var cancel context.CancelFunc
@@ -530,108 +437,6 @@ func fixtureM1LambdaContext(now time.Time, input FixtureContext) (context.Contex
 		ctx = lambdacontext.NewContext(ctx, &lambdacontext.LambdaContext{AwsRequestID: requestID})
 	}
 	return ctx, cancel
-}
-
-func eventBridgeWorkloadEnvelopeSummary(
-	ctx *apptheory.EventContext,
-	event events.EventBridgeEvent,
-	raw json.RawMessage,
-) map[string]any {
-	rawObject := rawJSONObject(raw)
-	correlationID, correlationSource := eventBridgeCorrelationID(ctx, event, rawObject)
-
-	return map[string]any{
-		"account":            event.AccountID,
-		"correlation_id":     correlationID,
-		"correlation_source": correlationSource,
-		"detail_type":        event.DetailType,
-		"event_id":           event.ID,
-		"region":             event.Region,
-		"request_id":         ctxRequestID(ctx),
-		"resources":          event.Resources,
-		"source":             event.Source,
-		"time":               rawString(rawObject, "time"),
-	}
-}
-
-func eventBridgeCorrelationID(
-	ctx *apptheory.EventContext,
-	event events.EventBridgeEvent,
-	raw map[string]any,
-) (string, string) {
-	if value := rawString(rawObjectField(raw, "metadata"), "correlation_id"); value != "" {
-		return value, "metadata.correlation_id"
-	}
-	if value := rawHeaderString(rawObjectField(raw, "headers"), "x-correlation-id"); value != "" {
-		return value, "headers.x-correlation-id"
-	}
-	if value := rawString(rawObjectField(raw, "detail"), "correlation_id"); value != "" {
-		return value, "detail.correlation_id"
-	}
-	if value := strings.TrimSpace(event.ID); value != "" {
-		return value, "event.id"
-	}
-	if value := ctxLambdaAWSRequestID(ctx); value != "" {
-		return value, "lambda.aws_request_id"
-	}
-	return "", ""
-}
-
-func rawJSONObject(raw json.RawMessage) map[string]any {
-	var object map[string]any
-	if err := json.Unmarshal(raw, &object); err != nil || object == nil {
-		return map[string]any{}
-	}
-	return object
-}
-
-func rawObjectField(object map[string]any, key string) map[string]any {
-	if object == nil {
-		return map[string]any{}
-	}
-	value, ok := object[key]
-	if !ok {
-		return map[string]any{}
-	}
-	child, ok := value.(map[string]any)
-	if !ok || child == nil {
-		return map[string]any{}
-	}
-	return child
-}
-
-func rawString(object map[string]any, key string) string {
-	if object == nil {
-		return ""
-	}
-	value, ok := object[key]
-	if !ok {
-		return ""
-	}
-	return asString(value)
-}
-
-func rawHeaderString(headers map[string]any, key string) string {
-	key = strings.TrimSpace(strings.ToLower(key))
-	if key == "" || headers == nil {
-		return ""
-	}
-	for name, value := range headers {
-		if strings.TrimSpace(strings.ToLower(name)) != key {
-			continue
-		}
-		if single := asString(value); single != "" {
-			return single
-		}
-		if values, ok := value.([]any); ok {
-			for _, entry := range values {
-				if single := asString(entry); single != "" {
-					return single
-				}
-			}
-		}
-	}
-	return ""
 }
 
 func containsAny(value string, sentinels []string) bool {
@@ -652,24 +457,6 @@ func asString(value any) string {
 	default:
 		return ""
 	}
-}
-
-func ctxRequestID(ctx *apptheory.EventContext) string {
-	if ctx == nil {
-		return ""
-	}
-	return strings.TrimSpace(ctx.RequestID)
-}
-
-func ctxLambdaAWSRequestID(ctx *apptheory.EventContext) string {
-	if ctx == nil {
-		return ""
-	}
-	lambdaCtx, ok := lambdacontext.FromContext(ctx.Context())
-	if !ok || lambdaCtx == nil {
-		return ""
-	}
-	return strings.TrimSpace(lambdaCtx.AwsRequestID)
 }
 
 func builtInOutputHandler[Event any](name string, prefix string) func(*apptheory.EventContext, Event) (any, error) {

--- a/contract-tests/runners/go/apptheory_m1.go
+++ b/contract-tests/runners/go/apptheory_m1.go
@@ -338,7 +338,11 @@ func requireDynamoDBSafeSummary(record events.DynamoDBEventRecord, failOnRemove 
 			return fmt.Errorf("missing normalized dynamodb %s", key)
 		}
 	}
-	if rawLog := strings.TrimSpace(asString(summary["safe_log"])); rawLog == "" || strings.Contains(rawLog, "do-not-log") {
+	if rawLog := strings.TrimSpace(asString(summary["safe_log"])); rawLog == "" || containsAny(rawLog, []string{
+		"release#rel_123",
+		"do-not-log",
+		"previous-secret",
+	}) {
 		return errors.New("unsafe dynamodb stream summary")
 	}
 	if failOnRemove && strings.TrimSpace(record.EventName) == dynamoDBEventNameRemove {
@@ -348,37 +352,17 @@ func requireDynamoDBSafeSummary(record events.DynamoDBEventRecord, failOnRemove 
 }
 
 func dynamoDBSafeSummary(record events.DynamoDBEventRecord) map[string]any {
-	tableName := dynamoDBFixtureTableNameFromStreamARN(record.EventSourceArn)
-	sequenceNumber := strings.TrimSpace(record.Change.SequenceNumber)
-	eventID := strings.TrimSpace(record.EventID)
-	eventName := strings.TrimSpace(record.EventName)
+	summary := apptheory.NormalizeDynamoDBStreamRecord(record)
 	return map[string]any{
-		"aws_region":       strings.TrimSpace(record.AWSRegion),
-		"event_id":         eventID,
-		"event_name":       eventName,
-		"safe_log":         fmt.Sprintf("table=%s event_id=%s event_name=%s sequence_number=%s", tableName, eventID, eventName, sequenceNumber),
-		"sequence_number":  sequenceNumber,
-		"size_bytes":       int(record.Change.SizeBytes),
-		"stream_view_type": strings.TrimSpace(record.Change.StreamViewType),
-		"table_name":       tableName,
+		"aws_region":       summary.AWSRegion,
+		"event_id":         summary.EventID,
+		"event_name":       summary.EventName,
+		"safe_log":         summary.SafeLog,
+		"sequence_number":  summary.SequenceNumber,
+		"size_bytes":       int(summary.SizeBytes),
+		"stream_view_type": summary.StreamViewType,
+		"table_name":       summary.TableName,
 	}
-}
-
-func dynamoDBFixtureTableNameFromStreamARN(arn string) string {
-	arn = strings.TrimSpace(arn)
-	if arn == "" {
-		return ""
-	}
-	if _, after, ok := strings.Cut(arn, ":table/"); ok {
-		if table, _, ok := strings.Cut(after, "/stream/"); ok {
-			return table
-		}
-		if table, _, ok := strings.Cut(after, "/"); ok {
-			return table
-		}
-		return after
-	}
-	return ""
 }
 
 func builtInEventBridgeHandler(name string, rawInput ...any) apptheory.EventBridgeHandler {
@@ -648,6 +632,15 @@ func rawHeaderString(headers map[string]any, key string) string {
 		}
 	}
 	return ""
+}
+
+func containsAny(value string, sentinels []string) bool {
+	for _, sentinel := range sentinels {
+		if sentinel != "" && strings.Contains(value, sentinel) {
+			return true
+		}
+	}
+	return false
 }
 
 func asString(value any) string {

--- a/runtime/aws_eventsources.go
+++ b/runtime/aws_eventsources.go
@@ -576,7 +576,7 @@ func (a *App) ServeEventBridge(ctx context.Context, event events.EventBridgeEven
 	return a.serveEventBridge(ctx, event, nil)
 }
 
-func (a *App) serveEventBridge(ctx context.Context, event events.EventBridgeEvent, raw json.RawMessage) (any, error) {
+func (a *App) serveEventBridge(ctx context.Context, event events.EventBridgeEvent, raw json.RawMessage) (out any, err error) {
 	handler := a.eventBridgeHandlerForEvent(event)
 	if handler == nil {
 		return nil, nil
@@ -584,6 +584,22 @@ func (a *App) serveEventBridge(ctx context.Context, event events.EventBridgeEven
 
 	evtCtx := a.eventContext(ctx)
 	evtCtx.rawEvent = append(json.RawMessage(nil), raw...)
+	observation := eventBridgeObservation(evtCtx, event)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			out = nil
+			err = eventWorkloadFailedError()
+			a.recordEventObservability(observation, "error", "app.internal")
+			return
+		}
+		if err != nil {
+			err = sanitizeEventWorkloadError(err)
+			a.recordEventObservability(observation, "error", "app.internal")
+			return
+		}
+		a.recordEventObservability(observation, "success", "")
+	}()
+
 	if a != nil && len(a.eventMiddlewares) > 0 {
 		original := handler
 		wrapped := a.applyEventMiddlewares(func(ctx *EventContext, event any) (any, error) {
@@ -664,7 +680,41 @@ var dynamoDBBatchSpec = newBatchEventSpec[events.DynamoDBEventRecord, events.Dyn
 //
 // If the table is unrecognized, it fails closed by returning all records as failures.
 func (a *App) ServeDynamoDBStream(ctx context.Context, event events.DynamoDBEvent) events.DynamoDBEventResponse {
-	return serveBatchEvent(ctx, a, event.Records, a.dynamoDBHandlerForEvent(event), dynamoDBBatchSpec)
+	handler := a.dynamoDBHandlerForEvent(event)
+	handler = wrapEventRecordHandler(a, handler, dynamoDBBatchSpec.coerce, dynamoDBBatchSpec.invalidTypeError)
+
+	evtCtx := a.eventContext(ctx)
+	failures := make([]events.DynamoDBBatchItemFailure, 0, len(event.Records))
+	for _, record := range event.Records {
+		recordCtx := evtCtx.cloneForRecord()
+		err := runDynamoDBStreamRecordHandler(recordCtx, record, handler)
+		if err != nil {
+			id := strings.TrimSpace(dynamoDBBatchSpec.recordID(record))
+			if id != "" {
+				failures = append(failures, dynamoDBBatchSpec.failureForID(id))
+			}
+			a.recordEventObservability(dynamoDBStreamObservation(recordCtx, record), "error", "app.internal")
+			continue
+		}
+		a.recordEventObservability(dynamoDBStreamObservation(recordCtx, record), "success", "")
+	}
+	return dynamoDBBatchSpec.responseForFailures(failures)
+}
+
+func runDynamoDBStreamRecordHandler(
+	ctx *EventContext,
+	record events.DynamoDBEventRecord,
+	handler func(*EventContext, events.DynamoDBEventRecord) error,
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = eventWorkloadFailedError()
+		}
+	}()
+	if handler == nil {
+		return eventWorkloadFailedError()
+	}
+	return handler(ctx, record)
 }
 
 type lambdaEnvelope struct {

--- a/runtime/aws_eventsources.go
+++ b/runtime/aws_eventsources.go
@@ -23,7 +23,8 @@ type EventContext struct {
 	RequestID   string
 	RemainingMS int
 
-	values map[string]any
+	rawEvent json.RawMessage
+	values   map[string]any
 }
 
 func (c *EventContext) cloneForRecord() *EventContext {
@@ -36,6 +37,7 @@ func (c *EventContext) cloneForRecord() *EventContext {
 		ids:         c.ids,
 		RequestID:   c.RequestID,
 		RemainingMS: c.RemainingMS,
+		rawEvent:    append(json.RawMessage(nil), c.rawEvent...),
 	}
 }
 
@@ -571,12 +573,17 @@ func (a *App) eventBridgeHandlerForEvent(event events.EventBridgeEvent) EventBri
 //
 // If no handler matches, it returns (nil, nil).
 func (a *App) ServeEventBridge(ctx context.Context, event events.EventBridgeEvent) (any, error) {
+	return a.serveEventBridge(ctx, event, nil)
+}
+
+func (a *App) serveEventBridge(ctx context.Context, event events.EventBridgeEvent, raw json.RawMessage) (any, error) {
 	handler := a.eventBridgeHandlerForEvent(event)
 	if handler == nil {
 		return nil, nil
 	}
 
 	evtCtx := a.eventContext(ctx)
+	evtCtx.rawEvent = append(json.RawMessage(nil), raw...)
 	if a != nil && len(a.eventMiddlewares) > 0 {
 		original := handler
 		wrapped := a.applyEventMiddlewares(func(ctx *EventContext, event any) (any, error) {
@@ -731,7 +738,7 @@ func (a *App) handleLambdaEventBridge(ctx context.Context, event json.RawMessage
 	if strings.TrimSpace(ev.DetailType) == "" && env.DetailTypeAlt != nil {
 		ev.DetailType = strings.TrimSpace(*env.DetailTypeAlt)
 	}
-	out, err := a.ServeEventBridge(ctx, ev)
+	out, err := a.serveEventBridge(ctx, ev, event)
 	return out, true, err
 }
 

--- a/runtime/aws_eventsources_coverage_test.go
+++ b/runtime/aws_eventsources_coverage_test.go
@@ -146,8 +146,8 @@ func TestServeEventBridge_EventMiddleware_TypeAssertionFailure(t *testing.T) {
 	})
 
 	_, err := app.ServeEventBridge(context.Background(), events.EventBridgeEvent{Source: "src", DetailType: "dt"})
-	if err == nil || !strings.Contains(err.Error(), "invalid eventbridge event type") {
-		t.Fatalf("expected invalid type error, got %v", err)
+	if err == nil || err.Error() != eventWorkloadFailedMessage {
+		t.Fatalf("expected safe event workload error, got %v", err)
 	}
 }
 

--- a/runtime/event_workloads.go
+++ b/runtime/event_workloads.go
@@ -12,6 +12,8 @@ import (
 )
 
 const (
+	eventWorkloadFailedMessage = "apptheory: event workload failed"
+
 	eventBridgeCorrelationSourceMetadata     = "metadata.correlation_id"
 	eventBridgeCorrelationSourceHeader       = "headers.x-correlation-id"
 	eventBridgeCorrelationSourceDetail       = "detail.correlation_id"
@@ -103,9 +105,55 @@ func RequireEventBridgeWorkloadEnvelope(
 	if strings.TrimSpace(envelope.Source) == "" ||
 		strings.TrimSpace(envelope.DetailType) == "" ||
 		strings.TrimSpace(envelope.CorrelationID) == "" {
-		return envelope, errors.New("apptheory: eventbridge workload envelope invalid")
+		return envelope, safeEventError{message: "apptheory: eventbridge workload envelope invalid"}
 	}
 	return envelope, nil
+}
+
+func eventWorkloadFailedError() error {
+	return errors.New(eventWorkloadFailedMessage)
+}
+
+type safeEventError struct {
+	message string
+}
+
+func (e safeEventError) Error() string { return e.message }
+
+func (e safeEventError) safeEventError() {}
+
+func sanitizeEventWorkloadError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var safe interface{ safeEventError() }
+	if errors.As(err, &safe) {
+		return err
+	}
+	return eventWorkloadFailedError()
+}
+
+func eventBridgeObservation(ctx *EventContext, event events.EventBridgeEvent) eventObservation {
+	envelope := NormalizeEventBridgeWorkloadEnvelope(ctx, event)
+	return eventObservation{
+		Trigger:       eventTriggerEventBridge,
+		RequestID:     envelope.RequestID,
+		CorrelationID: envelope.CorrelationID,
+		Source:        envelope.Source,
+		DetailType:    envelope.DetailType,
+	}
+}
+
+func dynamoDBStreamObservation(ctx *EventContext, record events.DynamoDBEventRecord) eventObservation {
+	summary := NormalizeDynamoDBStreamRecord(record)
+	return eventObservation{
+		Trigger:       eventTriggerDynamoDBStream,
+		RequestID:     eventContextRequestID(ctx),
+		CorrelationID: summary.EventID,
+		TableName:     summary.TableName,
+		EventID:       summary.EventID,
+		EventName:     summary.EventName,
+	}
 }
 
 // EventBridgeScheduledWorkloadSummary is the portable summary for EventBridge scheduled workloads.

--- a/runtime/event_workloads.go
+++ b/runtime/event_workloads.go
@@ -19,6 +19,39 @@ const (
 	eventBridgeCorrelationSourceAWSRequestID = "lambda.aws_request_id"
 )
 
+// DynamoDBStreamRecordSummary is the portable, safe summary for a DynamoDB Streams record.
+type DynamoDBStreamRecordSummary struct {
+	AWSRegion      string `json:"aws_region"`
+	EventID        string `json:"event_id"`
+	EventName      string `json:"event_name"`
+	SafeLog        string `json:"safe_log"`
+	SequenceNumber string `json:"sequence_number"`
+	SizeBytes      int64  `json:"size_bytes"`
+	StreamViewType string `json:"stream_view_type"`
+	TableName      string `json:"table_name"`
+}
+
+// NormalizeDynamoDBStreamRecord returns a portable, safe summary for a DynamoDB Streams record.
+//
+// The summary intentionally excludes raw Keys, NewImage, and OldImage values so sensitive item
+// material cannot be copied into logs, metrics, spans, or handler summaries through this helper.
+func NormalizeDynamoDBStreamRecord(record events.DynamoDBEventRecord) DynamoDBStreamRecordSummary {
+	tableName := dynamoDBTableNameFromStreamARN(record.EventSourceArn)
+	sequenceNumber := strings.TrimSpace(record.Change.SequenceNumber)
+	eventID := strings.TrimSpace(record.EventID)
+	eventName := strings.TrimSpace(record.EventName)
+	return DynamoDBStreamRecordSummary{
+		AWSRegion:      strings.TrimSpace(record.AWSRegion),
+		EventID:        eventID,
+		EventName:      eventName,
+		SafeLog:        "table=" + tableName + " event_id=" + eventID + " event_name=" + eventName + " sequence_number=" + sequenceNumber,
+		SequenceNumber: sequenceNumber,
+		SizeBytes:      record.Change.SizeBytes,
+		StreamViewType: strings.TrimSpace(record.Change.StreamViewType),
+		TableName:      tableName,
+	}
+}
+
 // EventBridgeWorkloadEnvelope is the portable, safe summary AppTheory exposes for EventBridge workloads.
 type EventBridgeWorkloadEnvelope struct {
 	Account           string   `json:"account"`

--- a/runtime/event_workloads.go
+++ b/runtime/event_workloads.go
@@ -75,6 +75,91 @@ func RequireEventBridgeWorkloadEnvelope(
 	return envelope, nil
 }
 
+// EventBridgeScheduledWorkloadSummary is the portable summary for EventBridge scheduled workloads.
+type EventBridgeScheduledWorkloadSummary struct {
+	CorrelationID     string                                    `json:"correlation_id"`
+	CorrelationSource string                                    `json:"correlation_source"`
+	DeadlineUnixMS    int64                                     `json:"deadline_unix_ms"`
+	DetailType        string                                    `json:"detail_type"`
+	EventID           string                                    `json:"event_id"`
+	IdempotencyKey    string                                    `json:"idempotency_key"`
+	Kind              string                                    `json:"kind"`
+	RemainingMS       int                                       `json:"remaining_ms"`
+	Result            EventBridgeScheduledWorkloadResultSummary `json:"result"`
+	RunID             string                                    `json:"run_id"`
+	ScheduledTime     string                                    `json:"scheduled_time"`
+	Source            string                                    `json:"source"`
+}
+
+// EventBridgeScheduledWorkloadResultSummary is the safe result summary for a scheduled workload.
+type EventBridgeScheduledWorkloadResultSummary struct {
+	Failed    int    `json:"failed"`
+	Processed int    `json:"processed"`
+	Status    string `json:"status"`
+}
+
+// NormalizeEventBridgeScheduledWorkload returns the canonical scheduled workload summary for an
+// EventBridge scheduled event.
+func NormalizeEventBridgeScheduledWorkload(
+	ctx *EventContext,
+	event events.EventBridgeEvent,
+) EventBridgeScheduledWorkloadSummary {
+	rawObject := eventContextRawJSONObject(ctx)
+	detail := eventBridgeDetailObject(event, rawObject)
+	result := rawObjectField(detail, "result")
+	envelope := NormalizeEventBridgeWorkloadEnvelope(ctx, event)
+
+	runID := rawString(detail, "run_id")
+	if runID == "" {
+		runID = strings.TrimSpace(event.ID)
+	}
+	if runID == "" {
+		runID = eventContextLambdaAWSRequestID(ctx)
+	}
+
+	idempotencyKey := rawString(detail, "idempotency_key")
+	if idempotencyKey == "" {
+		if eventID := strings.TrimSpace(event.ID); eventID != "" {
+			idempotencyKey = "eventbridge:" + eventID
+		} else if requestID := eventContextLambdaAWSRequestID(ctx); requestID != "" {
+			idempotencyKey = "lambda:" + requestID
+		}
+	}
+
+	status := rawString(result, "status")
+	if status == "" {
+		status = rawString(detail, "status")
+	}
+	if status == "" {
+		status = "ok"
+	}
+
+	remainingMS := eventContextRemainingMS(ctx)
+	var deadlineUnixMS int64
+	if remainingMS > 0 && ctx != nil {
+		deadlineUnixMS = ctx.Now().UnixMilli() + int64(remainingMS)
+	}
+
+	return EventBridgeScheduledWorkloadSummary{
+		CorrelationID:     envelope.CorrelationID,
+		CorrelationSource: envelope.CorrelationSource,
+		DeadlineUnixMS:    deadlineUnixMS,
+		DetailType:        envelope.DetailType,
+		EventID:           envelope.EventID,
+		IdempotencyKey:    idempotencyKey,
+		Kind:              "scheduled",
+		RemainingMS:       remainingMS,
+		Result: EventBridgeScheduledWorkloadResultSummary{
+			Failed:    rawInt(result, "failed"),
+			Processed: rawInt(result, "processed"),
+			Status:    status,
+		},
+		RunID:         runID,
+		ScheduledTime: envelope.Time,
+		Source:        envelope.Source,
+	}
+}
+
 func eventBridgeCorrelationID(
 	ctx *EventContext,
 	event events.EventBridgeEvent,
@@ -197,6 +282,39 @@ func rawHeaderString(headers map[string]any, key string) string {
 		}
 	}
 	return ""
+}
+
+func eventContextRemainingMS(ctx *EventContext) int {
+	if ctx == nil {
+		return 0
+	}
+	return ctx.RemainingMS
+}
+
+func rawInt(object map[string]any, key string) int {
+	if object == nil {
+		return 0
+	}
+	value, ok := object[key]
+	if !ok {
+		return 0
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	default:
+		return 0
+	}
 }
 
 func asTrimmedString(value any) string {

--- a/runtime/event_workloads.go
+++ b/runtime/event_workloads.go
@@ -1,0 +1,211 @@
+package apptheory
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+const (
+	eventBridgeCorrelationSourceMetadata     = "metadata.correlation_id"
+	eventBridgeCorrelationSourceHeader       = "headers.x-correlation-id"
+	eventBridgeCorrelationSourceDetail       = "detail.correlation_id"
+	eventBridgeCorrelationSourceEventID      = "event.id"
+	eventBridgeCorrelationSourceAWSRequestID = "lambda.aws_request_id"
+)
+
+// EventBridgeWorkloadEnvelope is the portable, safe summary AppTheory exposes for EventBridge workloads.
+type EventBridgeWorkloadEnvelope struct {
+	Account           string   `json:"account"`
+	CorrelationID     string   `json:"correlation_id"`
+	CorrelationSource string   `json:"correlation_source"`
+	DetailType        string   `json:"detail_type"`
+	EventID           string   `json:"event_id"`
+	Region            string   `json:"region"`
+	RequestID         string   `json:"request_id"`
+	Resources         []string `json:"resources"`
+	Source            string   `json:"source"`
+	Time              string   `json:"time"`
+}
+
+// NormalizeEventBridgeWorkloadEnvelope returns the canonical EventBridge workload envelope.
+//
+// Correlation IDs are selected in the contract-defined order:
+// metadata.correlation_id, headers["x-correlation-id"], detail.correlation_id, event.id,
+// and finally the Lambda awsRequestId.
+func NormalizeEventBridgeWorkloadEnvelope(
+	ctx *EventContext,
+	event events.EventBridgeEvent,
+) EventBridgeWorkloadEnvelope {
+	rawObject := eventContextRawJSONObject(ctx)
+	detail := eventBridgeDetailObject(event, rawObject)
+	correlationID, correlationSource := eventBridgeCorrelationID(ctx, event, rawObject, detail)
+
+	return EventBridgeWorkloadEnvelope{
+		Account:           strings.TrimSpace(event.AccountID),
+		CorrelationID:     correlationID,
+		CorrelationSource: correlationSource,
+		DetailType:        strings.TrimSpace(event.DetailType),
+		EventID:           strings.TrimSpace(event.ID),
+		Region:            strings.TrimSpace(event.Region),
+		RequestID:         eventContextRequestID(ctx),
+		Resources:         append([]string(nil), event.Resources...),
+		Source:            strings.TrimSpace(event.Source),
+		Time:              eventBridgeEventTime(event, rawObject),
+	}
+}
+
+// RequireEventBridgeWorkloadEnvelope returns the canonical EventBridge workload envelope and fails closed
+// when source, detail type, or correlation identity is missing.
+func RequireEventBridgeWorkloadEnvelope(
+	ctx *EventContext,
+	event events.EventBridgeEvent,
+) (EventBridgeWorkloadEnvelope, error) {
+	envelope := NormalizeEventBridgeWorkloadEnvelope(ctx, event)
+	if strings.TrimSpace(envelope.Source) == "" ||
+		strings.TrimSpace(envelope.DetailType) == "" ||
+		strings.TrimSpace(envelope.CorrelationID) == "" {
+		return envelope, errors.New("apptheory: eventbridge workload envelope invalid")
+	}
+	return envelope, nil
+}
+
+func eventBridgeCorrelationID(
+	ctx *EventContext,
+	event events.EventBridgeEvent,
+	raw map[string]any,
+	detail map[string]any,
+) (string, string) {
+	if value := rawString(rawObjectField(raw, "metadata"), "correlation_id"); value != "" {
+		return value, eventBridgeCorrelationSourceMetadata
+	}
+	if value := rawHeaderString(rawObjectField(raw, "headers"), "x-correlation-id"); value != "" {
+		return value, eventBridgeCorrelationSourceHeader
+	}
+	if value := rawString(detail, "correlation_id"); value != "" {
+		return value, eventBridgeCorrelationSourceDetail
+	}
+	if value := strings.TrimSpace(event.ID); value != "" {
+		return value, eventBridgeCorrelationSourceEventID
+	}
+	if value := eventContextLambdaAWSRequestID(ctx); value != "" {
+		return value, eventBridgeCorrelationSourceAWSRequestID
+	}
+	return "", ""
+}
+
+func eventBridgeDetailObject(event events.EventBridgeEvent, raw map[string]any) map[string]any {
+	detail := rawObjectField(raw, "detail")
+	if len(detail) > 0 {
+		return detail
+	}
+	return rawJSONObject(event.Detail)
+}
+
+func eventBridgeEventTime(event events.EventBridgeEvent, raw map[string]any) string {
+	if value := rawString(raw, "time"); value != "" {
+		return value
+	}
+	if event.Time.IsZero() {
+		return ""
+	}
+	return event.Time.UTC().Format(time.RFC3339)
+}
+
+func eventContextRequestID(ctx *EventContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return strings.TrimSpace(ctx.RequestID)
+}
+
+func eventContextLambdaAWSRequestID(ctx *EventContext) string {
+	if ctx == nil {
+		return ""
+	}
+	lambdaCtx, ok := lambdacontext.FromContext(ctx.Context())
+	if !ok || lambdaCtx == nil {
+		return ""
+	}
+	return strings.TrimSpace(lambdaCtx.AwsRequestID)
+}
+
+func eventContextRawJSONObject(ctx *EventContext) map[string]any {
+	if ctx == nil || len(ctx.rawEvent) == 0 {
+		return map[string]any{}
+	}
+	return rawJSONObject(ctx.rawEvent)
+}
+
+func rawJSONObject(raw json.RawMessage) map[string]any {
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+		return map[string]any{}
+	}
+	return object
+}
+
+func rawObjectField(object map[string]any, key string) map[string]any {
+	if object == nil {
+		return map[string]any{}
+	}
+	value, ok := object[key]
+	if !ok {
+		return map[string]any{}
+	}
+	child, ok := value.(map[string]any)
+	if !ok || child == nil {
+		return map[string]any{}
+	}
+	return child
+}
+
+func rawString(object map[string]any, key string) string {
+	if object == nil {
+		return ""
+	}
+	value, ok := object[key]
+	if !ok {
+		return ""
+	}
+	return asTrimmedString(value)
+}
+
+func rawHeaderString(headers map[string]any, key string) string {
+	key = strings.TrimSpace(strings.ToLower(key))
+	if key == "" || headers == nil {
+		return ""
+	}
+	for name, value := range headers {
+		if strings.TrimSpace(strings.ToLower(name)) != key {
+			continue
+		}
+		if single := asTrimmedString(value); single != "" {
+			return single
+		}
+		if values, ok := value.([]any); ok {
+			for _, entry := range values {
+				if single := asTrimmedString(entry); single != "" {
+					return single
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func asTrimmedString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return ""
+	}
+}

--- a/runtime/event_workloads_test.go
+++ b/runtime/event_workloads_test.go
@@ -3,6 +3,7 @@ package apptheory
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,5 +104,39 @@ func TestNormalizeEventBridgeScheduledWorkload_BuildsDeterministicSummary(t *tes
 	}
 	if summary.Result.Status != "ok" || summary.Result.Processed != 3 || summary.Result.Failed != 1 {
 		t.Fatalf("unexpected result summary: %#v", summary.Result)
+	}
+}
+
+func TestNormalizeDynamoDBStreamRecord_ExcludesRawImagesFromSafeLog(t *testing.T) {
+	t.Parallel()
+
+	summary := NormalizeDynamoDBStreamRecord(events.DynamoDBEventRecord{
+		AWSRegion:      "us-east-1",
+		EventID:        "stream-evt-1",
+		EventName:      "MODIFY",
+		EventSourceArn: "arn:aws:dynamodb:us-east-1:000000000000:table/ReleaseState/stream/2026-04-24T12:00:00.000",
+		Change: events.DynamoDBStreamRecord{
+			Keys: map[string]events.DynamoDBAttributeValue{
+				"pk": events.NewStringAttribute("release#rel_123"),
+			},
+			NewImage: map[string]events.DynamoDBAttributeValue{
+				"secret": events.NewStringAttribute("do-not-log"),
+			},
+			OldImage: map[string]events.DynamoDBAttributeValue{
+				"secret": events.NewStringAttribute("previous-secret"),
+			},
+			SequenceNumber: "000000000000000001",
+			SizeBytes:      128,
+			StreamViewType: "NEW_AND_OLD_IMAGES",
+		},
+	})
+
+	if summary.TableName != "ReleaseState" || summary.SequenceNumber != "000000000000000001" {
+		t.Fatalf("unexpected normalized summary: %#v", summary)
+	}
+	for _, sentinel := range []string{"release#rel_123", "do-not-log", "previous-secret"} {
+		if strings.Contains(summary.SafeLog, sentinel) {
+			t.Fatalf("safe log leaked sentinel %q: %q", sentinel, summary.SafeLog)
+		}
 	}
 }

--- a/runtime/event_workloads_test.go
+++ b/runtime/event_workloads_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambdacontext"
@@ -61,5 +62,46 @@ func TestRequireEventBridgeWorkloadEnvelope_FailsClosedWithoutCorrelation(t *tes
 	})
 	if err == nil || err.Error() != "apptheory: eventbridge workload envelope invalid" {
 		t.Fatalf("expected fail-closed validation error, got %v", err)
+	}
+}
+
+func TestNormalizeEventBridgeScheduledWorkload_BuildsDeterministicSummary(t *testing.T) {
+	t.Parallel()
+
+	app := New(WithClock(fixedClock{now: time.Unix(0, 0).UTC()}))
+	app.EventBridge(EventBridgePattern("aws.events", "Scheduled Event"), func(ctx *EventContext, event events.EventBridgeEvent) (any, error) {
+		return NormalizeEventBridgeScheduledWorkload(ctx, event), nil
+	})
+
+	raw := json.RawMessage(`{
+		"version":"0",
+		"id":"sched-evt",
+		"detail-type":"Scheduled Event",
+		"source":"aws.events",
+		"time":"2026-04-24T12:00:00Z",
+		"detail":{
+			"run_id":"run-1",
+			"idempotency_key":"schedule/test/1",
+			"result":{"status":"ok","processed":3,"failed":1}
+		},
+		"metadata":{"correlation_id":"corr-schedule"}
+	}`)
+	base := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{AwsRequestID: "aws-req"})
+	ctx, cancel := context.WithDeadline(base, time.Unix(0, 0).UTC().Add(25000*time.Millisecond))
+	defer cancel()
+
+	out, err := app.HandleLambda(ctx, raw)
+	if err != nil {
+		t.Fatalf("HandleLambda returned error: %v", err)
+	}
+	summary, ok := out.(EventBridgeScheduledWorkloadSummary)
+	if !ok {
+		t.Fatalf("expected EventBridgeScheduledWorkloadSummary, got %T", out)
+	}
+	if summary.RunID != "run-1" || summary.IdempotencyKey != "schedule/test/1" || summary.DeadlineUnixMS != 25000 {
+		t.Fatalf("unexpected scheduled identity fields: %#v", summary)
+	}
+	if summary.Result.Status != "ok" || summary.Result.Processed != 3 || summary.Result.Failed != 1 {
+		t.Fatalf("unexpected result summary: %#v", summary.Result)
 	}
 }

--- a/runtime/event_workloads_test.go
+++ b/runtime/event_workloads_test.go
@@ -1,0 +1,65 @@
+package apptheory
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+func TestNormalizeEventBridgeWorkloadEnvelope_UsesPortableCorrelationPrecedence(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	app.EventBridge(EventBridgePattern("apptheory.test", "thing.changed"), func(ctx *EventContext, event events.EventBridgeEvent) (any, error) {
+		envelope, err := RequireEventBridgeWorkloadEnvelope(ctx, event)
+		if err != nil {
+			return nil, err
+		}
+		return envelope, nil
+	})
+
+	raw := json.RawMessage(`{
+		"version":"0",
+		"id":"evt-123",
+		"detail-type":"thing.changed",
+		"source":"apptheory.test",
+		"account":"000000000000",
+		"time":"2026-04-24T12:00:00Z",
+		"region":"us-east-1",
+		"resources":["arn:aws:events:us-east-1:000000000000:rule/test"],
+		"detail":{"correlation_id":"corr-detail"},
+		"headers":{"X-Correlation-ID":["corr-header"]},
+		"metadata":{"correlation_id":"corr-metadata"}
+	}`)
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{AwsRequestID: "aws-req"})
+
+	out, err := app.HandleLambda(ctx, raw)
+	if err != nil {
+		t.Fatalf("HandleLambda returned error: %v", err)
+	}
+	envelope, ok := out.(EventBridgeWorkloadEnvelope)
+	if !ok {
+		t.Fatalf("expected EventBridgeWorkloadEnvelope, got %T", out)
+	}
+	if envelope.CorrelationID != "corr-metadata" || envelope.CorrelationSource != eventBridgeCorrelationSourceMetadata {
+		t.Fatalf("unexpected correlation: %#v", envelope)
+	}
+	if envelope.RequestID != "aws-req" || envelope.Time != "2026-04-24T12:00:00Z" {
+		t.Fatalf("unexpected request/time fields: %#v", envelope)
+	}
+}
+
+func TestRequireEventBridgeWorkloadEnvelope_FailsClosedWithoutCorrelation(t *testing.T) {
+	t.Parallel()
+
+	_, err := RequireEventBridgeWorkloadEnvelope(&EventContext{}, events.EventBridgeEvent{
+		Source:     "apptheory.test",
+		DetailType: "thing.changed",
+	})
+	if err == nil || err.Error() != "apptheory: eventbridge workload envelope invalid" {
+		t.Fatalf("expected fail-closed validation error, got %v", err)
+	}
+}

--- a/runtime/event_workloads_test.go
+++ b/runtime/event_workloads_test.go
@@ -3,6 +3,7 @@ package apptheory
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -138,5 +139,93 @@ func TestNormalizeDynamoDBStreamRecord_ExcludesRawImagesFromSafeLog(t *testing.T
 		if strings.Contains(summary.SafeLog, sentinel) {
 			t.Fatalf("safe log leaked sentinel %q: %q", sentinel, summary.SafeLog)
 		}
+	}
+}
+
+func TestServeEventBridge_RecoversPanicAndRecordsEventObservability(t *testing.T) {
+	t.Parallel()
+
+	var logs []LogRecord
+	var metrics []MetricRecord
+	var spans []SpanRecord
+	app := New(WithObservability(ObservabilityHooks{
+		Log: func(r LogRecord) {
+			logs = append(logs, r)
+		},
+		Metric: func(r MetricRecord) {
+			metrics = append(metrics, r)
+		},
+		Span: func(r SpanRecord) {
+			spans = append(spans, r)
+		},
+	}))
+	app.EventBridge(EventBridgePattern("apptheory.test", "thing.panic"), func(_ *EventContext, _ events.EventBridgeEvent) (any, error) {
+		panic("do-not-log")
+	})
+
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{AwsRequestID: "aws-req"})
+	out, err := app.ServeEventBridge(ctx, events.EventBridgeEvent{
+		ID:         "evt-1",
+		Source:     "apptheory.test",
+		DetailType: "thing.panic",
+	})
+	if out != nil || err == nil || err.Error() != eventWorkloadFailedMessage {
+		t.Fatalf("expected safe event workload failure, out=%v err=%v", out, err)
+	}
+	if strings.Contains(err.Error(), "do-not-log") {
+		t.Fatalf("safe error leaked panic payload: %v", err)
+	}
+	if len(logs) != 1 || logs[0].Level != "error" || logs[0].ErrorCode != "app.internal" || logs[0].CorrelationID != "evt-1" {
+		t.Fatalf("unexpected event log records: %#v", logs)
+	}
+	if len(metrics) != 1 || metrics[0].Tags["outcome"] != "error" || metrics[0].Tags["trigger"] != "eventbridge" {
+		t.Fatalf("unexpected event metrics: %#v", metrics)
+	}
+	if len(spans) != 1 || spans[0].Attributes["error.code"] != "app.internal" {
+		t.Fatalf("unexpected event spans: %#v", spans)
+	}
+}
+
+func TestServeDynamoDBStream_RecordsPerRecordObservability(t *testing.T) {
+	t.Parallel()
+
+	var logs []LogRecord
+	app := New(WithObservability(ObservabilityHooks{
+		Log: func(r LogRecord) {
+			logs = append(logs, r)
+		},
+	}))
+	app.DynamoDB("ReleaseState", func(_ *EventContext, record events.DynamoDBEventRecord) error {
+		if record.EventName == "REMOVE" {
+			return errors.New("do-not-log")
+		}
+		return nil
+	})
+
+	out := app.ServeDynamoDBStream(context.Background(), events.DynamoDBEvent{Records: []events.DynamoDBEventRecord{
+		{
+			EventID:        "stream-1",
+			EventName:      "MODIFY",
+			EventSourceArn: "arn:aws:dynamodb:us-east-1:000000000000:table/ReleaseState/stream/2026",
+			Change:         events.DynamoDBStreamRecord{SequenceNumber: "1", StreamViewType: "NEW_AND_OLD_IMAGES"},
+		},
+		{
+			EventID:        "stream-2",
+			EventName:      "REMOVE",
+			EventSourceArn: "arn:aws:dynamodb:us-east-1:000000000000:table/ReleaseState/stream/2026",
+			Change:         events.DynamoDBStreamRecord{SequenceNumber: "2", StreamViewType: "NEW_AND_OLD_IMAGES"},
+		},
+	}})
+	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "stream-2" {
+		t.Fatalf("unexpected batch failures: %#v", out.BatchItemFailures)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected per-record logs, got %#v", logs)
+	}
+	if logs[0].Level != "info" || logs[0].Trigger != "dynamodb_stream" || logs[0].CorrelationID != "stream-1" {
+		t.Fatalf("unexpected success log: %#v", logs[0])
+	}
+	if logs[1].Level != "error" || logs[1].ErrorCode != "app.internal" || logs[1].EventID != "stream-2" {
+		t.Fatalf("unexpected error log: %#v", logs[1])
 	}
 }

--- a/runtime/observability.go
+++ b/runtime/observability.go
@@ -2,6 +2,13 @@ package apptheory
 
 import "strconv"
 
+const (
+	logLevelInfo               = "info"
+	logLevelError              = "error"
+	eventTriggerEventBridge    = "eventbridge"
+	eventTriggerDynamoDBStream = "dynamodb_stream"
+)
+
 type LogRecord struct {
 	Level     string
 	Event     string
@@ -11,6 +18,14 @@ type LogRecord struct {
 	Path      string
 	Status    int
 	ErrorCode string
+
+	Trigger       string
+	CorrelationID string
+	Source        string
+	DetailType    string
+	TableName     string
+	EventID       string
+	EventName     string
 }
 
 type MetricRecord struct {
@@ -35,9 +50,9 @@ func (a *App) recordObservability(method, path, requestID, tenantID string, stat
 		return
 	}
 
-	level := "info"
+	level := logLevelInfo
 	if status >= 500 {
-		level = "error"
+		level = logLevelError
 	} else if status >= 400 {
 		level = "warn"
 	}
@@ -82,4 +97,105 @@ func (a *App) recordObservability(method, path, requestID, tenantID string, stat
 			},
 		})
 	}
+}
+
+type eventObservation struct {
+	Trigger       string
+	RequestID     string
+	CorrelationID string
+	Source        string
+	DetailType    string
+	TableName     string
+	EventID       string
+	EventName     string
+}
+
+func (a *App) recordEventObservability(observation eventObservation, outcome string, errorCode string) {
+	if a == nil {
+		return
+	}
+
+	level := logLevelInfo
+	if errorCode != "" || outcome == "error" {
+		level = logLevelError
+	}
+
+	if a.obs.Log != nil {
+		a.obs.Log(LogRecord{
+			Level:         level,
+			Event:         "event.completed",
+			RequestID:     observation.RequestID,
+			ErrorCode:     errorCode,
+			Trigger:       observation.Trigger,
+			CorrelationID: observation.CorrelationID,
+			Source:        observation.Source,
+			DetailType:    observation.DetailType,
+			TableName:     observation.TableName,
+			EventID:       observation.EventID,
+			EventName:     observation.EventName,
+		})
+	}
+
+	if a.obs.Metric != nil {
+		a.obs.Metric(MetricRecord{
+			Name:  "apptheory.event",
+			Value: 1,
+			Tags:  eventMetricTags(observation, outcome, errorCode),
+		})
+	}
+
+	if a.obs.Span != nil {
+		a.obs.Span(SpanRecord{
+			Name:       eventSpanName(observation),
+			Attributes: eventSpanAttributes(observation, outcome, errorCode),
+		})
+	}
+}
+
+func eventMetricTags(observation eventObservation, outcome string, errorCode string) map[string]string {
+	tags := map[string]string{
+		"correlation_id": observation.CorrelationID,
+		"error_code":     errorCode,
+		"outcome":        outcome,
+		"trigger":        observation.Trigger,
+	}
+	switch observation.Trigger {
+	case eventTriggerEventBridge:
+		tags["detail_type"] = observation.DetailType
+		tags["source"] = observation.Source
+	case eventTriggerDynamoDBStream:
+		tags["event_name"] = observation.EventName
+		tags["table_name"] = observation.TableName
+	}
+	return tags
+}
+
+func eventSpanName(observation eventObservation) string {
+	switch observation.Trigger {
+	case eventTriggerEventBridge:
+		return eventTriggerEventBridge + " " + observation.Source + " " + observation.DetailType
+	case eventTriggerDynamoDBStream:
+		return eventTriggerDynamoDBStream + " " + observation.TableName + " " + observation.EventName
+	default:
+		return observation.Trigger
+	}
+}
+
+func eventSpanAttributes(observation eventObservation, outcome string, errorCode string) map[string]string {
+	attrs := map[string]string{
+		"correlation.id": observation.CorrelationID,
+		"error.code":     errorCode,
+		"outcome":        outcome,
+		"trigger":        observation.Trigger,
+	}
+	switch observation.Trigger {
+	case eventTriggerEventBridge:
+		attrs["event.detail_type"] = observation.DetailType
+		attrs["event.source"] = observation.Source
+	case eventTriggerDynamoDBStream:
+		attrs["dynamodb.event_id"] = observation.EventID
+		attrs["dynamodb.event_name"] = observation.EventName
+		attrs["dynamodb.table_name"] = observation.TableName
+	}
+	return attrs
 }

--- a/runtime/observability.go
+++ b/runtime/observability.go
@@ -116,7 +116,7 @@ func (a *App) recordEventObservability(observation eventObservation, outcome str
 	}
 
 	level := logLevelInfo
-	if errorCode != "" || outcome == "error" {
+	if errorCode != "" || outcome == logLevelError {
 		level = logLevelError
 	}
 


### PR DESCRIPTION
## Milestone
go-event-workload-runtime — Implement the Go runtime helpers and safe runtime posture for the event workload contract pinned in PR #453.

## Linear
https://linear.app/pay-theory/project/apptheory-event-driven-lambda-workload-contracts-4470cd3263aa / `go-event-workload-runtime`

## Tasks
- [x] PAY-160 Add Go EventBridge workload envelope helpers
- [x] PAY-161 Add Go scheduled workload helpers
- [x] PAY-162 Add Go DynamoDB stream record normalization
- [x] PAY-163 Add Go event workload observability/error handling

## Contract impact
Go runtime public API growth with Go API snapshot updates. Shared fixtures remain the contract; the Go M1 runner now uses runtime helpers for envelope/scheduled/stream summaries and runtime-owned observability/safe error recovery.

## Validation
Commands run on the final commit (`05a6f1c`):
- `make rubric` — PASS

Commands run before each task commit:
- `make test-unit` — PASS
- `./scripts/verify-contract-tests.sh` — PASS
- `make rubric` — PASS
- `./scripts/update-api-snapshots.sh` — PASS/updated Go snapshot where public surface moved

Final `make rubric` includes:
- API snapshots — PASS
- contract tests Go/TS/Py — PASS (115 fixtures each)
- docs-standard — PASS
- examples — PASS

## Cross-repo notes
None. TypeScript and Python parity are tracked by the next Linear milestones (`ts-event-workload-runtime`, `py-event-workload-runtime`) and must land before this event workload surface ships in a stable release.



## CI follow-up
- `05a6f1c` fixes the fresh-run `goconst` failure in `runtime/observability.go` by reusing the existing error-level constant.
