### PR TITLE
fix(release): gate generated artifact sync

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -33,13 +33,18 @@ jobs:
 
       - name: Release Please (PR only)
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          target-branch: premain
-          config-file: release-please-config.premain.json
-          manifest-file: .release-please-manifest.premain.json
-          skip-github-release: true
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          npx -y release-please@17.1.3 release-pr \
+            --token "${RELEASE_PLEASE_TOKEN}" \
+            --repo-url "${GITHUB_REPOSITORY}" \
+            --target-branch premain \
+            --config-file release-please-config.premain.json \
+            --manifest-file .release-please-manifest.premain.json \
+            --draft-pull-request
 
       - name: Detect open release PR
         id: release_pr

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -90,7 +90,8 @@ jobs:
             --target-branch main \
             --config-file release-please-config.json \
             --manifest-file .release-please-manifest.json \
-            --release-as "${RELEASE_AS}"
+            --release-as "${RELEASE_AS}" \
+            --draft-pull-request
 
       - name: Release Please (PR only)
         if: steps.version.outputs.release_as == ''
@@ -105,7 +106,8 @@ jobs:
             --repo-url "${GITHUB_REPOSITORY}" \
             --target-branch main \
             --config-file release-please-config.json \
-            --manifest-file .release-please-manifest.json
+            --manifest-file .release-please-manifest.json \
+            --draft-pull-request
 
       - name: Detect open release PR
         id: release_pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,3 +224,31 @@ jobs:
           fi
 
           gh release edit "${TAG_NAME}" --draft=false --notes-file dist/RELEASE_NOTES.md
+
+      - name: Cleanup failed draft release (no remnants)
+        if: failure() && steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: |
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "release-cleanup: SKIP (missing tag_name output)"
+            exit 0
+          fi
+
+          # Only delete draft releases. If it's already published, do nothing.
+          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [[ "${is_draft}" != "true" ]]; then
+            echo "release-cleanup: SKIP (release not draft or not found)"
+            exit 0
+          fi
+
+          echo "release-cleanup: deleting draft release ${TAG_NAME}"
+          gh release delete "${TAG_NAME}" --yes
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "release-cleanup: deleting tag ${TAG_NAME}"
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG_NAME}"
+          else
+            echo "release-cleanup: SKIP tag delete (tag not found)"
+          fi

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -14,33 +14,46 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-open_pr_count="$(
+pr_line="$(
   gh pr list \
     --state open \
     --head "${release_branch}" \
-    --json number \
-    --jq 'length'
+    --json number,isDraft \
+    --jq '.[] | "\(.number)	\(.isDraft)"' \
+    | head -n 1
 )"
 
-if [[ "${open_pr_count}" == "0" ]]; then
+if [[ -z "${pr_line}" ]]; then
   echo "sync-release-pr-generated: SKIP (no open PR for ${release_branch})"
   exit 0
 fi
+
+pr_number="${pr_line%%$'\t'*}"
+pr_is_draft="${pr_line#*$'\t'}"
 
 git fetch origin "${release_branch}"
 git switch --detach FETCH_HEAD
 
 scripts/update-cdk-generated.sh >/dev/null
 
-if git diff --quiet -- cdk/.jsii cdk/lib cdk-go/apptheorycdk; then
-  echo "sync-release-pr-generated: PASS (${release_branch} already in sync)"
-  exit 0
+changed=false
+if ! git diff --quiet -- cdk/.jsii cdk/lib cdk-go/apptheorycdk; then
+  changed=true
+
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git add cdk/.jsii cdk/lib cdk-go/apptheorycdk
+  git commit -m "chore(release): sync generated cdk artifacts"
 fi
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git add cdk/.jsii cdk/lib cdk-go/apptheorycdk
-git commit -m "chore(release): sync generated cdk artifacts"
-git push origin HEAD:"${release_branch}"
+go test ./cdk-go/apptheorycdk
+
+if [[ "${changed}" == "true" ]]; then
+  git push origin HEAD:"${release_branch}"
+fi
+
+if [[ "${pr_is_draft}" == "true" ]]; then
+  gh pr ready "${pr_number}"
+fi
 
 echo "sync-release-pr-generated: PASS (${release_branch} updated)"


### PR DESCRIPTION
## Summary
- Create stable and prerelease Release Please PRs as drafts so they cannot merge before generated CDK artifacts are synced.
- Make `scripts/sync-release-pr-generated.sh` verify `cdk-go/apptheorycdk` generated metadata before pushing/marking the release PR ready.
- Add stable release cleanup parity with prerelease cleanup for failed draft releases.

## Validation
- `bash -n scripts/sync-release-pr-generated.sh`
- workflow text tab check for changed workflows
- `make test`
- `git diff --check`

## Notes
- `actionlint` and `shellcheck` are not installed in this local environment.
- This prevents a recurrence of PR #481 merging before `chore(release): sync generated cdk artifacts` lands.
