### PR TITLE
feat(mcp): harden capability transport

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1945,6 +1945,12 @@ var ErrStreamEventTooLarge = errors.New("stream event too large")
 
 var ErrStreamNotFound = errors.New("stream not found")
 
+type CapabilityConfig struct {
+	Tools     bool
+	Resources bool
+	Prompts   bool
+}
+
 type ContentBlock struct {
 	Type string `json:"type"`
 
@@ -2098,6 +2104,7 @@ type Server struct {
 	idGen            apptheory.IDGenerator
 	logger           *slog.Logger
 	originValidator  OriginValidator
+	capabilities     CapabilityConfig
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -2176,6 +2183,8 @@ type ToolResult struct {
 
 func AllowOrigins(...string) OriginValidator
 
+func DefaultCapabilityConfig() CapabilityConfig
+
 func MarshalResponse(*Response) ([]byte, error)
 
 func NewDynamoSessionStore(tablecore.DB) SessionStore
@@ -2203,6 +2212,8 @@ func ParseBatchRequest([]byte) ([]*Request, error)
 func ParseRequest([]byte) (*Request, error)
 
 func ParseResponse([]byte) (*Response, error)
+
+func WithCapabilityConfig(CapabilityConfig) ServerOption
 
 func WithClock(apptheory.Clock) MemorySessionStoreOption
 
@@ -2283,6 +2294,8 @@ func (*Server) Resources() *ResourceRegistry
 func (*ToolRegistry) Call(context.Context, string, json.RawMessage) (*ToolResult, error)
 
 func (*ToolRegistry) CallStreaming(context.Context, string, json.RawMessage, func(SSEEvent)) (*ToolResult, error)
+
+func (*ToolRegistry) Len() int
 
 func (*ToolRegistry) List() []ToolDef
 

--- a/cdk/docs/mcp-server-remote-mcp.md
+++ b/cdk/docs/mcp-server-remote-mcp.md
@@ -101,6 +101,18 @@ For SSE connections, expect disconnects (idle timeouts, client refresh, Lambda m
 - **resumable streams** (`Last-Event-ID`) + replay from an event log
 - emitting periodic progress updates during long-running work
 
+Strict Streamable HTTP compatibility:
+
+- `POST /mcp` clients must send `Content-Type: application/json` and
+  `Accept: application/json, text/event-stream`
+- `GET /mcp` clients must send `Accept: text/event-stream`
+- clients should omit `Mcp-Protocol-Version` after `initialize` or send the exact negotiated session version
+- streaming responses start with an empty-data priming event; clients should store that `id` for reconnect before
+  progress or result messages arrive
+- `Last-Event-ID` replay is stream-bound; AppTheory fails closed if the cursor belongs to another stream
+- canary older clients before rollout, especially clients that previously sent JSON-only `Accept` headers or assumed the
+  first SSE frame was JSON-RPC
+
 When you provision the optional stream table, wire the Go runtime with `mcp.WithStreamStore(mcp.NewDynamoStreamStore(db))`
 to use the canonical `sessionId` / `eventId` / `expiresAt` schema this construct creates. Use the standard TableTheory
 DB for production durable replay; its `TransactWrite` support is what gives `DynamoStreamStore` the strongest

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -175,6 +175,18 @@ For SSE connections, expect disconnects. Prefer:
 - periodic progress updates during long-running work
 - `GET /mcp` without `Last-Event-ID` as a keepalive listener path
 
+Strict Streamable HTTP compatibility:
+
+- `POST /mcp` clients must send `Content-Type: application/json` and
+  `Accept: application/json, text/event-stream`
+- `GET /mcp` clients must send `Accept: text/event-stream`
+- clients should omit `Mcp-Protocol-Version` after `initialize` or send the exact negotiated session version
+- streaming responses start with an empty-data priming event; clients should store that `id` for reconnect before
+  progress or result messages arrive
+- `Last-Event-ID` replay is stream-bound; AppTheory fails closed if the cursor belongs to another stream
+- canary older clients before rollout, especially clients that previously sent JSON-only `Accept` headers or assumed the
+  first SSE frame was JSON-RPC
+
 If your clients send an `Origin` header, remember that the default runtime allowlist is Claude-oriented:
 
 - `https://claude.ai`

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -191,8 +191,9 @@ ordinary tools return buffered JSON even though the client advertises SSE suppor
 
 For streaming tools, AppTheory responds as SSE:
 
-- every SSE frame is `event: message`
-- the frame `data:` is always a single JSON-RPC message
+- the first frame is a replay priming event with an `id` and an empty `data:` field
+- after the priming event, each application frame is `event: message`
+- application frame `data:` values are always a single JSON-RPC message
 - progress is emitted as JSON-RPC `notifications/progress`
 - the progress notification is correlated with `params._meta.progressToken` from the original `tools/call`
 - `progressToken` may be a string or an integer
@@ -223,8 +224,15 @@ Important deployment note:
 
 For streaming tool calls, AppTheory assigns SSE event ids and persists them in the active `StreamStore`.
 
+- each SSE stream starts with a persisted empty-data priming event so a client can reconnect before any JSON-RPC
+  progress or result message has been produced
 - `GET /mcp` with `last-event-id: <id>` resumes or replays that stream
+- `last-event-id` must belong to the stream being resumed; AppTheory fails closed instead of replaying events from a
+  different stream
 - clients must reuse the same `mcp-session-id`
+- clients should store the latest SSE `id`, reconnect with `GET /mcp` and `last-event-id` after any disconnect, and
+  treat disconnect as transport loss rather than tool cancellation
+- cancellation remains explicit: send `notifications/cancelled` instead of relying on a dropped connection
 - `GET /mcp` without `last-event-id` emits one keepalive comment and closes by default so idle callers do not hold
   Lambda concurrency indefinitely
 - if you want that path to stay open for a bounded window before EOF, opt in with

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -36,6 +36,9 @@ Header names are case-insensitive on the wire. The examples in this doc use lowe
 
 Important transport behavior:
 
+- `POST /mcp` requires `content-type: application/json`
+- `POST /mcp` requires `accept` support for both `application/json` and `text/event-stream`
+- `GET /mcp` requires `accept` support for `text/event-stream`
 - `initialize` is the only request that creates a session and returns `mcp-session-id`
 - subsequent `POST /mcp`, `GET /mcp`, and `DELETE /mcp` calls require `mcp-session-id`
 - missing session header returns `400`
@@ -182,7 +185,11 @@ _ = srv.Registry().RegisterTool(mcp.ToolDef{
 
 ### Streaming tool progress (SSE)
 
-If the client includes `Accept: text/event-stream` on `tools/call`, AppTheory may respond as SSE:
+Strict Streamable HTTP clients send `Accept: application/json, text/event-stream` on every `POST /mcp`.
+AppTheory still returns SSE only for a `tools/call` targeting a tool registered with `RegisterStreamingTool`;
+ordinary tools return buffered JSON even though the client advertises SSE support.
+
+For streaming tools, AppTheory responds as SSE:
 
 - every SSE frame is `event: message`
 - the frame `data:` is always a single JSON-RPC message

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -64,6 +64,25 @@ If a request includes an `Origin` header, AppTheory validates it fail-closed. Th
 
 Use `mcp.WithOriginValidator(...)` to replace that policy for other browser-based callers.
 
+### Strict transport compatibility rollout
+
+Roll strict Streamable HTTP behavior out with a client canary before making it the only production path:
+
+1. Canary clients must send `content-type: application/json` on every `POST /mcp`.
+2. Canary clients must send `accept: application/json, text/event-stream` on every `POST /mcp`.
+3. Canary clients must send `accept: text/event-stream` on every `GET /mcp`.
+4. After initialization, clients should either omit `mcp-protocol-version` or send the exact negotiated version.
+5. Streaming clients must tolerate the initial empty-data priming SSE event and store its `id` for reconnect.
+6. Reconnect with `GET /mcp` plus the latest `last-event-id`; do not assume dropped TCP connections cancel work.
+
+Compatibility risks to check during canary:
+
+- older clients that send `Accept: application/json` only on `POST /mcp` now receive HTTP `400`
+- clients that omit `Content-Type` or send non-JSON content types now receive HTTP `400`
+- clients that pin a protocol header different from the negotiated session version now receive HTTP `400`
+- SSE parsers that assume the first frame is JSON-RPC must skip or record the empty priming frame
+- replay clients that reuse a `Last-Event-ID` from another stream now fail closed instead of receiving unrelated events
+
 Mounting the handler is still just normal AppTheory routing:
 
 ```go

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -97,7 +97,8 @@ Other transport notes:
 
 - posted client responses are accepted for Streamable HTTP compliance and return `202 Accepted` with no body
 - notifications also return `202 Accepted` with no body
-- JSON-RPC batch requests are only supported for legacy `2025-03-26` callers
+- JSON-RPC batch requests are only supported for legacy `2025-03-26` callers; after a session is established, batch
+  dispatch uses the session's negotiated protocol version when the request omits `mcp-protocol-version`
 
 ### Runtime hardening guarantees
 
@@ -112,14 +113,20 @@ The MCP runtime fails closed around tool execution and durable replay:
 
 ### Capabilities advertisement (`initialize`)
 
-The `initialize` result always advertises `tools`.
+The `initialize` result advertises only surfaces that are both enabled in `mcp.CapabilityConfig` and actually registered
+on the server:
 
-It advertises `resources` and `prompts` only when something is registered:
+- if `srv.Registry().Len() > 0` and tools are enabled -> `"tools": {}`
+- if `srv.Resources().Len() > 0` and resources are enabled -> `"resources": {}`
+- if `srv.Prompts().Len() > 0` and prompts are enabled -> `"prompts": {}`
 
-- if `srv.Resources().Len() > 0` -> `"resources": {}`
-- if `srv.Prompts().Len() > 0` -> `"prompts": {}`
+The default capability policy enables the implemented surfaces, but registration is still required before they are
+advertised. Use `mcp.WithCapabilityConfig(...)` to withhold an implemented surface for a product rollout.
 
-This keeps tools-only clients stable while still exposing the broader MCP surface when you opt in.
+Unsupported optional MCP capabilities are fail-closed: AppTheory does not advertise `listChanged`, resource
+subscriptions, `logging`, `completions`, or `tasks` until the corresponding framework hook exists and is configured.
+Capability construction is also protocol-aware; if a future supported protocol version removes or changes a capability,
+AppTheory omits that capability for sessions negotiated to that version.
 
 ---
 

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -49,9 +49,15 @@ func buildApp() *apptheory.App {
 Important behaviors for Claude compatibility:
 - `initialize` returns `Mcp-Session-Id` and must negotiate `protocolVersion` (`2025-11-25`).
 - `notifications/initialized` must return `202 Accepted` with no body.
-- `tools/call` may stream with SSE when the client includes `Accept: text/event-stream`.
-- SSE frames stay on `event: message`; progress is emitted as JSON-RPC `notifications/progress`, not custom SSE event names.
+- `POST /mcp` requires `Content-Type: application/json` and `Accept: application/json, text/event-stream`.
+- `GET /mcp` requires `Accept: text/event-stream`.
+- `tools/call` may stream with SSE when the target tool is registered for streaming and the client advertises SSE.
+- SSE streams start with an empty-data priming event carrying a replay-safe `id`.
+- Application SSE frames stay on `event: message`; progress is emitted as JSON-RPC `notifications/progress`, not custom
+  SSE event names.
 - Disconnections are not cancellation; resumability uses `GET /mcp` + `Last-Event-ID`.
+- `Last-Event-ID` replay is stream-bound. A cursor from another stream fails closed instead of replaying unrelated
+  events.
 - `GET /mcp` without `Last-Event-ID` emits a short-lived keepalive SSE response by default.
 - If you want that path to stay open for a bounded window on Lambda, use
   `mcp.WithInitialSessionListenerBudget(...)`.
@@ -59,6 +65,17 @@ Important behaviors for Claude compatibility:
   `https://claude.com`); use `mcp.WithOriginValidator(...)` for other browser origins.
 - Tool handler panics are recovered as sanitized JSON-RPC internal errors. Do not rely on panic text reaching the
   client; AppTheory logs it server-side and keeps the MCP server reusable.
+
+Strict transport rollout checklist:
+
+- Canary one connector/client population first and confirm it sends the strict `Accept` and `Content-Type` headers.
+- Confirm the client carries forward the negotiated protocol version, or omits `Mcp-Protocol-Version` after
+  initialization so AppTheory uses the session value.
+- Confirm the client records the first SSE `id`, even when its `data:` field is empty, before long-running work emits
+  progress.
+- Confirm reconnect uses `GET /mcp` with the latest `Last-Event-ID` for the same session and stream.
+- Treat HTTP `400` responses during canary as compatibility failures to fix in the client, not as server fallbacks to
+  loosen.
 
 ## 2) Add OAuth protection (Remote MCP auth `2025-06-18`)
 

--- a/examples/mcp/resumable-sse/main_test.go
+++ b/examples/mcp/resumable-sse/main_test.go
@@ -35,9 +35,20 @@ func TestResumableSSEExample(t *testing.T) {
 		t.Fatalf("RawStream: %v", err)
 	}
 
+	priming, err := stream.Next()
+	if err != nil {
+		t.Fatalf("read priming event: %v", err)
+	}
+	if strings.TrimSpace(priming.ID) == "" {
+		t.Fatalf("expected priming SSE id to be set")
+	}
+	if got := strings.TrimSpace(string(priming.Data)); got != "" {
+		t.Fatalf("expected priming SSE data to be empty, got %q", got)
+	}
+
 	first, err := stream.Next()
 	if err != nil {
-		t.Fatalf("read first event: %v", err)
+		t.Fatalf("read first progress event: %v", err)
 	}
 	if strings.TrimSpace(first.ID) == "" {
 		t.Fatalf("expected SSE id to be set")

--- a/examples/mcp/resumable-sse/main_test.go
+++ b/examples/mcp/resumable-sse/main_test.go
@@ -81,8 +81,11 @@ func TestResumableSSEBuildApp(t *testing.T) {
 	}
 
 	event := testkit.APIGatewayV2Request("POST", "/mcp", testkit.HTTPEventOptions{
-		Headers: map[string]string{"content-type": "application/json"},
-		Body:    []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`),
+		Headers: map[string]string{
+			"accept":       "application/json, text/event-stream",
+			"content-type": "application/json",
+		},
+		Body: []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`),
 	})
 	resp := env.InvokeAPIGatewayV2(context.Background(), app, event)
 	if resp.StatusCode != 200 {

--- a/examples/mcp/tools-only/main_test.go
+++ b/examples/mcp/tools-only/main_test.go
@@ -40,8 +40,11 @@ func TestToolsOnlyBuildApp(t *testing.T) {
 	}
 
 	event := testkit.APIGatewayV2Request("POST", "/mcp", testkit.HTTPEventOptions{
-		Headers: map[string]string{"content-type": "application/json"},
-		Body:    []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`),
+		Headers: map[string]string{
+			"accept":       "application/json, text/event-stream",
+			"content-type": "application/json",
+		},
+		Body: []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`),
 	})
 	resp := env.InvokeAPIGatewayV2(context.Background(), app, event)
 	if resp.StatusCode != 200 {

--- a/examples/mcp/tools-resources-prompts/main_test.go
+++ b/examples/mcp/tools-resources-prompts/main_test.go
@@ -64,8 +64,11 @@ func TestToolsResourcesPromptsBuildApp(t *testing.T) {
 	}
 
 	event := testkit.APIGatewayV2Request("POST", "/mcp", testkit.HTTPEventOptions{
-		Headers: map[string]string{"content-type": "application/json"},
-		Body:    []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`),
+		Headers: map[string]string{
+			"accept":       "application/json, text/event-stream",
+			"content-type": "application/json",
+		},
+		Body: []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`),
 	})
 	resp := env.InvokeAPIGatewayV2(context.Background(), app, event)
 	if resp.StatusCode != 200 {

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T17:31:35Z",
+  "timestamp": "2026-05-14T19:25:22Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T19:37:14Z",
+  "timestamp": "2026-05-14T20:00:29Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T20:00:29Z",
+  "timestamp": "2026-05-14T20:25:01Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T20:33:49Z",
+  "timestamp": "2026-05-14T21:18:35Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T20:25:01Z",
+  "timestamp": "2026-05-14T20:33:49Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T19:25:22Z",
+  "timestamp": "2026-05-14T19:37:14Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -14,6 +14,14 @@ type CapabilityConfig struct {
 	Prompts   bool
 }
 
+type capabilitySurface string
+
+const (
+	capabilitySurfaceTools     capabilitySurface = "tools"
+	capabilitySurfaceResources capabilitySurface = "resources"
+	capabilitySurfacePrompts   capabilitySurface = "prompts"
+)
+
 // DefaultCapabilityConfig returns the default MCP capability policy.
 //
 // A surface is still advertised only when it is actually present on the server:
@@ -35,18 +43,22 @@ func WithCapabilityConfig(config CapabilityConfig) ServerOption {
 	}
 }
 
-func (s *Server) initializeCapabilities(_ string) map[string]any {
+func (s *Server) initializeCapabilities(protocolVersion string) map[string]any {
 	capabilities := map[string]any{}
 
-	if s.capabilities.Tools && s.registry.Len() > 0 {
+	if s.capabilities.Tools && protocolSupportsCapability(protocolVersion, capabilitySurfaceTools) && s.registry.Len() > 0 {
 		capabilities["tools"] = map[string]any{}
 	}
-	if s.capabilities.Resources && s.resourceRegistry.Len() > 0 {
+	if s.capabilities.Resources && protocolSupportsCapability(protocolVersion, capabilitySurfaceResources) && s.resourceRegistry.Len() > 0 {
 		capabilities["resources"] = map[string]any{}
 	}
-	if s.capabilities.Prompts && s.promptRegistry.Len() > 0 {
+	if s.capabilities.Prompts && protocolSupportsCapability(protocolVersion, capabilitySurfacePrompts) && s.promptRegistry.Len() > 0 {
 		capabilities["prompts"] = map[string]any{}
 	}
 
 	return capabilities
+}
+
+func protocolSupportsCapability(pv string, _ capabilitySurface) bool {
+	return isSupportedProtocolVersion(pv)
 }

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -1,0 +1,52 @@
+package mcp
+
+// CapabilityConfig controls which implemented MCP server surfaces may be
+// advertised during initialize.
+//
+// The config is intentionally limited to surfaces that AppTheory currently
+// implements. Optional MCP sub-capabilities such as listChanged, resource
+// subscriptions, logging, completions, and tasks are omitted until their
+// concrete hooks exist. That keeps capability negotiation fail-closed instead
+// of allowing callers to overclaim unsupported behavior.
+type CapabilityConfig struct {
+	Tools     bool
+	Resources bool
+	Prompts   bool
+}
+
+// DefaultCapabilityConfig returns the default MCP capability policy.
+//
+// A surface is still advertised only when it is actually present on the server:
+// tools require at least one registered tool, resources require at least one
+// registered resource, and prompts require at least one registered prompt.
+func DefaultCapabilityConfig() CapabilityConfig {
+	return CapabilityConfig{
+		Tools:     true,
+		Resources: true,
+		Prompts:   true,
+	}
+}
+
+// WithCapabilityConfig sets the server capability policy used for initialize
+// responses.
+func WithCapabilityConfig(config CapabilityConfig) ServerOption {
+	return func(s *Server) {
+		s.capabilities = config
+	}
+}
+
+func (s *Server) initializeCapabilities(_ string) map[string]any {
+	capabilities := map[string]any{}
+
+	if s.capabilities.Tools && s.registry.Len() > 0 {
+		capabilities["tools"] = map[string]any{}
+	}
+	if s.capabilities.Resources && s.resourceRegistry.Len() > 0 {
+		capabilities["resources"] = map[string]any{}
+	}
+	if s.capabilities.Prompts && s.promptRegistry.Len() > 0 {
+		capabilities["prompts"] = map[string]any{}
+	}
+
+	return capabilities
+}

--- a/runtime/mcp/capability_test.go
+++ b/runtime/mcp/capability_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func initializeCapabilityMap(t *testing.T, s *Server) map[string]any {
+	t.Helper()
+	resp := s.handleInitialize(&Request{JSONRPC: "2.0", ID: 1, Method: methodInitialize}, protocolVersion)
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected initialize result object, got %T", resp.Result)
+	}
+	caps, ok := result["capabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected capabilities object, got %T", result["capabilities"])
+	}
+	return caps
+}
+
+func TestInitializeCapabilities_FailClosedByRegisteredSurface(t *testing.T) {
+	s := NewServer("test", "dev")
+
+	caps := initializeCapabilityMap(t, s)
+	for _, name := range []string{"tools", "resources", "prompts", "logging", "completions", "tasks"} {
+		if _, ok := caps[name]; ok {
+			t.Fatalf("expected empty server not to advertise %q capability: %+v", name, caps)
+		}
+	}
+
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "echo",
+		Description: "Echoes input",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(context.Context, json.RawMessage) (*ToolResult, error) {
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+	if err := s.Resources().RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, func(context.Context) ([]ResourceContent, error) {
+		return []ResourceContent{{URI: "file://x", Text: "x"}}, nil
+	}); err != nil {
+		t.Fatalf("register resource: %v", err)
+	}
+	if err := s.Prompts().RegisterPrompt(PromptDef{Name: "p"}, func(context.Context, json.RawMessage) (*PromptResult, error) {
+		return &PromptResult{Messages: []PromptMessage{{Role: "user", Content: ContentBlock{Type: "text", Text: "p"}}}}, nil
+	}); err != nil {
+		t.Fatalf("register prompt: %v", err)
+	}
+
+	caps = initializeCapabilityMap(t, s)
+	for _, name := range []string{"tools", "resources", "prompts"} {
+		if _, ok := caps[name]; !ok {
+			t.Fatalf("expected %q capability for registered surface: %+v", name, caps)
+		}
+	}
+	for _, name := range []string{"logging", "completions", "tasks"} {
+		if _, ok := caps[name]; ok {
+			t.Fatalf("did not expect unsupported %q capability: %+v", name, caps)
+		}
+	}
+	assertNoUnsupportedSubCapabilities(t, "tools", caps["tools"])
+	assertNoUnsupportedSubCapabilities(t, "resources", caps["resources"])
+	assertNoUnsupportedSubCapabilities(t, "prompts", caps["prompts"])
+}
+
+func TestInitializeCapabilities_ExplicitConfigCanDisableSurface(t *testing.T) {
+	s := NewServer("test", "dev", WithCapabilityConfig(CapabilityConfig{
+		Tools:     true,
+		Resources: false,
+		Prompts:   false,
+	}))
+
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "echo",
+		Description: "Echoes input",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(context.Context, json.RawMessage) (*ToolResult, error) {
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+	if err := s.Resources().RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, func(context.Context) ([]ResourceContent, error) {
+		return []ResourceContent{{URI: "file://x", Text: "x"}}, nil
+	}); err != nil {
+		t.Fatalf("register resource: %v", err)
+	}
+	if err := s.Prompts().RegisterPrompt(PromptDef{Name: "p"}, func(context.Context, json.RawMessage) (*PromptResult, error) {
+		return &PromptResult{Messages: []PromptMessage{{Role: "user", Content: ContentBlock{Type: "text", Text: "p"}}}}, nil
+	}); err != nil {
+		t.Fatalf("register prompt: %v", err)
+	}
+
+	caps := initializeCapabilityMap(t, s)
+	if _, ok := caps["tools"]; !ok {
+		t.Fatalf("expected tools capability when enabled and registered: %+v", caps)
+	}
+	for _, name := range []string{"resources", "prompts"} {
+		if _, ok := caps[name]; ok {
+			t.Fatalf("expected explicitly disabled %q capability to be omitted: %+v", name, caps)
+		}
+	}
+}
+
+func assertNoUnsupportedSubCapabilities(t *testing.T, name string, raw any) {
+	t.Helper()
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("expected %s capability object, got %T", name, raw)
+	}
+	for _, sub := range []string{"listChanged", "subscribe"} {
+		if _, ok := obj[sub]; ok {
+			t.Fatalf("did not expect %s.%s overclaim: %+v", name, sub, obj)
+		}
+	}
+}

--- a/runtime/mcp/resources_prompts_test.go
+++ b/runtime/mcp/resources_prompts_test.go
@@ -83,6 +83,43 @@ func TestResourcesListAndRead_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestResourceAndPromptRegistryValidation(t *testing.T) {
+	resources := NewResourceRegistry()
+	if err := resources.RegisterResource(ResourceDef{}, func(context.Context) ([]ResourceContent, error) { return nil, nil }); err == nil {
+		t.Fatalf("expected missing resource uri to fail")
+	}
+	if err := resources.RegisterResource(ResourceDef{URI: "file://x"}, func(context.Context) ([]ResourceContent, error) { return nil, nil }); err == nil {
+		t.Fatalf("expected missing resource name to fail")
+	}
+	if err := resources.RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, nil); err == nil {
+		t.Fatalf("expected nil resource handler to fail")
+	}
+	if err := resources.RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, func(context.Context) ([]ResourceContent, error) {
+		return []ResourceContent{{URI: "file://x", Text: "x"}}, nil
+	}); err != nil {
+		t.Fatalf("register resource: %v", err)
+	}
+	if err := resources.RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, func(context.Context) ([]ResourceContent, error) { return nil, nil }); err == nil {
+		t.Fatalf("expected duplicate resource to fail")
+	}
+
+	prompts := NewPromptRegistry()
+	if err := prompts.RegisterPrompt(PromptDef{}, func(context.Context, json.RawMessage) (*PromptResult, error) { return nil, nil }); err == nil {
+		t.Fatalf("expected missing prompt name to fail")
+	}
+	if err := prompts.RegisterPrompt(PromptDef{Name: "p"}, nil); err == nil {
+		t.Fatalf("expected nil prompt handler to fail")
+	}
+	if err := prompts.RegisterPrompt(PromptDef{Name: "p"}, func(context.Context, json.RawMessage) (*PromptResult, error) {
+		return &PromptResult{Messages: []PromptMessage{{Role: "user", Content: ContentBlock{Type: "text", Text: "p"}}}}, nil
+	}); err != nil {
+		t.Fatalf("register prompt: %v", err)
+	}
+	if err := prompts.RegisterPrompt(PromptDef{Name: "p"}, func(context.Context, json.RawMessage) (*PromptResult, error) { return nil, nil }); err == nil {
+		t.Fatalf("expected duplicate prompt to fail")
+	}
+}
+
 func TestPromptsListAndGet_RoundTrip(t *testing.T) {
 	s := NewServer("test", "1.0.0")
 

--- a/runtime/mcp/resources_prompts_test.go
+++ b/runtime/mcp/resources_prompts_test.go
@@ -20,7 +20,7 @@ func TestResourcesListAndRead_RoundTrip(t *testing.T) {
 
 	sessionID := initializeSession(t, s)
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"application/json"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	if err := s.Resources().RegisterResource(ResourceDef{
 		URI:         "file://hello.txt",
@@ -88,7 +88,7 @@ func TestPromptsListAndGet_RoundTrip(t *testing.T) {
 
 	sessionID := initializeSession(t, s)
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"application/json"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	if err := s.Prompts().RegisterPrompt(PromptDef{
 		Name:        "greet",
@@ -156,7 +156,7 @@ func TestResourcesRead_NotFoundIsInvalidParams(t *testing.T) {
 
 	sessionID := initializeSession(t, s)
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"application/json"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	readParams := mustMarshal(t, map[string]any{"uri": "file://missing.txt"})
 	readReq := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesRead, Params: readParams})
@@ -178,7 +178,7 @@ func TestPromptsGet_NotFoundIsInvalidParams(t *testing.T) {
 
 	sessionID := initializeSession(t, s)
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"application/json"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	getParams := mustMarshal(t, map[string]any{"name": "missing", "arguments": json.RawMessage(`{}`)})
 	getReq := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodPromptsGet, Params: getParams})

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -1224,6 +1224,16 @@ func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, re
 		return internalServerError(), nil
 	}
 
+	// Persist an empty-data priming event before any tool output so a client
+	// that disconnects immediately can resume this stream with Last-Event-ID.
+	if _, primeErr := s.streamStore.Append(ctx, sessionID, streamID, nil); primeErr != nil {
+		s.logger.ErrorContext(ctx, "stream prime error", "sessionId", sessionID, "streamId", streamID, "error", primeErr)
+		if closeErr := s.streamStore.Close(context.WithoutCancel(ctx), sessionID, streamID); closeErr != nil {
+			s.logger.WarnContext(ctx, "stream prime cleanup error", "sessionId", sessionID, "streamId", streamID, "error", closeErr)
+		}
+		return internalServerError(), nil
+	}
+
 	// Run the tool out-of-band so disconnects do not cancel execution.
 	toolCtx := context.WithoutCancel(ctx)
 	go s.runStreamingTool(toolCtx, sessionID, streamID, req)
@@ -1400,8 +1410,8 @@ func (s *Server) streamToSSE(ctx context.Context, sessionID string, events <-cha
 					return
 				case out <- apptheory.SSEEvent{
 					ID:    ev.ID,
-					Event: "message",
-					Data:  ev.Data,
+					Event: streamEventName(ev),
+					Data:  streamEventData(ev),
 				}:
 				}
 			}
@@ -1417,6 +1427,20 @@ func (s *Server) streamToSSE(ctx context.Context, sessionID string, events <-cha
 	}
 	resp.Headers[headerMcpSessionID] = []string{sessionID}
 	return resp, nil
+}
+
+func streamEventName(ev StreamEvent) string {
+	if len(ev.Data) == 0 {
+		return ""
+	}
+	return "message"
+}
+
+func streamEventData(ev StreamEvent) any {
+	if len(ev.Data) == 0 {
+		return ""
+	}
+	return ev.Data
 }
 
 func badRequest(msg string) *apptheory.Response {

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -472,7 +472,7 @@ func (s *Server) handleDELETE(c *apptheory.Context) (*apptheory.Response, error)
 		return badRequest("missing Mcp-Session-Id"), nil
 	}
 
-	_, err := s.sessionStore.Get(ctx, sessionID)
+	sess, err := s.sessionStore.Get(ctx, sessionID)
 	switch {
 	case err == nil:
 		// ok
@@ -481,6 +481,9 @@ func (s *Server) handleDELETE(c *apptheory.Context) (*apptheory.Response, error)
 	default:
 		s.logger.ErrorContext(ctx, "session store error", "error", err)
 		return internalServerError(), nil
+	}
+	if pvResp := s.requireProtocolVersion(c.Request.Headers, sess); pvResp != nil {
+		return pvResp, nil
 	}
 
 	if err := s.sessionStore.Delete(ctx, sessionID); err != nil {

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -273,11 +273,11 @@ func (s *Server) handlePOSTRequest(ctx context.Context, body []byte, headers map
 
 	// Notifications return 202 Accepted with no body.
 	if req.ID == nil {
-		s.handleNotification(ctx, sess, req)
+		s.handleNotification(ctx, sess, req, sessionProtocolVersion(sess))
 		return &apptheory.Response{Status: 202}, nil
 	}
 
-	return s.handleRequestHTTP(ctx, sessionID, req, headers)
+	return s.handleRequestHTTP(ctx, sessionID, sess, req, headers)
 }
 
 func (s *Server) handlePOSTResponse(ctx context.Context, body []byte, headers map[string][]string) (*apptheory.Response, error) {
@@ -492,6 +492,15 @@ func (s *Server) handleDELETE(c *apptheory.Context) (*apptheory.Response, error)
 
 // dispatch routes a parsed JSON-RPC request to the appropriate MCP method handler.
 func (s *Server) dispatch(ctx context.Context, req *Request) *Response {
+	return s.dispatchForProtocol(ctx, req, protocolVersion)
+}
+
+func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocolVersion string) *Response {
+	if !methodAllowedForProtocol(protocolVersion, req.Method) {
+		s.logger.ErrorContext(ctx, "method not found", "method", req.Method, "protocolVersion", protocolVersion)
+		return NewErrorResponse(req.ID, CodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method))
+	}
+
 	switch req.Method {
 	case methodInitialize:
 		selectedPV, errResp := s.negotiateInitializeProtocolVersion(req)
@@ -516,6 +525,28 @@ func (s *Server) dispatch(ctx context.Context, req *Request) *Response {
 	default:
 		s.logger.ErrorContext(ctx, "method not found", "method", req.Method)
 		return NewErrorResponse(req.ID, CodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method))
+	}
+}
+
+func methodAllowedForProtocol(pv string, method string) bool {
+	if !isSupportedProtocolVersion(pv) {
+		return false
+	}
+
+	switch method {
+	case methodInitialize,
+		methodNotificationsInitialized,
+		methodNotificationsCancelled,
+		methodPing,
+		methodToolsList,
+		methodToolsCall,
+		methodResourcesList,
+		methodResourcesRead,
+		methodPromptsList,
+		methodPromptsGet:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -651,7 +682,15 @@ func (s *Server) handleBatch(ctx context.Context, body []byte, headers map[strin
 		return sessErrResp, nil
 	}
 
-	createdSessionID, responses := s.runBatchRequests(ctx, requests, sessionID, sess)
+	batchPV, pvResp := batchProtocolVersion(headers, sess)
+	if pvResp != nil {
+		return pvResp, nil
+	}
+	if batchPV != protocolVersionLegacy {
+		return badRequest("batch requests are only supported for MCP-Protocol-Version 2025-03-26"), nil
+	}
+
+	createdSessionID, responses := s.runBatchRequests(ctx, requests, sessionID, sess, batchPV)
 
 	if len(responses) == 0 {
 		return &apptheory.Response{Status: 202}, nil
@@ -706,12 +745,18 @@ func (s *Server) loadBatchSession(ctx context.Context, sessionID string) (*Sessi
 	}
 }
 
-func (s *Server) runBatchRequests(ctx context.Context, requests []*Request, sessionID string, sess *Session) (createdSessionID string, responses []*Response) {
+func (s *Server) runBatchRequests(
+	ctx context.Context,
+	requests []*Request,
+	sessionID string,
+	sess *Session,
+	batchProtocolVersion string,
+) (createdSessionID string, responses []*Response) {
 	responses = make([]*Response, 0, len(requests))
 
 	for _, req := range requests {
 		if req.Method == methodInitialize {
-			initResp, newSess, initErr := s.handleInitializeBatch(ctx, req)
+			initResp, newSess, initErr := s.handleInitializeBatch(ctx, req, batchProtocolVersion)
 			if initErr != nil {
 				// Return initialize error as a normal JSON-RPC error response.
 				if req.ID != nil {
@@ -747,7 +792,7 @@ func (s *Server) runBatchRequests(ctx context.Context, requests []*Request, sess
 			}
 		}
 
-		responses = append(responses, s.dispatch(ctx, req))
+		responses = append(responses, s.dispatchForProtocol(ctx, req, sessionProtocolVersion(sess)))
 	}
 
 	return createdSessionID, responses
@@ -853,21 +898,39 @@ func isSupportedProtocolVersion(v string) bool {
 }
 
 func (s *Server) requireProtocolVersion(headers map[string][]string, sess *Session) *apptheory.Response {
+	_, resp := requestProtocolVersion(headers, sess)
+	return resp
+}
+
+func requestProtocolVersion(headers map[string][]string, sess *Session) (string, *apptheory.Response) {
 	v := firstHeader(headers, headerMcpProtocolVersion)
 	if v == "" {
 		// Header is optional. When absent, behavior defaults to the session's
 		// negotiated protocol (if any) and otherwise the legacy default.
-		return nil
+		return sessionProtocolVersion(sess), nil
 	}
 	if !isSupportedProtocolVersion(v) {
-		return badRequest("unsupported MCP-Protocol-Version")
+		return "", badRequest("unsupported MCP-Protocol-Version")
 	}
 	if sess != nil && sess.Data != nil {
 		if expected := sess.Data["protocolVersion"]; expected != "" && expected != v {
-			return badRequest("MCP-Protocol-Version mismatch")
+			return "", badRequest("MCP-Protocol-Version mismatch")
 		}
 	}
-	return nil
+	return v, nil
+}
+
+func batchProtocolVersion(headers map[string][]string, sess *Session) (string, *apptheory.Response) {
+	return requestProtocolVersion(headers, sess)
+}
+
+func sessionProtocolVersion(sess *Session) string {
+	if sess != nil && sess.Data != nil {
+		if pv := strings.TrimSpace(sess.Data["protocolVersion"]); isSupportedProtocolVersion(pv) {
+			return pv
+		}
+	}
+	return protocolVersionLegacy
 }
 
 func (s *Server) requireSession(ctx context.Context, headers map[string][]string) (string, *Session, *apptheory.Response) {
@@ -932,7 +995,14 @@ func (s *Server) handleInitializeHTTP(ctx context.Context, req *Request) (*appth
 }
 
 func (s *Server) negotiateInitializeProtocolVersion(req *Request) (string, *Response) {
-	selected := protocolVersion
+	return s.negotiateInitializeProtocolVersionDefault(req, protocolVersion)
+}
+
+func (s *Server) negotiateInitializeProtocolVersionDefault(req *Request, defaultProtocolVersion string) (string, *Response) {
+	selected := defaultProtocolVersion
+	if !isSupportedProtocolVersion(selected) {
+		selected = protocolVersion
+	}
 	if len(req.Params) == 0 {
 		return selected, nil
 	}
@@ -977,10 +1047,13 @@ func (s *Server) createSession(ctx context.Context, selectedPV string) (*Session
 	return sess, nil
 }
 
-func (s *Server) handleInitializeBatch(ctx context.Context, req *Request) (*Response, *Session, *Response) {
-	selectedPV, errResp := s.negotiateInitializeProtocolVersion(req)
+func (s *Server) handleInitializeBatch(ctx context.Context, req *Request, batchProtocolVersion string) (*Response, *Session, *Response) {
+	selectedPV, errResp := s.negotiateInitializeProtocolVersionDefault(req, batchProtocolVersion)
 	if errResp != nil {
 		return nil, nil, errResp
+	}
+	if selectedPV != batchProtocolVersion {
+		return nil, nil, NewErrorResponse(req.ID, CodeInvalidParams, "batch initialize requires protocolVersion "+batchProtocolVersion)
 	}
 	sess, err := s.createSession(ctx, selectedPV)
 	if err != nil {
@@ -989,7 +1062,11 @@ func (s *Server) handleInitializeBatch(ctx context.Context, req *Request) (*Resp
 	return s.handleInitialize(req, selectedPV), sess, nil
 }
 
-func (s *Server) handleNotification(ctx context.Context, sess *Session, req *Request) {
+func (s *Server) handleNotification(ctx context.Context, sess *Session, req *Request, protocolVersion string) {
+	if !methodAllowedForProtocol(protocolVersion, req.Method) {
+		return
+	}
+
 	switch req.Method {
 	case methodNotificationsInitialized:
 		if sess == nil {
@@ -1009,12 +1086,19 @@ func (s *Server) handleNotification(ctx context.Context, sess *Session, req *Req
 	}
 }
 
-func (s *Server) handleRequestHTTP(ctx context.Context, sessionID string, req *Request, headers map[string][]string) (*apptheory.Response, error) {
+func (s *Server) handleRequestHTTP(
+	ctx context.Context,
+	sessionID string,
+	sess *Session,
+	req *Request,
+	headers map[string][]string,
+) (*apptheory.Response, error) {
+	requestPV := sessionProtocolVersion(sess)
 	if req.Method == methodToolsCall && acceptsEventStream(headers) {
 		return s.handleToolsCallStream(ctx, sessionID, req)
 	}
 
-	resp := s.dispatch(ctx, req)
+	resp := s.dispatchForProtocol(ctx, req, requestPV)
 	return s.marshalSingleResponse(resp, sessionID, false)
 }
 

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -221,6 +221,9 @@ func (s *Server) handlePOST(c *apptheory.Context) (*apptheory.Response, error) {
 	if resp := s.validateOrigin(c.Request.Headers); resp != nil {
 		return resp, nil
 	}
+	if resp := validatePOSTHeaders(c.Request.Headers); resp != nil {
+		return resp, nil
+	}
 
 	body := c.Request.Body
 
@@ -303,6 +306,9 @@ func (s *Server) handleGET(c *apptheory.Context) (*apptheory.Response, error) {
 	ctx := c.Context()
 
 	if resp := s.validateOrigin(c.Request.Headers); resp != nil {
+		return resp, nil
+	}
+	if resp := validateGETHeaders(c.Request.Headers); resp != nil {
 		return resp, nil
 	}
 
@@ -846,23 +852,112 @@ func jsonRPCErrorResponse(id any, code int, message string) *apptheory.Response 
 	}
 }
 
-// firstHeader returns the first value for a header key (case-insensitive lookup
-// on already-canonicalized headers).
+// firstHeader returns the first value for a header key using case-insensitive
+// lookup.
 func firstHeader(headers map[string][]string, key string) string {
-	values := headers[strings.ToLower(key)]
+	values := headerValues(headers, key)
 	if len(values) == 0 {
 		return ""
 	}
 	return values[0]
 }
 
+func headerValues(headers map[string][]string, key string) []string {
+	if len(headers) == 0 {
+		return nil
+	}
+	lowerKey := strings.ToLower(key)
+	if values, ok := headers[lowerKey]; ok {
+		return values
+	}
+	for k, values := range headers {
+		if strings.EqualFold(k, key) {
+			return values
+		}
+	}
+	return nil
+}
+
+func validatePOSTHeaders(headers map[string][]string) *apptheory.Response {
+	if !contentTypeIsJSON(headers) {
+		return badRequest("POST /mcp requires Content-Type: application/json")
+	}
+	if !acceptsJSON(headers) || !acceptsEventStream(headers) {
+		return badRequest("POST /mcp requires Accept: application/json and text/event-stream")
+	}
+	return nil
+}
+
+func validateGETHeaders(headers map[string][]string) *apptheory.Response {
+	if !acceptsEventStream(headers) {
+		return badRequest("GET /mcp requires Accept: text/event-stream")
+	}
+	return nil
+}
+
+func contentTypeIsJSON(headers map[string][]string) bool {
+	typ, subtype, ok := parseMediaRange(firstHeader(headers, "content-type"))
+	return ok && typ == "application" && subtype == "json"
+}
+
+func acceptsJSON(headers map[string][]string) bool {
+	return headerIncludesMediaType(headers, "accept", "application/json")
+}
+
 func acceptsEventStream(headers map[string][]string) bool {
-	for _, v := range headers["accept"] {
-		if strings.Contains(strings.ToLower(v), "text/event-stream") {
-			return true
+	return headerIncludesMediaType(headers, "accept", "text/event-stream")
+}
+
+func headerIncludesMediaType(headers map[string][]string, key string, want string) bool {
+	wantType, wantSubtype, ok := parseMediaRange(want)
+	if !ok {
+		return false
+	}
+	for _, value := range headerValues(headers, key) {
+		for _, part := range strings.Split(value, ",") {
+			typ, subtype, ok := parseMediaRange(part)
+			if !ok {
+				continue
+			}
+			typeMatches := typ == "*" || typ == wantType
+			subtypeMatches := subtype == "*" || subtype == wantSubtype
+			if typeMatches && subtypeMatches {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func parseMediaRange(raw string) (string, string, bool) {
+	parts := strings.Split(raw, ";")
+	mediaType := strings.ToLower(strings.TrimSpace(parts[0]))
+	if mediaType == "" {
+		return "", "", false
+	}
+
+	slash := strings.IndexByte(mediaType, '/')
+	if slash <= 0 || slash == len(mediaType)-1 {
+		return "", "", false
+	}
+	typ := strings.TrimSpace(mediaType[:slash])
+	subtype := strings.TrimSpace(mediaType[slash+1:])
+	if typ == "" || subtype == "" {
+		return "", "", false
+	}
+
+	for _, param := range parts[1:] {
+		name, value, ok := strings.Cut(param, "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(name), "q") {
+			continue
+		}
+		q, err := strconv.ParseFloat(strings.Trim(strings.TrimSpace(value), `"`), 64)
+		if err == nil && q <= 0 {
+			return "", "", false
+		}
+	}
+
+	return typ, subtype, true
 }
 
 func parseJSONObject(data []byte) (map[string]json.RawMessage, error) {
@@ -1094,12 +1189,27 @@ func (s *Server) handleRequestHTTP(
 	headers map[string][]string,
 ) (*apptheory.Response, error) {
 	requestPV := sessionProtocolVersion(sess)
-	if req.Method == methodToolsCall && acceptsEventStream(headers) {
+	if req.Method == methodToolsCall && acceptsEventStream(headers) && s.shouldStreamToolsCall(req) {
 		return s.handleToolsCallStream(ctx, sessionID, req)
 	}
 
 	resp := s.dispatchForProtocol(ctx, req, requestPV)
 	return s.marshalSingleResponse(resp, sessionID, false)
+}
+
+func (s *Server) shouldStreamToolsCall(req *Request) bool {
+	if s == nil || s.registry == nil || req == nil {
+		return false
+	}
+
+	var params toolsCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return false
+	}
+	if params.Name == "" {
+		return false
+	}
+	return s.registry.supportsStreaming(params.Name)
 }
 
 func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, req *Request) (*apptheory.Response, error) {

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -65,6 +65,7 @@ type Server struct {
 	idGen            apptheory.IDGenerator
 	logger           *slog.Logger
 	originValidator  OriginValidator
+	capabilities     CapabilityConfig
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -156,6 +157,7 @@ func NewServer(name, version string, opts ...ServerOption) *Server {
 		idGen:            apptheory.RandomIDGenerator{},
 		logger:           slog.Default(),
 		originValidator:  AllowOrigins("https://claude.ai", "https://claude.com"),
+		capabilities:     DefaultCapabilityConfig(),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -519,19 +521,9 @@ func (s *Server) dispatch(ctx context.Context, req *Request) *Response {
 
 // handleInitialize responds to the MCP initialize request with server capabilities.
 func (s *Server) handleInitialize(req *Request, selectedProtocolVersion string) *Response {
-	capabilities := map[string]any{
-		"tools": map[string]any{},
-	}
-	if s.resourceRegistry.Len() > 0 {
-		capabilities["resources"] = map[string]any{}
-	}
-	if s.promptRegistry.Len() > 0 {
-		capabilities["prompts"] = map[string]any{}
-	}
-
 	result := map[string]any{
 		"protocolVersion": selectedProtocolVersion,
-		"capabilities":    capabilities,
+		"capabilities":    s.initializeCapabilities(selectedProtocolVersion),
 		"serverInfo": map[string]any{
 			"name":    s.name,
 			"version": s.version,

--- a/runtime/mcp/server_additional_test.go
+++ b/runtime/mcp/server_additional_test.go
@@ -251,6 +251,61 @@ func TestDELETE_DeletesSession_AndStreamDeleteErrorsAreIgnored(t *testing.T) {
 	}
 }
 
+func TestDELETE_ValidatesProtocolVersion_BeforeDelete(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string][]string
+		wantErr string
+	}{
+		{
+			name: "unsupported protocol",
+			headers: map[string][]string{
+				"mcp-protocol-version": {"1900-01-01"},
+			},
+			wantErr: "unsupported MCP-Protocol-Version",
+		},
+		{
+			name: "mismatched negotiated protocol",
+			headers: map[string][]string{
+				"mcp-protocol-version": {protocolVersionPrior},
+			},
+			wantErr: "MCP-Protocol-Version mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("test", "dev")
+			sessionID := initializeSession(t, s)
+			headers := map[string][]string{
+				"mcp-session-id": {sessionID},
+			}
+			for k, v := range tt.headers {
+				headers[k] = v
+			}
+
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "DELETE", nil, headers)
+			if err != nil {
+				t.Fatalf("invoke invalid delete: %v", err)
+			}
+			if resp.Status != 400 {
+				t.Fatalf("invalid delete status: got %d want %d (body=%s)", resp.Status, 400, string(resp.Body))
+			}
+			if !strings.Contains(string(resp.Body), tt.wantErr) {
+				t.Fatalf("invalid delete body: got %s want error containing %q", string(resp.Body), tt.wantErr)
+			}
+
+			resp, err = invokeHandlerWithMethod(context.Background(), s, "DELETE", nil, sessionHeaders(sessionID))
+			if err != nil {
+				t.Fatalf("invoke valid delete: %v", err)
+			}
+			if resp.Status != 202 {
+				t.Fatalf("valid delete status after rejected delete: got %d want %d (body=%s)", resp.Status, 202, string(resp.Body))
+			}
+		})
+	}
+}
+
 func TestValidateOrigin_FailClosedWhenOriginPresent(t *testing.T) {
 	s := NewServer("test", "dev", WithOriginValidator(nil))
 	resp := s.validateOrigin(map[string][]string{

--- a/runtime/mcp/server_additional_test.go
+++ b/runtime/mcp/server_additional_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -277,6 +278,138 @@ func TestRequireProtocolVersion_RejectsUnsupportedAndMismatch(t *testing.T) {
 	}
 }
 
+func TestPOST_RequiresJSONContentTypeAndStrictAccept(t *testing.T) {
+	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodInitialize})
+
+	tests := []struct {
+		name       string
+		headers    map[string][]string
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name: "missing content type",
+			headers: map[string][]string{
+				"content-type": {},
+				"accept":       {"application/json, text/event-stream"},
+			},
+			wantStatus: 400,
+			wantBody:   "Content-Type: application/json",
+		},
+		{
+			name: "non json content type",
+			headers: map[string][]string{
+				"content-type": {"text/plain"},
+				"accept":       {"application/json, text/event-stream"},
+			},
+			wantStatus: 400,
+			wantBody:   "Content-Type: application/json",
+		},
+		{
+			name: "missing accept",
+			headers: map[string][]string{
+				"content-type": {"application/json"},
+				"accept":       {},
+			},
+			wantStatus: 400,
+			wantBody:   "Accept: application/json and text/event-stream",
+		},
+		{
+			name: "json only accept",
+			headers: map[string][]string{
+				"content-type": {"application/json"},
+				"accept":       {"application/json"},
+			},
+			wantStatus: 400,
+			wantBody:   "Accept: application/json and text/event-stream",
+		},
+		{
+			name: "sse only accept",
+			headers: map[string][]string{
+				"content-type": {"application/json"},
+				"accept":       {"text/event-stream"},
+			},
+			wantStatus: 400,
+			wantBody:   "Accept: application/json and text/event-stream",
+		},
+		{
+			name: "strict headers with params",
+			headers: map[string][]string{
+				"Content-Type": {"Application/JSON; charset=utf-8"},
+				"Accept":       {"application/json; q=1, text/event-stream; q=1"},
+			},
+			wantStatus: 200,
+		},
+		{
+			name: "q zero disables required media",
+			headers: map[string][]string{
+				"content-type": {"application/json"},
+				"accept":       {"application/json, text/event-stream; q=0"},
+			},
+			wantStatus: 400,
+			wantBody:   "Accept: application/json and text/event-stream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("test", "dev")
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, tt.headers)
+			if err != nil {
+				t.Fatalf("invoke: %v", err)
+			}
+			if resp.Status != tt.wantStatus {
+				t.Fatalf("status: got %d want %d (body=%s)", resp.Status, tt.wantStatus, string(resp.Body))
+			}
+			if tt.wantBody != "" && !strings.Contains(string(resp.Body), tt.wantBody) {
+				t.Fatalf("body: got %s want substring %q", string(resp.Body), tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestGET_RequiresEventStreamAccept(t *testing.T) {
+	s := NewServer("test", "dev")
+	sessionID := initializeSession(t, s)
+
+	tests := []struct {
+		name       string
+		accept     []string
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "missing accept", accept: nil, wantStatus: 400, wantBody: "Accept: text/event-stream"},
+		{name: "json only accept", accept: []string{"application/json"}, wantStatus: 400, wantBody: "Accept: text/event-stream"},
+		{name: "q zero disables sse", accept: []string{"text/event-stream; q=0"}, wantStatus: 400, wantBody: "Accept: text/event-stream"},
+		{name: "event stream accept", accept: []string{"text/event-stream"}, wantStatus: 200},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := sessionHeaders(sessionID)
+			if tt.accept != nil {
+				headers["accept"] = tt.accept
+			}
+
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, headers)
+			if err != nil {
+				t.Fatalf("invoke: %v", err)
+			}
+			if resp.Status != tt.wantStatus {
+				t.Fatalf("status: got %d want %d (body=%s)", resp.Status, tt.wantStatus, string(resp.Body))
+			}
+			if tt.wantBody != "" && !strings.Contains(string(resp.Body), tt.wantBody) {
+				t.Fatalf("body: got %s want substring %q", string(resp.Body), tt.wantBody)
+			}
+			if resp.BodyReader != nil {
+				if _, readErr := io.ReadAll(resp.BodyReader); readErr != nil {
+					t.Fatalf("read SSE body: %v", readErr)
+				}
+			}
+		})
+	}
+}
+
 func TestBatchProtocol_RespectsNegotiatedSessionVersion(t *testing.T) {
 	t.Run("latest session cannot use legacy batch without explicit legacy negotiation", func(t *testing.T) {
 		s := newTestServer()
@@ -391,7 +524,7 @@ func TestInitialize_SessionStorePutError_ReturnsJSONRPCErrorResponse(t *testing.
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodInitialize})
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, map[string][]string{
 		"content-type": {"application/json"},
-		"accept":       {"application/json"},
+		"accept":       {"application/json, text/event-stream"},
 	})
 	if err != nil {
 		t.Fatalf("invoke: %v", err)
@@ -475,7 +608,7 @@ func TestGET_NoLastEventID_ReturnsEmptySSE(t *testing.T) {
 	s := NewServer("test", "dev")
 	sessionID := initializeSession(t, s)
 
-	resp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, sessionHeaders(sessionID))
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, sseSessionHeaders(sessionID))
 	if err != nil {
 		t.Fatalf("invoke: %v", err)
 	}

--- a/runtime/mcp/server_additional_test.go
+++ b/runtime/mcp/server_additional_test.go
@@ -277,6 +277,66 @@ func TestRequireProtocolVersion_RejectsUnsupportedAndMismatch(t *testing.T) {
 	}
 }
 
+func TestBatchProtocol_RespectsNegotiatedSessionVersion(t *testing.T) {
+	t.Run("latest session cannot use legacy batch without explicit legacy negotiation", func(t *testing.T) {
+		s := newTestServer()
+		sessionID := initializeSession(t, s)
+
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", []byte(`[{"jsonrpc":"2.0","id":1,"method":"`+methodToolsList+`"}]`), map[string][]string{
+			"content-type":   {"application/json"},
+			"mcp-session-id": {sessionID},
+		})
+		if err != nil {
+			t.Fatalf("invoke batch: %v", err)
+		}
+		if resp.Status != 400 {
+			t.Fatalf("status: got %d want 400 (body=%s)", resp.Status, string(resp.Body))
+		}
+	})
+
+	t.Run("legacy session can use batch without protocol header", func(t *testing.T) {
+		s := newTestServer()
+		sessionID := initializeSessionWithProtocol(t, s, protocolVersionLegacy)
+
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", []byte(`[{"jsonrpc":"2.0","id":1,"method":"`+methodToolsList+`"}]`), map[string][]string{
+			"content-type":   {"application/json"},
+			"mcp-session-id": {sessionID},
+		})
+		if err != nil {
+			t.Fatalf("invoke legacy batch: %v", err)
+		}
+		if resp.Status != 200 {
+			t.Fatalf("status: got %d want 200 (body=%s)", resp.Status, string(resp.Body))
+		}
+	})
+
+	t.Run("batch initialize defaults to legacy protocol", func(t *testing.T) {
+		s := newTestServer()
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", []byte(`[{"jsonrpc":"2.0","id":1,"method":"initialize"}]`), nil)
+		if err != nil {
+			t.Fatalf("invoke batch initialize: %v", err)
+		}
+		if resp.Status != 200 {
+			t.Fatalf("status: got %d want 200 (body=%s)", resp.Status, string(resp.Body))
+		}
+
+		var responses []Response
+		if err := json.Unmarshal(resp.Body, &responses); err != nil {
+			t.Fatalf("unmarshal batch response: %v", err)
+		}
+		if len(responses) != 1 {
+			t.Fatalf("expected one batch response, got %d", len(responses))
+		}
+		result, ok := responses[0].Result.(map[string]any)
+		if !ok {
+			t.Fatalf("expected initialize result object, got %T", responses[0].Result)
+		}
+		if got := result["protocolVersion"]; got != protocolVersionLegacy {
+			t.Fatalf("protocolVersion: got %v want %s", got, protocolVersionLegacy)
+		}
+	})
+}
+
 func TestHandleNotification_Initialized_PersistsSessionFlag(t *testing.T) {
 	s := NewServer("test", "dev")
 	sessionID := initializeSession(t, s)
@@ -303,7 +363,7 @@ func TestHandleNotification_Initialized_PersistsSessionFlag(t *testing.T) {
 
 func TestHandleNotification_NilSession_DoesNotPanic(t *testing.T) {
 	s := NewServer("test", "dev")
-	s.handleNotification(context.Background(), nil, &Request{Method: methodNotificationsInitialized})
+	s.handleNotification(context.Background(), nil, &Request{Method: methodNotificationsInitialized}, protocolVersion)
 }
 
 func TestSessionTTL_EnvOverride_AndFallbacks(t *testing.T) {

--- a/runtime/mcp/server_additional_test.go
+++ b/runtime/mcp/server_additional_test.go
@@ -261,6 +261,22 @@ func TestValidateOrigin_FailClosedWhenOriginPresent(t *testing.T) {
 	}
 }
 
+func TestAllowOrigins_TrimsAndFailsClosed(t *testing.T) {
+	validator := AllowOrigins(" https://ok.example ", "", "https://other.example")
+	if !validator(" https://ok.example ") {
+		t.Fatalf("expected trimmed allowed origin to pass")
+	}
+	if !validator("https://other.example") {
+		t.Fatalf("expected second allowed origin to pass")
+	}
+	if validator("") {
+		t.Fatalf("expected empty origin to fail")
+	}
+	if validator("https://evil.example") {
+		t.Fatalf("expected unknown origin to fail")
+	}
+}
+
 func TestRequireProtocolVersion_RejectsUnsupportedAndMismatch(t *testing.T) {
 	s := NewServer("test", "dev")
 

--- a/runtime/mcp/server_coverage_more_test.go
+++ b/runtime/mcp/server_coverage_more_test.go
@@ -380,7 +380,7 @@ func TestRunBatchRequests_EdgeCases(t *testing.T) {
 	t.Run("missing session yields error response", func(t *testing.T) {
 		_, responses := s.runBatchRequests(context.Background(), []*Request{
 			{JSONRPC: "2.0", ID: 1, Method: methodToolsList},
-		}, "", nil)
+		}, "", nil, protocolVersionLegacy)
 		if len(responses) != 1 || responses[0].Error == nil || responses[0].Error.Code != CodeInvalidRequest {
 			t.Fatalf("expected invalid request error for missing session, got: %+v", responses)
 		}
@@ -389,7 +389,7 @@ func TestRunBatchRequests_EdgeCases(t *testing.T) {
 	t.Run("initialize invalid params yields JSON-RPC error", func(t *testing.T) {
 		_, responses := s.runBatchRequests(context.Background(), []*Request{
 			{JSONRPC: "2.0", ID: 1, Method: methodInitialize, Params: json.RawMessage("{")},
-		}, "", nil)
+		}, "", nil, protocolVersionLegacy)
 		if len(responses) != 1 || responses[0].Error == nil || responses[0].Error.Code != CodeInvalidParams {
 			t.Fatalf("expected invalid params error for initialize, got: %+v", responses)
 		}
@@ -399,7 +399,7 @@ func TestRunBatchRequests_EdgeCases(t *testing.T) {
 		created, responses := s.runBatchRequests(context.Background(), []*Request{
 			{JSONRPC: "2.0", ID: nil, Method: methodInitialize},
 			{JSONRPC: "2.0", ID: 2, Method: methodToolsList},
-		}, "", nil)
+		}, "", nil, protocolVersionLegacy)
 		if created == "" {
 			t.Fatalf("expected initialize notification to create a session id")
 		}
@@ -416,7 +416,7 @@ func TestRunBatchRequests_EdgeCases(t *testing.T) {
 		}))
 		_, responses := s2.runBatchRequests(context.Background(), []*Request{
 			{JSONRPC: "2.0", ID: 1, Method: methodToolsList},
-		}, "sess-1", nil)
+		}, "sess-1", nil, protocolVersionLegacy)
 		if len(responses) != 1 || responses[0].Error == nil || responses[0].Error.Code != CodeInternalError {
 			t.Fatalf("expected internal error response, got: %+v", responses)
 		}

--- a/runtime/mcp/server_coverage_more_test.go
+++ b/runtime/mcp/server_coverage_more_test.go
@@ -202,7 +202,7 @@ func TestHandleGET_EventNotFound_AndStoreErrors(t *testing.T) {
 	s := NewServer("test", "dev")
 	sessionID := initializeSession(t, s)
 
-	headers := sessionHeaders(sessionID)
+	headers := sseSessionHeaders(sessionID)
 	headers["last-event-id"] = []string{"9999"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, headers)
@@ -275,9 +275,25 @@ func TestHandleToolsCallStream_StreamingNotSupported_AndStreamStoreErrors(t *tes
 
 	params := mustMarshal(t, map[string]any{"name": "any", "arguments": json.RawMessage(`{}`)})
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: params})
+	registerAnyStreamingTool := func(t *testing.T, srv *Server) {
+		t.Helper()
+		if err := srv.Registry().RegisterStreamingTool(
+			ToolDef{
+				Name:        "any",
+				Description: "Streaming test tool",
+				InputSchema: json.RawMessage(`{"type":"object"}`),
+			},
+			func(context.Context, json.RawMessage, func(SSEEvent)) (*ToolResult, error) {
+				return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+			},
+		); err != nil {
+			t.Fatalf("register streaming tool: %v", err)
+		}
+	}
+	registerAnyStreamingTool(t, s)
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 	if err != nil {
@@ -296,6 +312,7 @@ func TestHandleToolsCallStream_StreamingNotSupported_AndStreamStoreErrors(t *tes
 
 	// Create error should map to internalServerError (500).
 	s2 := NewServer("test", "dev")
+	registerAnyStreamingTool(t, s2)
 	s2.sessionStore = NewMemorySessionStore()
 	requirePut(t, s2.sessionStore, &Session{ID: sessionID, ExpiresAt: time.Now().Add(time.Minute), Data: map[string]string{"protocolVersion": protocolVersion}})
 	s2.streamStore = configurableStreamStore{
@@ -311,6 +328,7 @@ func TestHandleToolsCallStream_StreamingNotSupported_AndStreamStoreErrors(t *tes
 
 	// Subscribe error should map to internalServerError (500).
 	s3 := NewServer("test", "dev")
+	registerAnyStreamingTool(t, s3)
 	s3.sessionStore = NewMemorySessionStore()
 	requirePut(t, s3.sessionStore, &Session{ID: sessionID, ExpiresAt: time.Now().Add(time.Minute), Data: map[string]string{"protocolVersion": protocolVersion}})
 	s3.streamStore = configurableStreamStore{

--- a/runtime/mcp/server_coverage_more_test.go
+++ b/runtime/mcp/server_coverage_more_test.go
@@ -326,6 +326,33 @@ func TestHandleToolsCallStream_StreamingNotSupported_AndStreamStoreErrors(t *tes
 		t.Fatalf("status: got %d want %d", resp.Status, 500)
 	}
 
+	// Prime append error should close the newly created stream and return 500.
+	sPrime := NewServer("test", "dev")
+	registerAnyStreamingTool(t, sPrime)
+	sPrime.sessionStore = NewMemorySessionStore()
+	requirePut(t, sPrime.sessionStore, &Session{ID: sessionID, ExpiresAt: time.Now().Add(time.Minute), Data: map[string]string{"protocolVersion": protocolVersion}})
+	closeCalled := false
+	sPrime.streamStore = configurableStreamStore{
+		create: func(context.Context, string) (string, error) { return "stream-1", nil },
+		append: func(context.Context, string, string, json.RawMessage) (string, error) {
+			return "", errors.New("prime failed")
+		},
+		close: func(context.Context, string, string) error {
+			closeCalled = true
+			return nil
+		},
+	}
+	resp, err = invokeHandlerWithMethod(context.Background(), sPrime, "POST", body, headers)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if resp.Status != 500 {
+		t.Fatalf("status: got %d want %d", resp.Status, 500)
+	}
+	if !closeCalled {
+		t.Fatalf("expected stream cleanup close to run after prime failure")
+	}
+
 	// Subscribe error should map to internalServerError (500).
 	s3 := NewServer("test", "dev")
 	registerAnyStreamingTool(t, s3)

--- a/runtime/mcp/server_property_test.go
+++ b/runtime/mcp/server_property_test.go
@@ -83,11 +83,24 @@ type tbFatalf interface {
 }
 
 func initializeSession(t tbFatalf, s *Server) string {
+	return initializeSessionWithProtocol(t, s, "")
+}
+
+func initializeSessionWithProtocol(t tbFatalf, s *Server, requestedProtocolVersion string) string {
 	if h, ok := any(t).(interface{ Helper() }); ok {
 		h.Helper()
 	}
 
-	body, err := json.Marshal(Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	var params json.RawMessage
+	if requestedProtocolVersion != "" {
+		paramsBytes, err := json.Marshal(map[string]any{"protocolVersion": requestedProtocolVersion})
+		if err != nil {
+			t.Fatalf("marshal initialize params: %v", err)
+		}
+		params = paramsBytes
+	}
+
+	body, err := json.Marshal(Request{JSONRPC: "2.0", ID: 1, Method: "initialize", Params: params})
 	if err != nil {
 		t.Fatalf("marshal initialize: %v", err)
 	}

--- a/runtime/mcp/server_property_test.go
+++ b/runtime/mcp/server_property_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -51,6 +52,9 @@ func invokeHandlerWithMethod(ctx context.Context, s *Server, method string, body
 	if method == "POST" {
 		if _, ok := headers["content-type"]; !ok {
 			headers["content-type"] = []string{"application/json"}
+		}
+		if _, ok := headers["accept"]; !ok {
+			headers["accept"] = []string{"application/json, text/event-stream"}
 		}
 	}
 
@@ -128,6 +132,12 @@ func sessionHeaders(sessionID string) map[string][]string {
 		"mcp-session-id":       {sessionID},
 		"mcp-protocol-version": {protocolVersion},
 	}
+}
+
+func sseSessionHeaders(sessionID string) map[string][]string {
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"text/event-stream"}
+	return headers
 }
 
 func TestToolsCallBuffered_PanicReturnsInternalError(t *testing.T) {
@@ -240,7 +250,7 @@ func TestProperty6_ProtocolErrorCodeCorrectness(t *testing.T) {
 			}
 
 			headers := sessionHeaders(sessionID)
-			headers["accept"] = []string{"application/json"}
+			headers["accept"] = []string{"application/json, text/event-stream"}
 
 			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 			if err != nil {
@@ -274,7 +284,7 @@ func TestProperty6_ProtocolErrorCodeCorrectness(t *testing.T) {
 			}
 
 			headers := sessionHeaders(sessionID)
-			headers["accept"] = []string{"application/json"}
+			headers["accept"] = []string{"application/json, text/event-stream"}
 
 			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 			if err != nil {
@@ -338,7 +348,7 @@ func TestProperty7_ToolHandlerErrorWrapping(t *testing.T) {
 
 		sessionID := initializeSession(t, s)
 		headers := sessionHeaders(sessionID)
-		headers["accept"] = []string{"application/json"}
+		headers["accept"] = []string{"application/json, text/event-stream"}
 
 		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 		if err != nil {
@@ -362,28 +372,46 @@ func TestProperty7_ToolHandlerErrorWrapping(t *testing.T) {
 	})
 }
 
-// Feature: cloud-mcp-gateway, Property 10: Response Format Matches Accept Header
+// Feature: cloud-mcp-gateway, Property 10: Response Format Matches Streaming Support
 // Validates: Requirements 5.1, 5.4
 //
-// For any valid tools/call request, when the Accept header is text/event-stream
-// the response content type SHALL be text/event-stream, and when the Accept
-// header is application/json (or absent) the response content type SHALL be
-// application/json.
-func TestProperty10_ResponseFormatMatchesAcceptHeader(t *testing.T) {
+// For any valid tools/call request with the strict Streamable HTTP Accept
+// header, AppTheory SHALL return SSE only for tools registered with streaming
+// support. Non-streaming tools return buffered JSON even though the client also
+// advertises text/event-stream support.
+func TestProperty10_ResponseFormatMatchesStreamingSupport(t *testing.T) {
 	s := newTestServer()
+	if err := s.registry.RegisterStreamingTool(
+		ToolDef{
+			Name:        "stream_echo",
+			Description: "Streams echo input back",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`),
+		},
+		func(_ context.Context, args json.RawMessage, _ func(SSEEvent)) (*ToolResult, error) {
+			var p struct {
+				Message string `json:"message"`
+			}
+			if err := json.Unmarshal(args, &p); err != nil {
+				return nil, err
+			}
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: p.Message}}}, nil
+		},
+	); err != nil {
+		t.Fatalf("failed to register streaming tool: %v", err)
+	}
 
 	rapid.Check(t, func(t *rapid.T) {
 		sessionID := initializeSession(t, s)
 
 		reqID := genRequestID().Draw(t, "id")
-		acceptType := rapid.SampledFrom([]string{
-			"text/event-stream",
-			"application/json",
-			"", // absent
-		}).Draw(t, "accept")
+		streaming := rapid.Bool().Draw(t, "streaming")
+		toolName := "echo"
+		if streaming {
+			toolName = "stream_echo"
+		}
 
 		params, err := json.Marshal(toolsCallParams{
-			Name:      "echo",
+			Name:      toolName,
 			Arguments: json.RawMessage(`{"message":"hello"}`),
 		})
 		if err != nil {
@@ -400,13 +428,16 @@ func TestProperty10_ResponseFormatMatchesAcceptHeader(t *testing.T) {
 		}
 
 		headers := sessionHeaders(sessionID)
-		if acceptType != "" {
-			headers["accept"] = []string{acceptType}
-		}
+		headers["accept"] = []string{"application/json, text/event-stream"}
 
 		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 		if err != nil {
 			t.Fatalf("handler error: %v", err)
+		}
+		if resp.BodyReader != nil {
+			if _, readErr := io.ReadAll(resp.BodyReader); readErr != nil {
+				t.Fatalf("read streaming response: %v", readErr)
+			}
 		}
 
 		ct := ""
@@ -414,12 +445,11 @@ func TestProperty10_ResponseFormatMatchesAcceptHeader(t *testing.T) {
 			ct = vals[0]
 		}
 
-		if acceptType == "text/event-stream" {
+		if streaming {
 			if ct != "text/event-stream" {
 				t.Fatalf("expected content-type text/event-stream, got %q", ct)
 			}
 		} else {
-			// application/json or absent → expect JSON
 			if ct != "application/json" && ct != "application/json; charset=utf-8" {
 				t.Fatalf("expected content-type application/json, got %q", ct)
 			}
@@ -433,7 +463,7 @@ func TestToolsCall_AcceptsNumericProgressToken(t *testing.T) {
 
 	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"},"_meta":{"progressToken":123}}}`)
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"application/json"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 	if err != nil {

--- a/runtime/mcp/server_remaining_coverage_test.go
+++ b/runtime/mcp/server_remaining_coverage_test.go
@@ -142,7 +142,7 @@ func TestServerHTTPHandlers_CoverageBranches(t *testing.T) {
 		s := NewServer("test", "dev")
 		sessionID := initializeSession(t, s)
 
-		headers := sessionHeaders(sessionID)
+		headers := sseSessionHeaders(sessionID)
 		headers[headerMcpProtocolVersion] = []string{"not-a-real-version"}
 
 		resp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, headers)
@@ -167,7 +167,7 @@ func TestServerHTTPHandlers_CoverageBranches(t *testing.T) {
 			},
 		}
 
-		headers := sessionHeaders(sessionID)
+		headers := sseSessionHeaders(sessionID)
 		headers[headerLastEventID] = []string{"1"}
 
 		resp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, headers)

--- a/runtime/mcp/server_remaining_coverage_test.go
+++ b/runtime/mcp/server_remaining_coverage_test.go
@@ -329,7 +329,7 @@ func TestServerHelpersAndInternalBranches(t *testing.T) {
 			},
 		}))
 
-		_, sess, errResp := s.handleInitializeBatch(context.Background(), &Request{JSONRPC: "2.0", ID: 1, Method: methodInitialize})
+		_, sess, errResp := s.handleInitializeBatch(context.Background(), &Request{JSONRPC: "2.0", ID: 1, Method: methodInitialize}, protocolVersionLegacy)
 		if sess != nil {
 			t.Fatalf("expected nil session on failure")
 		}
@@ -345,7 +345,7 @@ func TestServerHelpersAndInternalBranches(t *testing.T) {
 			},
 		}))
 		sess := &Session{ID: "s1"}
-		s.handleNotification(context.Background(), sess, &Request{Method: methodNotificationsInitialized})
+		s.handleNotification(context.Background(), sess, &Request{Method: methodNotificationsInitialized}, protocolVersion)
 		if sess.Data == nil || sess.Data["initialized"] != sessionInitializedValue {
 			t.Fatalf("expected initialized flag to be set, got: %+v", sess.Data)
 		}

--- a/runtime/mcp/stream_store.go
+++ b/runtime/mcp/stream_store.go
@@ -28,7 +28,8 @@ type StreamStore interface {
 	Close(ctx context.Context, sessionID, streamID string) error
 
 	// Subscribe streams events after afterEventID. If afterEventID is empty,
-	// it streams from the beginning.
+	// it streams from the beginning. If afterEventID is present, it must belong
+	// to the requested stream.
 	Subscribe(ctx context.Context, sessionID, streamID, afterEventID string) (<-chan StreamEvent, error)
 
 	// StreamForEvent returns the stream id that the given event id belongs to.
@@ -207,6 +208,13 @@ func (m *MemoryStreamStore) Subscribe(ctx context.Context, sessionID, streamID, 
 	if stream == nil {
 		m.mu.Unlock()
 		return nil, ErrStreamNotFound
+	}
+	if afterSeq > 0 {
+		eventStreamID, ok := sess.seqToStream[afterSeq]
+		if !ok || eventStreamID != streamID {
+			m.mu.Unlock()
+			return nil, ErrEventNotFound
+		}
 	}
 
 	nextIndex := startIndexAfterSeq(stream.events, afterSeq)

--- a/runtime/mcp/stream_store_additional_test.go
+++ b/runtime/mcp/stream_store_additional_test.go
@@ -36,6 +36,34 @@ func TestMemoryStreamStore_IDGeneratorAndDeleteSession(t *testing.T) {
 	}
 }
 
+func TestMemoryStreamStore_SubscribeRejectsLastEventIDFromDifferentStream(t *testing.T) {
+	store := NewMemoryStreamStore()
+
+	streamA, err := store.Create(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("Create streamA: %v", err)
+	}
+	streamB, err := store.Create(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("Create streamB: %v", err)
+	}
+
+	if _, appendErr := store.Append(context.Background(), "sess-1", streamA, json.RawMessage(`{"stream":"A","seq":1}`)); appendErr != nil {
+		t.Fatalf("Append streamA: %v", appendErr)
+	}
+	eventB, err := store.Append(context.Background(), "sess-1", streamB, json.RawMessage(`{"stream":"B","seq":1}`))
+	if err != nil {
+		t.Fatalf("Append streamB: %v", err)
+	}
+	if _, appendErr := store.Append(context.Background(), "sess-1", streamA, json.RawMessage(`{"stream":"A","seq":2}`)); appendErr != nil {
+		t.Fatalf("Append streamA second: %v", appendErr)
+	}
+
+	if _, err := store.Subscribe(context.Background(), "sess-1", streamA, eventB); !errors.Is(err, ErrEventNotFound) {
+		t.Fatalf("Subscribe with cross-stream Last-Event-ID: got %v want %v", err, ErrEventNotFound)
+	}
+}
+
 func TestMemoryStreamStore_Errors(t *testing.T) {
 	store := NewMemoryStreamStore()
 

--- a/runtime/mcp/stream_store_dynamo.go
+++ b/runtime/mcp/stream_store_dynamo.go
@@ -373,10 +373,38 @@ func (d *DynamoStreamStore) Subscribe(ctx context.Context, sessionID, streamID, 
 		}
 		return nil, err
 	}
+	if afterEventID != "" {
+		if err := d.requireEventBelongsToStream(ctx, sessionID, streamID, afterEventID); err != nil {
+			return nil, err
+		}
+	}
 
 	out := make(chan StreamEvent)
 	go d.pumpSubscription(ctx, sessionID, streamID, afterEventID, out)
 	return out, nil
+}
+
+func (d *DynamoStreamStore) requireEventBelongsToStream(ctx context.Context, sessionID, streamID, eventID string) error {
+	var record dynamoStreamRecord
+	err := d.db.Model(&dynamoStreamRecord{}).
+		WithContext(ctx).
+		ConsistentRead().
+		Where("SessionID", "=", sessionID).
+		Where("EventID", "=", eventID).
+		First(&record)
+	if err != nil {
+		if tableerrors.IsNotFound(err) {
+			return ErrEventNotFound
+		}
+		return err
+	}
+	if record.Kind != dynamoStreamRecordKindEvent || record.StreamID != streamID {
+		return ErrEventNotFound
+	}
+	if d.streamRecordExpired(record, d.now().UTC()) {
+		return ErrEventNotFound
+	}
+	return nil
 }
 
 func (d *DynamoStreamStore) StreamForEvent(ctx context.Context, sessionID, eventID string) (string, error) {

--- a/runtime/mcp/stream_store_dynamo_test.go
+++ b/runtime/mcp/stream_store_dynamo_test.go
@@ -269,7 +269,7 @@ func TestDynamoStreamStore_ServerReplayFromSecondInstance(t *testing.T) {
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
 	resp, err := invokeHandlerWithMethod(reqCtx, s1, "POST", body, headers)
@@ -355,7 +355,7 @@ func TestHandleToolsCallStream_OversizeFinalResponseEmitsStableError(t *testing.
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 7, Method: methodToolsCall, Params: mustMarshal(t, params)})
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 	require.NoError(t, err)

--- a/runtime/mcp/stream_store_dynamo_test.go
+++ b/runtime/mcp/stream_store_dynamo_test.go
@@ -141,6 +141,9 @@ func TestDynamoStreamStore_ReplayPreservesSessionSequenceAcrossStreams(t *testin
 	require.Equal(t, eventA2, replayed.ID)
 	require.JSONEq(t, `{"stream":"A","seq":2}`, string(replayed.Data))
 	requireStreamClosed(t, replay)
+
+	_, err = store.Subscribe(context.Background(), "sess-1", streamA, eventB1)
+	require.ErrorIs(t, err, ErrEventNotFound)
 }
 
 func TestDynamoStreamStore_DeleteSessionRejectsLateAppend(t *testing.T) {
@@ -249,6 +252,7 @@ func TestDynamoStreamStore_ServerReplayFromSecondInstance(t *testing.T) {
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
 		func(ctx context.Context, _ json.RawMessage, emit func(SSEEvent)) (*ToolResult, error) {
+			defer close(toolDone)
 			emit(SSEEvent{Data: map[string]any{"seq": 1}})
 			close(firstEmitted)
 
@@ -284,26 +288,20 @@ func TestDynamoStreamStore_ServerReplayFromSecondInstance(t *testing.T) {
 		t.Fatal("timed out waiting for first progress emission")
 	}
 
+	primingFrame, err := readSSEFrame(reader)
+	require.NoError(t, err)
+	requirePrimingSSEFrame(t, primingFrame)
+
 	firstFrame, err := readSSEFrame(reader)
 	require.NoError(t, err)
 	require.Contains(t, firstFrame, `"method":"notifications/progress"`)
 	require.Contains(t, firstFrame, `"progress":1`)
 
-	lastID := ""
-	for _, line := range strings.Split(firstFrame, "\n") {
-		if strings.HasPrefix(line, "id: ") {
-			lastID = strings.TrimSpace(strings.TrimPrefix(line, "id: "))
-			break
-		}
-	}
-	require.NotEmpty(t, lastID)
+	lastID := sseFrameID(t, firstFrame)
 
 	cancel()
 
-	go func() {
-		defer close(toolDone)
-		close(continueTool)
-	}()
+	close(continueTool)
 
 	select {
 	case <-toolDone:

--- a/runtime/mcp/streaming.go
+++ b/runtime/mcp/streaming.go
@@ -14,9 +14,10 @@ type SSEEvent struct {
 type StreamingToolHandler func(ctx context.Context, args json.RawMessage, emit func(SSEEvent)) (*ToolResult, error)
 
 // RegisterStreamingTool registers a tool that supports SSE streaming.
-// When invoked with Accept: text/event-stream, progress events are streamed.
-// When invoked with Accept: application/json (or absent), the handler runs
-// to completion and returns a buffered JSON response.
+// When invoked by a strict Streamable HTTP POST with an Accept header that
+// supports both application/json and text/event-stream, progress events are
+// streamed. Buffered calls to the same tool still run to completion and return a
+// JSON response when the server does not select the SSE path.
 func (r *ToolRegistry) RegisterStreamingTool(def ToolDef, handler StreamingToolHandler) error {
 	// Wrap the streaming handler as a regular ToolHandler that buffers results.
 	// The actual SSE streaming is handled at the server level by checking the

--- a/runtime/mcp/streaming_test.go
+++ b/runtime/mcp/streaming_test.go
@@ -61,7 +61,7 @@ func TestToolsCallStreaming_StreamsProgressIncrementally(t *testing.T) {
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestToolsCallStreaming_ProgressToken_NumberIsPreserved(t *testing.T) {
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 	if err != nil {
@@ -254,7 +254,7 @@ func TestToolsCallStreaming_CanResumeViaGETWithLastEventID(t *testing.T) {
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
 	resp, err := invokeHandlerWithMethod(reqCtx, s, "POST", body, headers)
@@ -421,7 +421,7 @@ func TestToolsCallStreaming_PanicReturnsInternalError(t *testing.T) {
 	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
 
 	headers := sessionHeaders(sessionID)
-	headers["accept"] = []string{"text/event-stream"}
+	headers["accept"] = []string{"application/json, text/event-stream"}
 
 	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
 	if err != nil {

--- a/runtime/mcp/streaming_test.go
+++ b/runtime/mcp/streaming_test.go
@@ -24,6 +24,32 @@ func readSSEFrame(r *bufio.Reader) (string, error) {
 	}
 }
 
+func sseFrameID(t *testing.T, frame string) string {
+	t.Helper()
+	for _, line := range strings.Split(frame, "\n") {
+		if strings.HasPrefix(line, "id: ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "id: "))
+		}
+	}
+	t.Fatalf("expected SSE frame to include an id line, got:\n%s", frame)
+	return ""
+}
+
+func requirePrimingSSEFrame(t *testing.T, frame string) string {
+	t.Helper()
+	id := sseFrameID(t, frame)
+	if strings.Contains(frame, "event: message\n") {
+		t.Fatalf("expected priming frame to omit message event name, got:\n%s", frame)
+	}
+	if !strings.Contains(frame, "data: \n") {
+		t.Fatalf("expected priming frame to contain an empty data field, got:\n%s", frame)
+	}
+	if strings.Contains(frame, `"jsonrpc"`) {
+		t.Fatalf("expected priming frame to omit JSON-RPC payload, got:\n%s", frame)
+	}
+	return id
+}
+
 func TestToolsCallStreaming_StreamsProgressIncrementally(t *testing.T) {
 	s := NewServer("test-server", "1.0.0")
 
@@ -78,18 +104,12 @@ func TestToolsCallStreaming_StreamsProgressIncrementally(t *testing.T) {
 
 	reader := bufio.NewReader(resp.BodyReader)
 
-	select {
-	case <-firstEmitted:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for first progress emission")
-	}
-
 	firstFrameCh := make(chan string, 1)
 	firstFrameErrCh := make(chan error, 1)
 	go func() {
-		frame, err := readSSEFrame(reader)
-		if err != nil {
-			firstFrameErrCh <- err
+		frame, readErr := readSSEFrame(reader)
+		if readErr != nil {
+			firstFrameErrCh <- readErr
 			return
 		}
 		firstFrameCh <- frame
@@ -98,20 +118,32 @@ func TestToolsCallStreaming_StreamsProgressIncrementally(t *testing.T) {
 	var firstFrame string
 	select {
 	case firstFrame = <-firstFrameCh:
-	case err := <-firstFrameErrCh:
-		t.Fatalf("read first SSE frame: %v", err)
+	case frameErr := <-firstFrameErrCh:
+		t.Fatalf("read first SSE frame: %v", frameErr)
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for first SSE frame")
 	}
+	requirePrimingSSEFrame(t, firstFrame)
 
-	if !strings.Contains(firstFrame, "event: message\n") {
-		t.Fatalf("expected first frame to be message event, got:\n%s", firstFrame)
+	select {
+	case <-firstEmitted:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for first progress emission")
 	}
-	if !strings.Contains(firstFrame, `"method":"notifications/progress"`) {
-		t.Fatalf("expected first frame to be progress notification, got:\n%s", firstFrame)
+
+	progressFrame, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read progress SSE frame: %v", err)
 	}
-	if !strings.Contains(firstFrame, `"progressToken":"pt-123"`) {
-		t.Fatalf("expected first frame to contain progressToken, got:\n%s", firstFrame)
+
+	if !strings.Contains(progressFrame, "event: message\n") {
+		t.Fatalf("expected progress frame to be message event, got:\n%s", progressFrame)
+	}
+	if !strings.Contains(progressFrame, `"method":"notifications/progress"`) {
+		t.Fatalf("expected progress frame to be progress notification, got:\n%s", progressFrame)
+	}
+	if !strings.Contains(progressFrame, `"progressToken":"pt-123"`) {
+		t.Fatalf("expected progress frame to contain progressToken, got:\n%s", progressFrame)
 	}
 
 	close(continueTool)
@@ -136,7 +168,7 @@ func TestToolsCallStreaming_StreamsProgressIncrementally(t *testing.T) {
 		t.Fatalf("timed out reading rest of SSE stream")
 	}
 
-	all := firstFrame + string(rest)
+	all := firstFrame + progressFrame + string(rest)
 	if !strings.Contains(all, `"method":"notifications/progress"`) {
 		t.Fatalf("expected SSE stream to contain progress notification, got:\n%s", all)
 	}
@@ -200,15 +232,21 @@ func TestToolsCallStreaming_ProgressToken_NumberIsPreserved(t *testing.T) {
 		t.Fatalf("timed out waiting for first progress emission")
 	}
 
+	primingFrame, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read priming SSE frame: %v", err)
+	}
+	requirePrimingSSEFrame(t, primingFrame)
+
 	firstFrame, err := readSSEFrame(reader)
 	if err != nil {
-		t.Fatalf("read first SSE frame: %v", err)
+		t.Fatalf("read first progress SSE frame: %v", err)
 	}
 	if !strings.Contains(firstFrame, `"method":"notifications/progress"`) {
-		t.Fatalf("expected first frame to be progress notification, got:\n%s", firstFrame)
+		t.Fatalf("expected first progress frame to be progress notification, got:\n%s", firstFrame)
 	}
 	if !strings.Contains(firstFrame, `"progressToken":123`) {
-		t.Fatalf("expected first frame to contain numeric progressToken, got:\n%s", firstFrame)
+		t.Fatalf("expected first progress frame to contain numeric progressToken, got:\n%s", firstFrame)
 	}
 
 	close(continueTool)
@@ -273,29 +311,26 @@ func TestToolsCallStreaming_CanResumeViaGETWithLastEventID(t *testing.T) {
 		t.Fatalf("timed out waiting for first progress emission")
 	}
 
+	primingFrame, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read priming SSE frame: %v", err)
+	}
+	requirePrimingSSEFrame(t, primingFrame)
+
 	firstFrame, err := readSSEFrame(reader)
 	if err != nil {
-		t.Fatalf("read first SSE frame: %v", err)
+		t.Fatalf("read first progress SSE frame: %v", err)
 	}
 
 	if !strings.Contains(firstFrame, "event: message\n") {
-		t.Fatalf("expected first frame to be message event, got:\n%s", firstFrame)
+		t.Fatalf("expected first progress frame to be message event, got:\n%s", firstFrame)
 	}
 	if !strings.Contains(firstFrame, `"method":"notifications/progress"`) {
-		t.Fatalf("expected first frame to be progress notification, got:\n%s", firstFrame)
+		t.Fatalf("expected first progress frame to be progress notification, got:\n%s", firstFrame)
 	}
 
 	// Capture the SSE id to use as Last-Event-ID.
-	lastID := ""
-	for _, line := range strings.Split(firstFrame, "\n") {
-		if strings.HasPrefix(line, "id: ") {
-			lastID = strings.TrimSpace(strings.TrimPrefix(line, "id: "))
-			break
-		}
-	}
-	if lastID == "" {
-		t.Fatalf("expected first frame to include an id line, got:\n%s", firstFrame)
-	}
+	lastID := sseFrameID(t, firstFrame)
 
 	// Simulate disconnect: stop the POST stream.
 	cancel()
@@ -334,6 +369,99 @@ func TestToolsCallStreaming_CanResumeViaGETWithLastEventID(t *testing.T) {
 	}
 	if !strings.Contains(all, `"result"`) {
 		t.Fatalf("expected resumed stream to contain final result, got:\n%s", all)
+	}
+}
+
+func TestToolsCallStreaming_PrimingEventAllowsResumeBeforeMessages(t *testing.T) {
+	s := NewServer("test-server", "1.0.0")
+	sessionID := initializeSession(t, s)
+
+	toolEntered := make(chan struct{})
+	continueTool := make(chan struct{})
+	toolDone := make(chan struct{})
+
+	if err := s.registry.RegisterStreamingTool(
+		ToolDef{
+			Name:        "delayed_tool",
+			Description: "Waits before emitting progress",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		func(ctx context.Context, _ json.RawMessage, emit func(SSEEvent)) (*ToolResult, error) {
+			defer close(toolDone)
+			close(toolEntered)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-continueTool:
+			}
+			emit(SSEEvent{Data: map[string]any{"seq": 1}})
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+		},
+	); err != nil {
+		t.Fatalf("register streaming tool: %v", err)
+	}
+
+	params := toolsCallParams{Name: "delayed_tool", Arguments: json.RawMessage(`{}`)}
+	params.Meta.ProgressToken = json.RawMessage(`"pt-primed"`)
+	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
+
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	resp, err := invokeHandlerWithMethod(reqCtx, s, "POST", body, headers)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if resp.BodyReader == nil {
+		t.Fatalf("expected streaming response BodyReader to be set")
+	}
+
+	reader := bufio.NewReader(resp.BodyReader)
+	primingFrame, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read priming frame: %v", err)
+	}
+	primingID := requirePrimingSSEFrame(t, primingFrame)
+
+	select {
+	case <-toolEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for tool to enter")
+	}
+
+	cancel()
+	close(continueTool)
+	select {
+	case <-toolDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for tool completion")
+	}
+
+	getHeaders := sseSessionHeaders(sessionID)
+	getHeaders["last-event-id"] = []string{primingID}
+
+	getResp, err := invokeHandlerWithMethod(context.Background(), s, "GET", nil, getHeaders)
+	if err != nil {
+		t.Fatalf("invoke GET: %v", err)
+	}
+	if getResp.BodyReader == nil {
+		t.Fatalf("expected GET response BodyReader to be set")
+	}
+
+	b, err := io.ReadAll(getResp.BodyReader)
+	if err != nil {
+		t.Fatalf("read GET SSE: %v", err)
+	}
+	all := string(b)
+	if !strings.Contains(all, `"method":"notifications/progress"`) {
+		t.Fatalf("expected replay after priming id to include progress notification, got:\n%s", all)
+	}
+	if !strings.Contains(all, `"progressToken":"pt-primed"`) {
+		t.Fatalf("expected replay after priming id to include progress token, got:\n%s", all)
+	}
+	if !strings.Contains(all, `"result"`) {
+		t.Fatalf("expected replay after priming id to include final result, got:\n%s", all)
 	}
 }
 

--- a/runtime/mcp/tool.go
+++ b/runtime/mcp/tool.go
@@ -125,6 +125,13 @@ func (r *ToolRegistry) List() []ToolDef {
 	return defs
 }
 
+// Len returns the number of registered tools.
+func (r *ToolRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.tools)
+}
+
 // Call looks up a tool by name and invokes its handler with the given arguments.
 // It returns an error if the tool is not found.
 func (r *ToolRegistry) Call(ctx context.Context, name string, args json.RawMessage) (*ToolResult, error) {

--- a/runtime/mcp/tool.go
+++ b/runtime/mcp/tool.go
@@ -132,6 +132,17 @@ func (r *ToolRegistry) Len() int {
 	return len(r.tools)
 }
 
+func (r *ToolRegistry) supportsStreaming(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	idx, ok := r.index[name]
+	if !ok {
+		return false
+	}
+	return r.tools[idx].streamingHandler != nil
+}
+
 // Call looks up a tool by name and invokes its handler with the given arguments.
 // It returns an error if the tool is not found.
 func (r *ToolRegistry) Call(ctx context.Context, name string, args json.RawMessage) (*ToolResult, error) {

--- a/testkit/mcp/claude_remote_mcp_contract_test.go
+++ b/testkit/mcp/claude_remote_mcp_contract_test.go
@@ -280,12 +280,26 @@ func TestClaudeRemoteMcp_Lifecycle_AndStreamingResume_WithBearerAuth(t *testing.
 		t.Fatalf("timed out waiting for first progress emission")
 	}
 
+	primingMsg, err := stream.Next()
+	if err != nil {
+		t.Fatalf("read priming SSE message: %v", err)
+	}
+	if strings.TrimSpace(primingMsg.ID) == "" {
+		t.Fatalf("expected priming SSE message to include id")
+	}
+	if got := strings.TrimSpace(primingMsg.Event); got != "" {
+		t.Fatalf("expected priming SSE event to be empty, got %q", got)
+	}
+	if got := strings.TrimSpace(string(primingMsg.Data)); got != "" {
+		t.Fatalf("expected priming SSE data to be empty, got %q", got)
+	}
+
 	firstMsg, err := stream.Next()
 	if err != nil {
-		t.Fatalf("read first SSE message: %v", err)
+		t.Fatalf("read first progress SSE message: %v", err)
 	}
 	if strings.TrimSpace(firstMsg.ID) == "" {
-		t.Fatalf("expected first SSE message to include id")
+		t.Fatalf("expected first progress SSE message to include id")
 	}
 	if !strings.Contains(string(firstMsg.Data), `"method":"notifications/progress"`) {
 		t.Fatalf("expected progress notification in first event, got: %s", string(firstMsg.Data))

--- a/testkit/mcp/mcp.go
+++ b/testkit/mcp/mcp.go
@@ -273,7 +273,7 @@ func (c *Client) Raw(ctx context.Context, req *mcpruntime.Request) (*mcpruntime.
 
 	headers := map[string][]string{
 		"content-type": {"application/json"},
-		"accept":       {"application/json"},
+		"accept":       {"application/json, text/event-stream"},
 	}
 	if c.sessionID != "" {
 		headers["mcp-session-id"] = []string{c.sessionID}

--- a/testkit/mcp/stream.go
+++ b/testkit/mcp/stream.go
@@ -129,7 +129,7 @@ func ReadSSEMessage(r *bufio.Reader) (*SSEMessage, error) {
 	}, nil
 }
 
-// RawStream sends a JSON-RPC request to POST /mcp with `Accept: text/event-stream` and
+// RawStream sends a strict Streamable HTTP JSON-RPC request to POST /mcp and
 // returns a Stream for reading incremental SSE messages.
 func (c *Client) RawStream(ctx context.Context, req *mcpruntime.Request, extraHeaders map[string][]string) (*Stream, error) {
 	if c == nil {

--- a/testkit/mcp/stream_test.go
+++ b/testkit/mcp/stream_test.go
@@ -75,9 +75,23 @@ func TestClient_RawStream_AndResumeStream(t *testing.T) {
 		t.Fatalf("timed out waiting for first progress emission")
 	}
 
+	priming, err := stream.Next()
+	if err != nil {
+		t.Fatalf("read priming SSE message: %v", err)
+	}
+	if strings.TrimSpace(priming.ID) == "" {
+		t.Fatalf("expected priming SSE id to be set")
+	}
+	if got := strings.TrimSpace(priming.Event); got != "" {
+		t.Fatalf("expected priming SSE event to be empty, got %q", got)
+	}
+	if got := strings.TrimSpace(string(priming.Data)); got != "" {
+		t.Fatalf("expected priming SSE data to be empty, got %q", got)
+	}
+
 	first, err := stream.Next()
 	if err != nil {
-		t.Fatalf("read first SSE message: %v", err)
+		t.Fatalf("read first progress SSE message: %v", err)
 	}
 	if strings.TrimSpace(first.ID) == "" {
 		t.Fatalf("expected SSE id to be set")


### PR DESCRIPTION
## Milestone
mcp-capability-transport — Make AppTheory's initialize capability surface and Streamable HTTP behavior explicit, protocol-aware, and canary-ready.

## Linear
https://linear.app/theorycloud/project/apptheory-mcp-runtime-prerequisites-for-issue-144-6458c5ddb11c / mcp-capability-transport

## Tasks
- [x] THE-1004 Add explicit MCP capability configuration
- [x] THE-1005 Gate MCP capabilities by negotiated protocol version
- [x] THE-1006 Enforce Streamable HTTP request headers
- [x] THE-1007 Prime and replay Streamable HTTP SSE streams correctly
- [x] THE-1008 Document strict transport compatibility rollout

## Contract impact
Go MCP runtime public initialize/transport behavior and Go API snapshot updates. Changes are fixture-first within `runtime/mcp` tests for the Go MCP runtime surface; shared HTTP contract fixtures are not changed in this milestone.

## Validation
Commands run:
- Baseline on `staging` 66be609: `make rubric` — PASS (28 pass / 0 fail / 0 blocked)
- THE-1004: `go test ./runtime/mcp`
- THE-1004: `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh`
- THE-1004: `make test-unit && make rubric` — PASS (28 pass / 0 fail / 0 blocked)
- THE-1005: `go test ./runtime/mcp`
- THE-1005: `./scripts/verify-api-snapshots.sh`
- THE-1005: `bash ./scripts/verify-docs-standard.sh`
- THE-1005: `make test-unit && make rubric` — PASS (28 pass / 0 fail / 0 blocked)
- THE-1006: `go test ./runtime/mcp`
- THE-1006: `go test ./runtime/mcp ./testkit/mcp ./examples/mcp/tools-only ./examples/mcp/tools-resources-prompts ./examples/mcp/resumable-sse`
- THE-1006: `bash ./scripts/verify-docs-standard.sh`
- THE-1006: `make test-unit && make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T20:00:29Z)
- THE-1007: `go test ./runtime/mcp ./testkit/mcp ./examples/mcp/resumable-sse`
- THE-1007: `go test ./...`
- THE-1007: `make lint`
- THE-1007: `make test-unit`
- THE-1007: `bash ./scripts/verify-docs-standard.sh`
- THE-1007: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T20:25:01Z)
- THE-1008: `bash ./scripts/verify-docs-standard.sh`
- THE-1008/final: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T20:33:49Z)
- PR review fix: `go test ./runtime/mcp` — PASS
- PR review fix: `make test-unit` — PASS
- PR review fix/final: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T21:18:35Z)
- Final: `./scripts/verify-contract-tests.sh` — PASS (Go/TS/Python, 121 fixtures each)
- Final: `./scripts/verify-version-alignment.sh` — PASS (1.5.0)

## Cross-repo notes
This remains AppTheory-owned runtime/deployment prerequisite work. theory-mcp-server should only consume these changes after an AppTheory release and should not advertise optional MCP capabilities until product policy is wired.


