### PR TITLE
fix(release): allow draft release PR CLI

### DIFF
--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -137,22 +137,40 @@ if [[ -f ".github/workflows/prerelease-pr.yml" ]]; then
     echo "branch-release: prerelease-pr workflow must target premain"
     failures=$((failures + 1))
   }
-  grep -Eq 'googleapis/release-please-action@[0-9a-fA-F]{40}.*\bv4\b' ".github/workflows/prerelease-pr.yml" || {
-    echo "branch-release: prerelease-pr workflow must pin release-please v4 by commit SHA"
+  if grep -Eq 'googleapis/release-please-action@[0-9a-fA-F]{40}.*\bv4\b' ".github/workflows/prerelease-pr.yml"; then
+    grep -Eq 'config-file:\s*release-please-config\.premain\.json' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must reference release-please-config.premain.json"
+      failures=$((failures + 1))
+    }
+    grep -Eq 'manifest-file:\s*\.release-please-manifest\.premain\.json' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must reference .release-please-manifest.premain.json"
+      failures=$((failures + 1))
+    }
+    grep -Eq 'skip-github-release:\s*true' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must set skip-github-release: true"
+      failures=$((failures + 1))
+    }
+    grep -Eq 'draft-pull-request:\s*true' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must create draft release PRs"
+      failures=$((failures + 1))
+    }
+  elif grep -Eq 'release-please@[0-9]+\.[0-9]+\.[0-9]+' ".github/workflows/prerelease-pr.yml"; then
+    grep -Eq -- '--config-file\s+release-please-config\.premain\.json' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must pass --config-file release-please-config.premain.json"
+      failures=$((failures + 1))
+    }
+    grep -Eq -- '--manifest-file\s+\.release-please-manifest\.premain\.json' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must pass --manifest-file .release-please-manifest.premain.json"
+      failures=$((failures + 1))
+    }
+    grep -Eq -- '--draft-pull-request' ".github/workflows/prerelease-pr.yml" || {
+      echo "branch-release: prerelease-pr workflow must create draft release PRs"
+      failures=$((failures + 1))
+    }
+  else
+    echo "branch-release: prerelease-pr workflow must pin release-please (action SHA or CLI version)"
     failures=$((failures + 1))
-  }
-  grep -Eq 'config-file:\s*release-please-config\.premain\.json' ".github/workflows/prerelease-pr.yml" || {
-    echo "branch-release: prerelease-pr workflow must reference release-please-config.premain.json"
-    failures=$((failures + 1))
-  }
-  grep -Eq 'manifest-file:\s*\.release-please-manifest\.premain\.json' ".github/workflows/prerelease-pr.yml" || {
-    echo "branch-release: prerelease-pr workflow must reference .release-please-manifest.premain.json"
-    failures=$((failures + 1))
-  }
-  grep -Eq 'skip-github-release:\s*true' ".github/workflows/prerelease-pr.yml" || {
-    echo "branch-release: prerelease-pr workflow must set skip-github-release: true"
-    failures=$((failures + 1))
-  }
+  fi
   grep -Fq "scripts/sync-release-pr-generated.sh" ".github/workflows/prerelease-pr.yml" || {
     echo "branch-release: prerelease-pr workflow must sync generated cdk artifacts onto the release PR branch"
     failures=$((failures + 1))
@@ -186,6 +204,10 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
     }
     grep -Eq -- '--manifest-file\s+\.release-please-manifest\.json' ".github/workflows/release-pr.yml" || {
       echo "branch-release: release-pr workflow must pass --manifest-file .release-please-manifest.json"
+      failures=$((failures + 1))
+    }
+    grep -Eq -- '--draft-pull-request' ".github/workflows/release-pr.yml" || {
+      echo "branch-release: release-pr workflow must create draft release PRs"
       failures=$((failures + 1))
     }
   else


### PR DESCRIPTION
## Summary
- Follow-up to #482: update the branch release supply-chain verifier so it accepts the intentionally pinned Release Please CLI path for draft release PRs.
- Require both stable and prerelease release PR workflows to create draft PRs before generated CDK sync marks them ready.

## Validation
- `bash -n scripts/verify-branch-release-supply-chain.sh`
- `scripts/verify-branch-release-supply-chain.sh`
- `make test`
- `git diff --check`

## Notes
#482 merged before this verifier update was included, which is why staging CI failed after merge.
