### PR TITLE
feat(testkit): support HTTP source provenance migration

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2528,6 +2528,7 @@ type HTTPEventOptions struct {
 	Cookies      []string
 	Body         []byte
 	IsBase64     bool
+	SourceIP     string
 }
 
 type KinesisEventOptions struct {

--- a/contract-tests/fixtures/p0/source-provenance-apigw-v2-ipv6-canonical.json
+++ b/contract-tests/fixtures/p0/source-provenance-apigw-v2-ipv6-canonical.json
@@ -1,0 +1,79 @@
+{
+  "id": "p0.source_provenance.apigw_v2_ipv6_canonical",
+  "tier": "p0",
+  "name": "Source provenance: API Gateway v2 IPv6 source IP is canonicalized",
+  "setup": {
+    "routes": [
+      {
+        "method": "GET",
+        "path": "/source",
+        "handler": "source_provenance"
+      }
+    ]
+  },
+  "input": {
+    "request": {
+      "method": "GET",
+      "path": "/source",
+      "query": {},
+      "headers": {
+        "forwarded": [
+          "for=203.0.113.10;proto=https"
+        ],
+        "x-forwarded-for": [
+          "203.0.113.10, 70.0.0.1"
+        ]
+      },
+      "body": {
+        "encoding": "utf8",
+        "value": ""
+      },
+      "is_base64": false
+    },
+    "aws_event": {
+      "source": "apigw_v2",
+      "event": {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/source",
+        "rawQueryString": "",
+        "cookies": [],
+        "headers": {
+          "forwarded": "for=203.0.113.10;proto=https",
+          "x-forwarded-for": "203.0.113.10, 70.0.0.1"
+        },
+        "queryStringParameters": null,
+        "requestContext": {
+          "http": {
+            "method": "GET",
+            "path": "/source",
+            "sourceIp": "2001:DB8::1"
+          }
+        },
+        "body": "",
+        "isBase64Encoded": false
+      }
+    }
+  },
+  "expect": {
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "cookies": [],
+      "body_json": {
+        "source_ip": "2001:db8::1",
+        "source_provenance": {
+          "source_ip": "2001:db8::1",
+          "provider": "apigw-v2",
+          "source": "provider_request_context",
+          "valid": true
+        }
+      },
+      "is_base64": false
+    }
+  }
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,9 +48,10 @@ Security migration note:
 
 Shared request model:
 
-- `Request`: method, path, headers, query, and body
+- `Request`: method, path, headers, query, body, and normalized source provenance
 - `Response`: status, headers, cookies, body, and streaming fields where supported
-- `Context`: request-scoped accessors for headers, params, request ID, tenant, clock, IDs, and middleware state
+- `Context`: request-scoped accessors for headers, params, request ID, tenant, source provenance, clock, IDs, and
+  middleware state
 
 Common helper exports:
 
@@ -69,6 +70,42 @@ HTTP error compatibility:
   - TypeScript: `createApp({ httpErrorFormat: HTTP_ERROR_FORMAT_FLAT_LEGACY })`
   - Python: `create_app(http_error_format=HTTP_ERROR_FORMAT_FLAT_LEGACY)`
 - This setting applies to HTTP serialization only. AppSync and WebSocket error payloads keep their existing shapes.
+
+## HTTP source provenance
+
+`SourceProvenance` is the portable, structured source-IP contract for HTTP requests. It is available in every HTTP
+tier, including P0, and is derived only from AWS provider request context fields.
+
+| Concern | Go | TypeScript | Python |
+| --- | --- | --- | --- |
+| Structured type | `SourceProvenance` | `SourceProvenance` | `SourceProvenance` |
+| Request field | `Request.SourceProvenance` | `Request.sourceProvenance` | `Request.source_provenance` |
+| Context accessor | `ctx.SourceProvenance()` | `ctx.sourceProvenance()` | `ctx.source_provenance()` |
+| Convenience IP accessor | `ctx.SourceIP()` | `ctx.sourceIP()` | `ctx.source_ip()` |
+| API Gateway v2 test builder option | `HTTPEventOptions.SourceIP` | `sourceIp` | `source_ip` |
+| Lambda Function URL test builder option | `HTTPEventOptions.SourceIP` | `sourceIp` | `source_ip` |
+
+The structured value has four fields:
+
+- `source_ip`: canonical parsed source IP string, or `""` when invalid/unknown
+- `provider`: `apigw-v2`, `lambda-url`, `apigw-v1`, or `unknown`
+- `source`: `provider_request_context` or `unknown`
+- `valid`: `true` only when the provider supplied a parseable source IP
+
+Provider mapping:
+
+- API Gateway v2 HTTP API: `requestContext.http.sourceIp` -> `provider = "apigw-v2"`
+- Lambda Function URL: `requestContext.http.sourceIp` -> `provider = "lambda-url"`
+- API Gateway v1 REST proxy: `requestContext.identity.sourceIp` -> `provider = "apigw-v1"`
+- Missing, malformed, unsupported, or ALB source values -> `provider = "unknown"`, `source = "unknown"`,
+  `valid = false`
+
+Valid IPs are parsed and re-emitted in canonical form before they become public response or handler strings. For
+example, `2001:DB8::1` becomes `2001:db8::1` in all three runtimes.
+
+AppTheory does not parse or trust `Forwarded`, `X-Forwarded-For`, or similar client-controlled forwarding headers for
+this contract. Those headers remain ordinary request headers if AWS forwards them, but they do not influence
+`SourceProvenance` or `SourceIP`.
 
 ## Universal Lambda entrypoint
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,6 +139,39 @@ single-Lambda entrypoint can continue to use `HandleLambda`, `handleLambda`, or 
 For the GraphQL front door itself, use native AppSync infrastructure such as `aws-cdk-lib/aws-appsync`; AppTheory owns
 the Lambda resolver adapter, not the GraphQL API construct.
 
+## Safe HTTP source IP access
+
+Use AppTheory source provenance when a handler or middleware needs the provider-observed client IP. Do not derive
+security decisions from `Forwarded` or `X-Forwarded-For`; those are viewer-controlled headers unless a product has its
+own separate trusted-proxy model.
+
+```go
+app.Get("/source", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+	return apptheory.JSON(200, map[string]string{"source_ip": ctx.SourceIP()})
+})
+
+event := testkit.APIGatewayV2Request("GET", "/source", testkit.HTTPEventOptions{
+	SourceIP: "2001:DB8::1",
+})
+```
+
+```ts
+app.get("/source", (ctx) => json(200, { source_ip: ctx.sourceIP() }));
+
+const event = buildAPIGatewayV2Request("GET", "/source", {
+  sourceIp: "2001:DB8::1",
+});
+```
+
+```py
+app.get("/source", lambda ctx: json(200, {"source_ip": ctx.source_ip()}))
+
+event = build_apigw_v2_request("GET", "/source", source_ip="2001:DB8::1")
+```
+
+The runtime canonicalizes valid provider IPs, so each example exposes `2001:db8::1`. Missing or malformed provider
+values return unknown/invalid provenance instead of falling back to forwarding headers.
+
 ## Next reads
 
 - [Documentation Index](./README.md)

--- a/docs/migration/v1-security.md
+++ b/docs/migration/v1-security.md
@@ -70,6 +70,48 @@ Why this changed:
 - Indefinitely open initial listeners and session resurrection both undermined the intended MCP transport and session
   boundaries.
 
+## HTTP source IP now uses provider provenance
+
+Affected surface:
+
+- Go / TypeScript / Python HTTP handlers and middleware that need the provider-observed source IP
+- Local tests that build API Gateway v2 or Lambda Function URL events
+- Product migration shims, including Lesser’s temporary bridge-header injection
+
+What changed:
+
+- HTTP requests now carry a portable `SourceProvenance` value and a convenience `SourceIP` / `sourceIP` /
+  `source_ip` accessor in every HTTP tier, including P0.
+- The value is derived only from AWS provider request context:
+  - API Gateway v2 HTTP API: `requestContext.http.sourceIp`
+  - Lambda Function URL: `requestContext.http.sourceIp`
+  - API Gateway v1 REST proxy: `requestContext.identity.sourceIp`
+- Valid IPs are canonicalized across runtimes before exposure. For example, `2001:DB8::1` becomes `2001:db8::1`.
+- Missing or malformed provider values return unknown/invalid provenance instead of failing the request or broadening
+  to forwarding headers.
+- ALB does not have source provenance in this pass; it returns unknown/invalid provenance.
+
+What you need to do:
+
+1. Replace any temporary bridge-header reads with the AppTheory context accessor:
+   - Go: `ctx.SourceIP()` or `ctx.SourceProvenance()`
+   - TypeScript: `ctx.sourceIP()` or `ctx.sourceProvenance()`
+   - Python: `ctx.source_ip()` or `ctx.source_provenance()`
+2. Update deterministic tests to set provider source metadata through the test builders:
+   - Go: `testkit.HTTPEventOptions{SourceIP: "..."}`
+   - TypeScript: `buildAPIGatewayV2Request(..., { sourceIp: "..." })`
+   - Python: `build_apigw_v2_request(..., source_ip="...")`
+3. Remove Lesser’s bridge-header injection after the application is upgraded to the source provenance API.
+4. Do not replace the bridge header with `Forwarded` or `X-Forwarded-For` parsing inside AppTheory handlers. Those
+   headers are viewer-controlled unless a product owns a separate trusted-proxy chain outside the AppTheory contract.
+
+Why this changed:
+
+- Public source-IP strings are a cross-language contract, so the runtime must expose the same canonical value in Go,
+  TypeScript, and Python.
+- Header-derived source IPs are not fail-closed without a trusted-proxy configuration. AppTheory’s portable contract
+  therefore uses provider context only.
+
 ## Credentialed CORS now requires an explicit allowlist
 
 Affected surface:

--- a/py/src/apptheory/aws_http.py
+++ b/py/src/apptheory/aws_http.py
@@ -195,6 +195,7 @@ def build_apigw_v2_request(
     cookies: list[str] | None = None,
     body: Any = b"",
     is_base64: bool = False,
+    source_ip: str | None = None,
 ) -> dict[str, Any]:
     raw_path, raw_query_string = _split_path_and_query(path, query)
     body_bytes = to_bytes(body)
@@ -207,6 +208,13 @@ def build_apigw_v2_request(
         if values:
             query_string_parameters[str(key)] = str(values[0])
 
+    request_context_http = {
+        "method": str(method or "").strip().upper(),
+        "path": raw_path,
+    }
+    if source_ip is not None:
+        request_context_http["sourceIp"] = str(source_ip or "").strip()
+
     return {
         "version": "2.0",
         "routeKey": "$default",
@@ -215,12 +223,7 @@ def build_apigw_v2_request(
         "cookies": [str(c) for c in (cookies or [])],
         "headers": dict(headers or {}),
         "queryStringParameters": query_string_parameters or None,
-        "requestContext": {
-            "http": {
-                "method": str(method or "").strip().upper(),
-                "path": raw_path,
-            }
-        },
+        "requestContext": {"http": request_context_http},
         "body": body_str,
         "isBase64Encoded": bool(is_base64),
     }
@@ -235,6 +238,7 @@ def build_lambda_function_url_request(
     cookies: list[str] | None = None,
     body: Any = b"",
     is_base64: bool = False,
+    source_ip: str | None = None,
 ) -> dict[str, Any]:
     raw_path, raw_query_string = _split_path_and_query(path, query)
     body_bytes = to_bytes(body)
@@ -247,6 +251,13 @@ def build_lambda_function_url_request(
         if values:
             query_string_parameters[str(key)] = str(values[0])
 
+    request_context_http = {
+        "method": str(method or "").strip().upper(),
+        "path": raw_path,
+    }
+    if source_ip is not None:
+        request_context_http["sourceIp"] = str(source_ip or "").strip()
+
     return {
         "version": "2.0",
         "rawPath": raw_path,
@@ -254,12 +265,7 @@ def build_lambda_function_url_request(
         "cookies": [str(c) for c in (cookies or [])],
         "headers": dict(headers or {}),
         "queryStringParameters": query_string_parameters or None,
-        "requestContext": {
-            "http": {
-                "method": str(method or "").strip().upper(),
-                "path": raw_path,
-            }
-        },
+        "requestContext": {"http": request_context_http},
         "body": body_str,
         "isBase64Encoded": bool(is_base64),
     }

--- a/py/tests/test_aws_http.py
+++ b/py/tests/test_aws_http.py
@@ -19,6 +19,7 @@ from apptheory.aws_http import (  # noqa: E402
     request_from_alb_target_group,
     request_from_apigw_proxy,
     request_from_apigw_v2,
+    request_from_lambda_function_url,
 )
 from apptheory.response import Response  # noqa: E402
 
@@ -36,6 +37,17 @@ class TestAwsHttp(unittest.TestCase):
         self.assertEqual(evt["rawQueryString"], "a=1&b=2")
         self.assertEqual(evt["body"], base64.b64encode(b"\x01\x02").decode("ascii"))
         self.assertTrue(evt["isBase64Encoded"])
+
+    def test_http_request_builders_set_source_ip(self) -> None:
+        v2_evt = build_apigw_v2_request("get", "/source", source_ip="2001:DB8::1")
+        self.assertEqual(v2_evt["requestContext"]["http"]["sourceIp"], "2001:DB8::1")
+        v2_req = request_from_apigw_v2(v2_evt)
+        self.assertEqual(v2_req.source_provenance.source_ip, "2001:db8::1")
+
+        url_evt = build_lambda_function_url_request("get", "/source", source_ip="198.51.100.88")
+        self.assertEqual(url_evt["requestContext"]["http"]["sourceIp"], "198.51.100.88")
+        url_req = request_from_lambda_function_url(url_evt)
+        self.assertEqual(url_req.source_provenance.source_ip, "198.51.100.88")
 
     def test_request_from_apigw_v2_prefers_cookies_and_parses_raw_query(self) -> None:
         evt = build_apigw_v2_request(

--- a/testkit/http_events.go
+++ b/testkit/http_events.go
@@ -19,6 +19,7 @@ type HTTPEventOptions struct {
 	Cookies      []string
 	Body         []byte
 	IsBase64     bool
+	SourceIP     string
 }
 
 func APIGatewayV2Request(method, path string, opts HTTPEventOptions) events.APIGatewayV2HTTPRequest {
@@ -52,8 +53,9 @@ func APIGatewayV2Request(method, path string, opts HTTPEventOptions) events.APIG
 		}(),
 		RequestContext: events.APIGatewayV2HTTPRequestContext{
 			HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
-				Method: strings.ToUpper(strings.TrimSpace(method)),
-				Path:   rawPath,
+				Method:   strings.ToUpper(strings.TrimSpace(method)),
+				Path:     rawPath,
+				SourceIP: opts.SourceIP,
 			},
 		},
 		Body:            body,
@@ -91,8 +93,9 @@ func LambdaFunctionURLRequest(method, path string, opts HTTPEventOptions) events
 		}(),
 		RequestContext: events.LambdaFunctionURLRequestContext{
 			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
-				Method: strings.ToUpper(strings.TrimSpace(method)),
-				Path:   rawPath,
+				Method:   strings.ToUpper(strings.TrimSpace(method)),
+				Path:     rawPath,
+				SourceIP: opts.SourceIP,
 			},
 		},
 		Body:            body,

--- a/testkit/http_events_test.go
+++ b/testkit/http_events_test.go
@@ -46,6 +46,37 @@ func TestInvokeLambdaFunctionURL(t *testing.T) {
 	}
 }
 
+func TestHTTPEventBuildersSourceIP(t *testing.T) {
+	env := testkit.New()
+	app := env.App()
+
+	app.Get("/source", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		return apptheory.Text(200, ctx.SourceIP()), nil
+	})
+
+	v2Event := testkit.APIGatewayV2Request("GET", "/source", testkit.HTTPEventOptions{
+		SourceIP: "2001:DB8::1",
+	})
+	if v2Event.RequestContext.HTTP.SourceIP != "2001:DB8::1" {
+		t.Fatalf("expected API Gateway v2 source IP to be set, got %q", v2Event.RequestContext.HTTP.SourceIP)
+	}
+	v2Resp := env.InvokeAPIGatewayV2(context.TODO(), app, v2Event)
+	if v2Resp.Body != "2001:db8::1" {
+		t.Fatalf("expected canonical API Gateway v2 source IP, got %q", v2Resp.Body)
+	}
+
+	urlEvent := testkit.LambdaFunctionURLRequest("GET", "/source", testkit.HTTPEventOptions{
+		SourceIP: "198.51.100.88",
+	})
+	if urlEvent.RequestContext.HTTP.SourceIP != "198.51.100.88" {
+		t.Fatalf("expected Lambda Function URL source IP to be set, got %q", urlEvent.RequestContext.HTTP.SourceIP)
+	}
+	urlResp := env.InvokeLambdaFunctionURL(context.TODO(), app, urlEvent)
+	if urlResp.Body != "198.51.100.88" {
+		t.Fatalf("expected Lambda Function URL source IP, got %q", urlResp.Body)
+	}
+}
+
 func TestInvokeALB(t *testing.T) {
 	env := testkit.New()
 	app := env.App()

--- a/ts/dist/internal/source-provenance.js
+++ b/ts/dist/internal/source-provenance.js
@@ -22,8 +22,9 @@ export function sourceProvenanceFromProviderRequestContext(provider, sourceIP) {
     if (isIP(sourceIPValue) === 0) {
         return unknownSourceProvenance();
     }
+    const canonicalSourceIP = canonicalizeIP(sourceIPValue);
     return {
-        sourceIP: sourceIPValue,
+        sourceIP: canonicalSourceIP,
         provider: providerValue,
         source: SOURCE_PROVIDER_REQUEST_CONTEXT,
         valid: true,
@@ -49,8 +50,9 @@ export function normalizeSourceProvenance(input) {
     if (isIP(sourceIP) === 0) {
         return unknownSourceProvenance();
     }
+    const canonicalSourceIP = canonicalizeIP(sourceIP);
     return {
-        sourceIP,
+        sourceIP: canonicalSourceIP,
         provider,
         source,
         valid: true,
@@ -60,4 +62,153 @@ function isKnownProvider(provider) {
     return (provider === PROVIDER_APIGW_V2 ||
         provider === PROVIDER_LAMBDA_URL ||
         provider === PROVIDER_APIGW_V1);
+}
+function canonicalizeIP(value) {
+    if (isIP(value) === 4) {
+        return value;
+    }
+    const words = parseIPv6Words(value);
+    if (!words) {
+        return value.toLowerCase();
+    }
+    if (isIPv4MappedIPv6(words)) {
+        const high = words[6];
+        const low = words[7];
+        if (high === undefined || low === undefined) {
+            return value.toLowerCase();
+        }
+        return `::ffff:${ipv4StringFromWords(high, low)}`;
+    }
+    const run = longestZeroRun(words);
+    if (!run || run.length < 2) {
+        return words.map((word) => word.toString(16)).join(":");
+    }
+    const left = words.slice(0, run.start).map((word) => word.toString(16));
+    const right = words
+        .slice(run.start + run.length)
+        .map((word) => word.toString(16));
+    if (left.length === 0 && right.length === 0) {
+        return "::";
+    }
+    if (left.length === 0) {
+        return `::${right.join(":")}`;
+    }
+    if (right.length === 0) {
+        return `${left.join(":")}::`;
+    }
+    return `${left.join(":")}::${right.join(":")}`;
+}
+function parseIPv6Words(input) {
+    let value = input.toLowerCase();
+    if (value.includes(".")) {
+        const lastColon = value.lastIndexOf(":");
+        if (lastColon < 0) {
+            return undefined;
+        }
+        const ipv4Words = parseIPv4Suffix(value.slice(lastColon + 1));
+        if (!ipv4Words) {
+            return undefined;
+        }
+        value = `${value.slice(0, lastColon)}:${ipv4Words[0].toString(16)}:${ipv4Words[1].toString(16)}`;
+    }
+    const compressedParts = value.split("::");
+    if (compressedParts.length > 2) {
+        return undefined;
+    }
+    if (compressedParts.length === 2) {
+        const left = parseIPv6Groups(compressedParts[0] ?? "");
+        const right = parseIPv6Groups(compressedParts[1] ?? "");
+        if (!left || !right) {
+            return undefined;
+        }
+        const missing = 8 - left.length - right.length;
+        if (missing < 1) {
+            return undefined;
+        }
+        return [...left, ...Array.from({ length: missing }, () => 0), ...right];
+    }
+    const words = parseIPv6Groups(value);
+    if (!words || words.length !== 8) {
+        return undefined;
+    }
+    return words;
+}
+function parseIPv6Groups(value) {
+    if (value === "") {
+        return [];
+    }
+    const groups = value.split(":");
+    if (groups.some((group) => group === "")) {
+        return undefined;
+    }
+    const words = [];
+    for (const group of groups) {
+        if (!/^[\da-f]{1,4}$/u.test(group)) {
+            return undefined;
+        }
+        words.push(Number.parseInt(group, 16));
+    }
+    return words;
+}
+function parseIPv4Suffix(value) {
+    const parts = value.split(".");
+    if (parts.length !== 4) {
+        return undefined;
+    }
+    const bytes = [];
+    for (const part of parts) {
+        if (!/^\d{1,3}$/u.test(part)) {
+            return undefined;
+        }
+        const byte = Number.parseInt(part, 10);
+        if (byte > 255) {
+            return undefined;
+        }
+        bytes.push(byte);
+    }
+    const [first, second, third, fourth] = bytes;
+    if (first === undefined ||
+        second === undefined ||
+        third === undefined ||
+        fourth === undefined) {
+        return undefined;
+    }
+    return [(first << 8) | second, (third << 8) | fourth];
+}
+function isIPv4MappedIPv6(words) {
+    return (words[0] === 0 &&
+        words[1] === 0 &&
+        words[2] === 0 &&
+        words[3] === 0 &&
+        words[4] === 0 &&
+        words[5] === 0xffff);
+}
+function ipv4StringFromWords(high, low) {
+    return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+function longestZeroRun(words) {
+    let bestStart = -1;
+    let bestLength = 0;
+    let currentStart = -1;
+    let currentLength = 0;
+    for (const [index, word] of words.entries()) {
+        if (word === 0) {
+            if (currentStart === -1) {
+                currentStart = index;
+                currentLength = 0;
+            }
+            currentLength += 1;
+            if (currentLength > bestLength) {
+                bestStart = currentStart;
+                bestLength = currentLength;
+            }
+            continue;
+        }
+        currentStart = -1;
+        currentLength = 0;
+    }
+    if (bestStart === -1) {
+        return undefined;
+    }
+    return { start: bestStart, length: bestLength };
 }

--- a/ts/dist/testkit.d.ts
+++ b/ts/dist/testkit.d.ts
@@ -50,6 +50,7 @@ export declare function buildAPIGatewayV2Request(method: string, path: string, o
     cookies?: string[];
     body?: Uint8Array | string;
     isBase64?: boolean;
+    sourceIp?: string;
 }): APIGatewayV2HTTPRequest;
 export declare function buildLambdaFunctionURLRequest(method: string, path: string, options?: {
     query?: Query;
@@ -57,6 +58,7 @@ export declare function buildLambdaFunctionURLRequest(method: string, path: stri
     cookies?: string[];
     body?: Uint8Array | string;
     isBase64?: boolean;
+    sourceIp?: string;
 }): LambdaFunctionURLRequest;
 export declare function buildALBTargetGroupRequest(method: string, path: string, options?: {
     query?: Query;

--- a/ts/dist/testkit.js
+++ b/ts/dist/testkit.js
@@ -152,6 +152,9 @@ export function buildAPIGatewayV2Request(method, path, options = {}) {
     if (queryStringParameters) {
         out.queryStringParameters = queryStringParameters;
     }
+    if (options.sourceIp !== undefined) {
+        out.requestContext.http.sourceIp = String(options.sourceIp ?? "").trim();
+    }
     return out;
 }
 export function buildLambdaFunctionURLRequest(method, path, options = {}) {
@@ -179,6 +182,9 @@ export function buildLambdaFunctionURLRequest(method, path, options = {}) {
     };
     if (queryStringParameters) {
         out.queryStringParameters = queryStringParameters;
+    }
+    if (options.sourceIp !== undefined) {
+        out.requestContext.http.sourceIp = String(options.sourceIp ?? "").trim();
     }
     return out;
 }

--- a/ts/src/internal/source-provenance.ts
+++ b/ts/src/internal/source-provenance.ts
@@ -31,9 +31,10 @@ export function sourceProvenanceFromProviderRequestContext(
   if (isIP(sourceIPValue) === 0) {
     return unknownSourceProvenance();
   }
+  const canonicalSourceIP = canonicalizeIP(sourceIPValue);
 
   return {
-    sourceIP: sourceIPValue,
+    sourceIP: canonicalSourceIP,
     provider: providerValue,
     source: SOURCE_PROVIDER_REQUEST_CONTEXT,
     valid: true,
@@ -64,9 +65,10 @@ export function normalizeSourceProvenance(input: unknown): SourceProvenance {
   if (isIP(sourceIP) === 0) {
     return unknownSourceProvenance();
   }
+  const canonicalSourceIP = canonicalizeIP(sourceIP);
 
   return {
-    sourceIP,
+    sourceIP: canonicalSourceIP,
     provider,
     source,
     valid: true,
@@ -79,4 +81,182 @@ function isKnownProvider(provider: string): boolean {
     provider === PROVIDER_LAMBDA_URL ||
     provider === PROVIDER_APIGW_V1
   );
+}
+
+function canonicalizeIP(value: string): string {
+  if (isIP(value) === 4) {
+    return value;
+  }
+
+  const words = parseIPv6Words(value);
+  if (!words) {
+    return value.toLowerCase();
+  }
+
+  if (isIPv4MappedIPv6(words)) {
+    const high = words[6];
+    const low = words[7];
+    if (high === undefined || low === undefined) {
+      return value.toLowerCase();
+    }
+    return `::ffff:${ipv4StringFromWords(high, low)}`;
+  }
+
+  const run = longestZeroRun(words);
+  if (!run || run.length < 2) {
+    return words.map((word) => word.toString(16)).join(":");
+  }
+
+  const left = words.slice(0, run.start).map((word) => word.toString(16));
+  const right = words
+    .slice(run.start + run.length)
+    .map((word) => word.toString(16));
+
+  if (left.length === 0 && right.length === 0) {
+    return "::";
+  }
+  if (left.length === 0) {
+    return `::${right.join(":")}`;
+  }
+  if (right.length === 0) {
+    return `${left.join(":")}::`;
+  }
+  return `${left.join(":")}::${right.join(":")}`;
+}
+
+function parseIPv6Words(input: string): number[] | undefined {
+  let value = input.toLowerCase();
+  if (value.includes(".")) {
+    const lastColon = value.lastIndexOf(":");
+    if (lastColon < 0) {
+      return undefined;
+    }
+    const ipv4Words = parseIPv4Suffix(value.slice(lastColon + 1));
+    if (!ipv4Words) {
+      return undefined;
+    }
+    value = `${value.slice(0, lastColon)}:${ipv4Words[0].toString(16)}:${ipv4Words[1].toString(16)}`;
+  }
+
+  const compressedParts = value.split("::");
+  if (compressedParts.length > 2) {
+    return undefined;
+  }
+
+  if (compressedParts.length === 2) {
+    const left = parseIPv6Groups(compressedParts[0] ?? "");
+    const right = parseIPv6Groups(compressedParts[1] ?? "");
+    if (!left || !right) {
+      return undefined;
+    }
+    const missing = 8 - left.length - right.length;
+    if (missing < 1) {
+      return undefined;
+    }
+    return [...left, ...Array.from({ length: missing }, () => 0), ...right];
+  }
+
+  const words = parseIPv6Groups(value);
+  if (!words || words.length !== 8) {
+    return undefined;
+  }
+  return words;
+}
+
+function parseIPv6Groups(value: string): number[] | undefined {
+  if (value === "") {
+    return [];
+  }
+
+  const groups = value.split(":");
+  if (groups.some((group) => group === "")) {
+    return undefined;
+  }
+
+  const words: number[] = [];
+  for (const group of groups) {
+    if (!/^[\da-f]{1,4}$/u.test(group)) {
+      return undefined;
+    }
+    words.push(Number.parseInt(group, 16));
+  }
+  return words;
+}
+
+function parseIPv4Suffix(value: string): [number, number] | undefined {
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const bytes: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/u.test(part)) {
+      return undefined;
+    }
+    const byte = Number.parseInt(part, 10);
+    if (byte > 255) {
+      return undefined;
+    }
+    bytes.push(byte);
+  }
+
+  const [first, second, third, fourth] = bytes;
+  if (
+    first === undefined ||
+    second === undefined ||
+    third === undefined ||
+    fourth === undefined
+  ) {
+    return undefined;
+  }
+
+  return [(first << 8) | second, (third << 8) | fourth];
+}
+
+function isIPv4MappedIPv6(words: number[]): boolean {
+  return (
+    words[0] === 0 &&
+    words[1] === 0 &&
+    words[2] === 0 &&
+    words[3] === 0 &&
+    words[4] === 0 &&
+    words[5] === 0xffff
+  );
+}
+
+function ipv4StringFromWords(high: number, low: number): string {
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
+function longestZeroRun(
+  words: number[],
+): { start: number; length: number } | undefined {
+  let bestStart = -1;
+  let bestLength = 0;
+  let currentStart = -1;
+  let currentLength = 0;
+
+  for (const [index, word] of words.entries()) {
+    if (word === 0) {
+      if (currentStart === -1) {
+        currentStart = index;
+        currentLength = 0;
+      }
+      currentLength += 1;
+      if (currentLength > bestLength) {
+        bestStart = currentStart;
+        bestLength = currentLength;
+      }
+      continue;
+    }
+
+    currentStart = -1;
+    currentLength = 0;
+  }
+
+  if (bestStart === -1) {
+    return undefined;
+  }
+  return { start: bestStart, length: bestLength };
 }

--- a/ts/src/testkit.ts
+++ b/ts/src/testkit.ts
@@ -261,6 +261,7 @@ export function buildAPIGatewayV2Request(
     cookies?: string[];
     body?: Uint8Array | string;
     isBase64?: boolean;
+    sourceIp?: string;
   } = {},
 ): APIGatewayV2HTTPRequest {
   const normalizedMethod = normalizeMethod(method);
@@ -290,6 +291,9 @@ export function buildAPIGatewayV2Request(
   if (queryStringParameters) {
     out.queryStringParameters = queryStringParameters;
   }
+  if (options.sourceIp !== undefined) {
+    out.requestContext.http.sourceIp = String(options.sourceIp ?? "").trim();
+  }
   return out;
 }
 
@@ -302,6 +306,7 @@ export function buildLambdaFunctionURLRequest(
     cookies?: string[];
     body?: Uint8Array | string;
     isBase64?: boolean;
+    sourceIp?: string;
   } = {},
 ): LambdaFunctionURLRequest {
   const normalizedMethod = normalizeMethod(method);
@@ -329,6 +334,9 @@ export function buildLambdaFunctionURLRequest(
   };
   if (queryStringParameters) {
     out.queryStringParameters = queryStringParameters;
+  }
+  if (options.sourceIp !== undefined) {
+    out.requestContext.http.sourceIp = String(options.sourceIp ?? "").trim();
   }
   return out;
 }

--- a/ts/test/http-testkit.test.mjs
+++ b/ts/test/http-testkit.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp, json } from "../dist/index.js";
+import {
+  buildAPIGatewayV2Request,
+  buildLambdaFunctionURLRequest,
+  createTestEnv,
+} from "../dist/testkit.js";
+
+test("HTTP testkit builders set provider sourceIp metadata", async () => {
+  const env = createTestEnv();
+  const app = createApp({ tier: "p0" });
+
+  app.get("/source", (ctx) => json(200, { source_ip: ctx.sourceIP() }));
+
+  const v2Event = buildAPIGatewayV2Request("GET", "/source", {
+    sourceIp: "2001:DB8::1",
+  });
+  assert.equal(v2Event.requestContext.http.sourceIp, "2001:DB8::1");
+
+  const v2Out = await env.invokeAPIGatewayV2(app, v2Event);
+  assert.deepEqual(JSON.parse(v2Out.body), { source_ip: "2001:db8::1" });
+
+  const urlEvent = buildLambdaFunctionURLRequest("GET", "/source", {
+    sourceIp: "198.51.100.88",
+  });
+  assert.equal(urlEvent.requestContext.http.sourceIp, "198.51.100.88");
+
+  const urlOut = await env.invokeLambdaFunctionURL(app, urlEvent);
+  assert.deepEqual(JSON.parse(urlOut.body), { source_ip: "198.51.100.88" });
+});


### PR DESCRIPTION
## Milestone
Consumer Migration Path — testkit and docs make SourceProvenance usable and document Lesser’s bridge-header replacement path.

## Linear
https://linear.app/theorycloud/project/apptheory-trusted-http-source-provenance-5d4b17d0f51a / Consumer Migration Path

## Tasks
- [x] THE-426 Canonicalize IPv6 source provenance across runtimes
- [x] THE-424 Support HTTP source IP events in testkit builders
- [x] THE-425 Document HTTP source provenance semantics

## Contract impact
- Adds a P0 contract fixture pinning valid uppercase IPv6 provider `sourceIp` to canonical `source_ip` output.
- Updates the Go public API snapshot for `testkit.HTTPEventOptions.SourceIP`.
- Documents provider-context-only source provenance semantics and migration from Lesser’s temporary bridge-header injection.

## Validation
Commands run on the final commit:
- `make rubric`: PASS
- `make test`: PASS (before final docs commit)
- `npm -C ts run build`: PASS
- `npm -C ts run check`: PASS
- `./scripts/verify-ts-tests.sh`: PASS
- `./scripts/verify-python-tests.sh`: PASS
- `go test ./testkit`: PASS
- `./scripts/verify-contract-tests.sh`: PASS (121 fixtures)
- `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh`: PASS
- `bash scripts/verify-docs-standard.sh && git diff --check`: PASS

## Cross-repo notes
Lesser migration guidance remains provider-context-only: no `Forwarded` / `X-Forwarded-For` trust and no ALB source provenance support in this pass.
