### PR TITLE
feat(mcp): add utility hooks

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1962,10 +1962,45 @@ var ErrStreamEventTooLarge = errors.New("stream event too large")
 var ErrStreamNotFound = errors.New("stream not found")
 
 type CapabilityConfig struct {
-	Tools     bool
-	Resources bool
-	Prompts   bool
-	Logging   bool
+	Tools       bool
+	Resources   bool
+	Prompts     bool
+	Logging     bool
+	Completions bool
+}
+
+type Completion struct {
+	Values  []string `json:"values"`
+	Total   *int     `json:"total,omitempty"`
+	HasMore *bool    `json:"hasMore,omitempty"`
+}
+
+type CompletionArgument struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type CompletionContext struct {
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+type CompletionHook func(context.Context, CompletionRequest) (*CompletionResult, error)
+
+type CompletionRef struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+	URI  string `json:"uri,omitempty"`
+}
+
+type CompletionRequest struct {
+	SessionID string             `json:"sessionId"`
+	Ref       CompletionRef      `json:"ref"`
+	Argument  CompletionArgument `json:"argument"`
+	Context   CompletionContext  `json:"context,omitempty"`
+}
+
+type CompletionResult struct {
+	Completion Completion `json:"completion"`
 }
 
 type ContentBlock struct {
@@ -2142,6 +2177,8 @@ type Server struct {
 	resourceSubscribeHook   ResourceSubscriptionHook
 	resourceUnsubscribeHook ResourceSubscriptionHook
 	loggingLevelHook        LoggingLevelHook
+	promptCompletionHook    CompletionHook
+	resourceCompletionHook  CompletionHook
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -2253,6 +2290,8 @@ func ParseResponse([]byte) (*Response, error)
 func WithCapabilityConfig(CapabilityConfig) ServerOption
 
 func WithClock(apptheory.Clock) MemorySessionStoreOption
+
+func WithCompletionHooks(CompletionHook, CompletionHook) ServerOption
 
 func WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions) ServerOption
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1965,7 +1965,6 @@ type CapabilityConfig struct {
 	Tools       bool
 	Resources   bool
 	Prompts     bool
-	Logging     bool
 	Completions bool
 }
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2082,6 +2082,13 @@ type ResourceRegistry struct {
 	index     map[string]int
 }
 
+type ResourceSubscription struct {
+	SessionID string `json:"sessionId"`
+	URI       string `json:"uri"`
+}
+
+type ResourceSubscriptionHook func(context.Context, ResourceSubscription) error
+
 type Response struct {
 	JSONRPC string    `json:"jsonrpc"`
 	ID      any       `json:"id"`
@@ -2105,6 +2112,9 @@ type Server struct {
 	logger           *slog.Logger
 	originValidator  OriginValidator
 	capabilities     CapabilityConfig
+
+	resourceSubscribeHook   ResourceSubscriptionHook
+	resourceUnsubscribeHook ResourceSubscriptionHook
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -2222,6 +2232,8 @@ func WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions) Serve
 func WithLogger(*slog.Logger) ServerOption
 
 func WithOriginValidator(OriginValidator) ServerOption
+
+func WithResourceSubscriptionHooks(ResourceSubscriptionHook, ResourceSubscriptionHook) ServerOption
 
 func WithServerIDGenerator(apptheory.IDGenerator) ServerOption
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2169,6 +2169,7 @@ type Server struct {
 	promptRegistry   *PromptRegistry
 	sessionStore     SessionStore
 	streamStore      StreamStore
+	cancellations    *cancellationTracker
 	idGen            apptheory.IDGenerator
 	logger           *slog.Logger
 	originValidator  OriginValidator

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -1937,6 +1937,22 @@ const CodeParseError = -32700
 
 const CodeServerError = -32000
 
+const LoggingLevelAlert LoggingLevel = "alert"
+
+const LoggingLevelCritical LoggingLevel = "critical"
+
+const LoggingLevelDebug LoggingLevel = "debug"
+
+const LoggingLevelEmergency LoggingLevel = "emergency"
+
+const LoggingLevelError LoggingLevel = "error"
+
+const LoggingLevelInfo LoggingLevel = "info"
+
+const LoggingLevelNotice LoggingLevel = "notice"
+
+const LoggingLevelWarning LoggingLevel = "warning"
+
 var ErrEventNotFound = errors.New("event not found")
 
 var ErrSessionNotFound = errors.New("session not found")
@@ -1949,6 +1965,7 @@ type CapabilityConfig struct {
 	Tools     bool
 	Resources bool
 	Prompts   bool
+	Logging   bool
 }
 
 type ContentBlock struct {
@@ -1993,6 +2010,15 @@ type Icon struct {
 type InitialSessionListenerBudgetOptions struct {
 	SafetyBuffer time.Duration
 	MaxDuration  time.Duration
+}
+
+type LoggingLevel string
+
+type LoggingLevelHook func(context.Context, LoggingLevelRequest) error
+
+type LoggingLevelRequest struct {
+	SessionID string       `json:"sessionId"`
+	Level     LoggingLevel `json:"level"`
 }
 
 type MemorySessionStore struct {
@@ -2115,6 +2141,7 @@ type Server struct {
 
 	resourceSubscribeHook   ResourceSubscriptionHook
 	resourceUnsubscribeHook ResourceSubscriptionHook
+	loggingLevelHook        LoggingLevelHook
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -2230,6 +2257,8 @@ func WithClock(apptheory.Clock) MemorySessionStoreOption
 func WithInitialSessionListenerBudget(InitialSessionListenerBudgetOptions) ServerOption
 
 func WithLogger(*slog.Logger) ServerOption
+
+func WithLoggingLevelHook(LoggingLevelHook) ServerOption
 
 func WithOriginValidator(OriginValidator) ServerOption
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -165,9 +165,10 @@ CORRECT:
   still replay by logical `Last-Event-ID`, and AppTheory bounds S3 spill reads before byte-count/hash validation
 - treat tool panics as server faults: AppTheory recovers them into sanitized JSON-RPC internal errors, not client-visible
   panic strings
-- keep optional MCP utility capabilities hook-gated: resource subscriptions, logging, and completions are advertised
-  only by AppTheory after the matching hook is configured, and cancellation notifications only cancel tracked
-  in-flight requests for the same session
+- keep optional MCP utility capabilities fail-closed: completions are advertised only by AppTheory after a matching hook
+  is configured, resource subscription and logging methods are hook-gated but their capabilities remain omitted until
+  outbound notification contracts exist, and cancellation notifications only cancel tracked in-flight requests for the
+  same session
 
 INCORRECT:
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -165,6 +165,9 @@ CORRECT:
   still replay by logical `Last-Event-ID`, and AppTheory bounds S3 spill reads before byte-count/hash validation
 - treat tool panics as server faults: AppTheory recovers them into sanitized JSON-RPC internal errors, not client-visible
   panic strings
+- keep optional MCP utility capabilities hook-gated: resource subscriptions, logging, and completions are advertised
+  only by AppTheory after the matching hook is configured, and cancellation notifications only cancel tracked
+  in-flight requests for the same session
 
 INCORRECT:
 
@@ -172,6 +175,8 @@ INCORRECT:
 - assuming `enableStreamTable` alone makes replay durable without `mcp.WithStreamStore(...)`
 - splitting tool results or returning object links to work around stream-store storage limits
 - depending on panic text or duplicate session-create failures as part of product behavior
+- hard-coding `resources.subscribe`, `logging`, or `completions` in a product wrapper before product authorization,
+  tenant policy, and abuse controls are wired
 
 ## Pattern: sanitize user payloads before logging
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -107,6 +107,10 @@ AppTheory currently dispatches these MCP request methods:
 - `tools/call`
 - `resources/list`
 - `resources/read`
+- `resources/subscribe`
+- `resources/unsubscribe`
+- `logging/setLevel`
+- `completion/complete`
 - `prompts/list`
 - `prompts/get`
 
@@ -141,14 +145,85 @@ on the server:
 - if `srv.Registry().Len() > 0` and tools are enabled -> `"tools": {}`
 - if `srv.Resources().Len() > 0` and resources are enabled -> `"resources": {}`
 - if `srv.Prompts().Len() > 0` and prompts are enabled -> `"prompts": {}`
+- if `mcp.WithLoggingLevelHook(...)` is configured and logging is enabled -> `"logging": {}`
+- if `mcp.WithCompletionHooks(...)` has at least one hook and completions are enabled -> `"completions": {}`
 
 The default capability policy enables the implemented surfaces, but registration is still required before they are
 advertised. Use `mcp.WithCapabilityConfig(...)` to withhold an implemented surface for a product rollout.
 
-Unsupported optional MCP capabilities are fail-closed: AppTheory does not advertise `listChanged`, resource
-subscriptions, `logging`, `completions`, or `tasks` until the corresponding framework hook exists and is configured.
+Optional MCP utility capabilities are fail-closed:
+
+- resource subscription support is advertised as `"resources": {"subscribe": true}` only when resources are registered
+  and both hooks are configured with `mcp.WithResourceSubscriptionHooks(...)`
+- `logging` is advertised only when `mcp.WithLoggingLevelHook(...)` is configured
+- `completions` is advertised only when `mcp.WithCompletionHooks(...)` has at least one prompt or resource hook
+- `notifications/cancelled` is accepted for every initialized session, but it only cancels AppTheory-tracked in-flight
+  requests for that session and safely ignores unknown or completed request ids
+- unsupported utility surfaces such as `listChanged` and `tasks` remain omitted until their concrete AppTheory contract
+  exists
+
 Capability construction is also protocol-aware; if a future supported protocol version removes or changes a capability,
 AppTheory omits that capability for sessions negotiated to that version.
+
+Products should not advertise these optional utility capabilities outside AppTheory's initialize response and should not
+enable the hooks for downstream services until product authorization, tenant policy, audit logging, and abuse controls
+are wired. The single path is: configure the AppTheory hook, let AppTheory advertise the capability, and handle the
+request through the hook. Do not hard-code capabilities in a product-specific wrapper.
+
+### Optional utility hooks
+
+Resource subscription hooks:
+
+```go
+srv := mcp.NewServer("my-mcp-server", "dev",
+  mcp.WithResourceSubscriptionHooks(
+    func(ctx context.Context, sub mcp.ResourceSubscription) error {
+      // Persist session-scoped interest in sub.URI.
+      return nil
+    },
+    func(ctx context.Context, sub mcp.ResourceSubscription) error {
+      // Remove session-scoped interest in sub.URI.
+      return nil
+    },
+  ),
+)
+```
+
+`resources/subscribe` and `resources/unsubscribe` fail closed with JSON-RPC `method not found` unless both hooks are
+configured. The hook receives the negotiated MCP session id and the target resource URI.
+
+Logging hooks:
+
+```go
+srv := mcp.NewServer("my-mcp-server", "dev",
+  mcp.WithLoggingLevelHook(func(ctx context.Context, req mcp.LoggingLevelRequest) error {
+    // Store the per-session logging threshold.
+    return nil
+  }),
+)
+```
+
+`logging/setLevel` validates MCP logging levels (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`,
+`emergency`) before invoking the hook.
+
+Completion hooks:
+
+```go
+srv := mcp.NewServer("my-mcp-server", "dev",
+  mcp.WithCompletionHooks(
+    func(ctx context.Context, req mcp.CompletionRequest) (*mcp.CompletionResult, error) {
+      return &mcp.CompletionResult{
+        Completion: mcp.Completion{Values: []string{"python"}},
+      }, nil
+    },
+    nil,
+  ),
+)
+```
+
+`completion/complete` routes prompt references to the first hook and resource references to the second hook. If a
+specific reference type has no configured hook, AppTheory returns JSON-RPC invalid params instead of broadening to a
+fallback hook.
 
 ---
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -145,7 +145,6 @@ on the server:
 - if `srv.Registry().Len() > 0` and tools are enabled -> `"tools": {}`
 - if `srv.Resources().Len() > 0` and resources are enabled -> `"resources": {}`
 - if `srv.Prompts().Len() > 0` and prompts are enabled -> `"prompts": {}`
-- if `mcp.WithLoggingLevelHook(...)` is configured and logging is enabled -> `"logging": {}`
 - if `mcp.WithCompletionHooks(...)` has at least one hook and completions are enabled -> `"completions": {}`
 
 The default capability policy enables the implemented surfaces, but registration is still required before they are
@@ -153,9 +152,11 @@ advertised. Use `mcp.WithCapabilityConfig(...)` to withhold an implemented surfa
 
 Optional MCP utility capabilities are fail-closed:
 
-- resource subscription support is advertised as `"resources": {"subscribe": true}` only when resources are registered
-  and both hooks are configured with `mcp.WithResourceSubscriptionHooks(...)`
-- `logging` is advertised only when `mcp.WithLoggingLevelHook(...)` is configured
+- resource subscription hooks are accepted only when both hooks are configured with
+  `mcp.WithResourceSubscriptionHooks(...)`, but `resources.subscribe` is not advertised until AppTheory has a
+  first-class outbound `notifications/resources/updated` contract
+- `logging/setLevel` is accepted only when `mcp.WithLoggingLevelHook(...)` is configured, but `logging` is not
+  advertised until AppTheory has a first-class outbound `notifications/message` contract
 - `completions` is advertised only when `mcp.WithCompletionHooks(...)` has at least one prompt or resource hook
 - `notifications/cancelled` is accepted for every initialized session, but it only cancels AppTheory-tracked in-flight
   requests for that session and safely ignores unknown or completed request ids
@@ -167,8 +168,8 @@ AppTheory omits that capability for sessions negotiated to that version.
 
 Products should not advertise these optional utility capabilities outside AppTheory's initialize response and should not
 enable the hooks for downstream services until product authorization, tenant policy, audit logging, and abuse controls
-are wired. The single path is: configure the AppTheory hook, let AppTheory advertise the capability, and handle the
-request through the hook. Do not hard-code capabilities in a product-specific wrapper.
+are wired. The single path is: configure the AppTheory hook, let AppTheory advertise only capabilities it can deliver
+end-to-end, and handle the request through the hook. Do not hard-code capabilities in a product-specific wrapper.
 
 ### Optional utility hooks
 

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -65,6 +65,11 @@ Important behaviors for Claude compatibility:
   `https://claude.com`); use `mcp.WithOriginValidator(...)` for other browser origins.
 - Tool handler panics are recovered as sanitized JSON-RPC internal errors. Do not rely on panic text reaching the
   client; AppTheory logs it server-side and keeps the MCP server reusable.
+- Optional utility capabilities are hook-gated. Resource subscriptions require
+  `mcp.WithResourceSubscriptionHooks(...)`, logging requires `mcp.WithLoggingLevelHook(...)`, and completions require
+  `mcp.WithCompletionHooks(...)`; AppTheory advertises only the hooks you configure.
+- `notifications/cancelled` cancels matching in-flight AppTheory requests for the same session and safely ignores
+  unknown or already-completed request ids.
 
 Strict transport rollout checklist:
 
@@ -76,6 +81,9 @@ Strict transport rollout checklist:
 - Confirm reconnect uses `GET /mcp` with the latest `Last-Event-ID` for the same session and stream.
 - Treat HTTP `400` responses during canary as compatibility failures to fix in the client, not as server fallbacks to
   loosen.
+- Do not hard-code `resources.subscribe`, `logging`, or `completions` capabilities in a Remote MCP product wrapper.
+  Configure the AppTheory hook, let AppTheory emit the initialize capability, and keep the capability absent until
+  product authorization and tenant policy are ready.
 
 ## 2) Add OAuth protection (Remote MCP auth `2025-06-18`)
 

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -65,9 +65,11 @@ Important behaviors for Claude compatibility:
   `https://claude.com`); use `mcp.WithOriginValidator(...)` for other browser origins.
 - Tool handler panics are recovered as sanitized JSON-RPC internal errors. Do not rely on panic text reaching the
   client; AppTheory logs it server-side and keeps the MCP server reusable.
-- Optional utility capabilities are hook-gated. Resource subscriptions require
-  `mcp.WithResourceSubscriptionHooks(...)`, logging requires `mcp.WithLoggingLevelHook(...)`, and completions require
-  `mcp.WithCompletionHooks(...)`; AppTheory advertises only the hooks you configure.
+- Optional utility methods are hook-gated. Resource subscription requests require
+  `mcp.WithResourceSubscriptionHooks(...)`, logging level requests require `mcp.WithLoggingLevelHook(...)`, and
+  completions require `mcp.WithCompletionHooks(...)`. AppTheory advertises only capabilities it can deliver
+  end-to-end: completions can be advertised with hooks today, while `resources.subscribe` and `logging` remain omitted
+  until the outbound notification contracts for resource updates and log messages exist.
 - `notifications/cancelled` cancels matching in-flight AppTheory requests for the same session and safely ignores
   unknown or already-completed request ids.
 

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T22:49:19Z",
+  "timestamp": "2026-05-14T22:59:55Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T22:37:44Z",
+  "timestamp": "2026-05-14T22:49:19Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T22:24:22Z",
+  "timestamp": "2026-05-14T22:37:44Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T22:59:55Z",
+  "timestamp": "2026-05-14T23:11:42Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-05-14T21:18:35Z",
+  "timestamp": "2026-05-14T22:24:22Z",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"

--- a/runtime/mcp/cancel.go
+++ b/runtime/mcp/cancel.go
@@ -1,0 +1,144 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+)
+
+type cancellationTracker struct {
+	mu       sync.Mutex
+	requests map[string]*cancellationEntry
+}
+
+type cancellationEntry struct {
+	cancel context.CancelFunc
+}
+
+func newCancellationTracker() *cancellationTracker {
+	return &cancellationTracker{
+		requests: make(map[string]*cancellationEntry),
+	}
+}
+
+func (t *cancellationTracker) track(ctx context.Context, sessionID string, requestID any) (context.Context, func()) {
+	if t == nil {
+		return ctx, func() {}
+	}
+	key, ok := cancellationKey(sessionID, requestID)
+	if !ok {
+		return ctx, func() {}
+	}
+
+	trackedCtx, cancel := context.WithCancel(ctx)
+	entry := &cancellationEntry{cancel: cancel}
+	t.mu.Lock()
+	t.requests[key] = entry
+	t.mu.Unlock()
+
+	finish := func() {
+		t.mu.Lock()
+		if t.requests[key] == entry {
+			delete(t.requests, key)
+		}
+		t.mu.Unlock()
+		cancel()
+	}
+	return trackedCtx, finish
+}
+
+func (t *cancellationTracker) cancel(sessionID string, requestID any) bool {
+	if t == nil {
+		return false
+	}
+	key, ok := cancellationKey(sessionID, requestID)
+	if !ok {
+		return false
+	}
+
+	t.mu.Lock()
+	entry := t.requests[key]
+	t.mu.Unlock()
+	if entry == nil || entry.cancel == nil {
+		return false
+	}
+	entry.cancel()
+	return true
+}
+
+func cancellationKey(sessionID string, requestID any) (string, bool) {
+	if sessionID == "" {
+		return "", false
+	}
+	idKey, ok := requestIDKey(requestID)
+	if !ok {
+		return "", false
+	}
+	return sessionID + "\x00" + idKey, true
+}
+
+func requestIDKey(requestID any) (string, bool) {
+	switch id := requestID.(type) {
+	case nil:
+		return "", false
+	case json.RawMessage:
+		raw := bytes.TrimSpace(id)
+		if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+			return "", false
+		}
+		var decoded any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return "", false
+		}
+		return requestIDKey(decoded)
+	default:
+		encoded, err := json.Marshal(id)
+		if err != nil {
+			return "", false
+		}
+		encoded = bytes.TrimSpace(encoded)
+		if len(encoded) == 0 || bytes.Equal(encoded, []byte("null")) {
+			return "", false
+		}
+		return string(encoded), true
+	}
+}
+
+type cancelledNotificationParams struct {
+	RequestID json.RawMessage `json:"requestId"`
+	Reason    string          `json:"reason,omitempty"`
+}
+
+func (s *Server) trackRequest(ctx context.Context, sessionID string, requestID any) (context.Context, func()) {
+	if s == nil || s.cancellations == nil {
+		return ctx, func() {}
+	}
+	return s.cancellations.track(ctx, sessionID, requestID)
+}
+
+func (s *Server) handleCancellationNotification(ctx context.Context, sess *Session, req *Request) {
+	if s == nil || sess == nil {
+		return
+	}
+	var params cancelledNotificationParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.logCancellationDebug(ctx, "invalid cancellation params", "sessionId", sess.ID, "error", err)
+		return
+	}
+	if len(bytes.TrimSpace(params.RequestID)) == 0 {
+		s.logCancellationDebug(ctx, "missing cancellation request id", "sessionId", sess.ID)
+		return
+	}
+	if !s.cancellations.cancel(sess.ID, params.RequestID) {
+		s.logCancellationDebug(ctx, "cancellation target not active", "sessionId", sess.ID)
+	}
+}
+
+func (s *Server) logCancellationDebug(ctx context.Context, msg string, args ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	s.logger.Log(ctx, slog.LevelDebug, msg, args...)
+}

--- a/runtime/mcp/cancel_test.go
+++ b/runtime/mcp/cancel_test.go
@@ -116,6 +116,54 @@ func TestCancellationNotification_IgnoresUnknownAndCompletedRequests(t *testing.
 	}
 }
 
+func TestStreamingCancellation_PersistsTerminalResponseAfterContextCancelled(t *testing.T) {
+	s := NewServer("test", "1.0.0")
+	store := &contextSensitiveStreamStore{}
+	s.streamStore = store
+
+	if err := s.Registry().RegisterStreamingTool(ToolDef{
+		Name:        "canceled",
+		Description: "returns when its context is canceled",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(ctx context.Context, _ json.RawMessage, _ func(SSEEvent)) (*ToolResult, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}); err != nil {
+		t.Fatalf("register streaming tool: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := &Request{
+		JSONRPC: jsonrpcVersion,
+		ID:      "stream-req",
+		Method:  methodToolsCall,
+		Params:  mustMarshal(t, toolsCallParams{Name: "canceled", Arguments: json.RawMessage(`{}`)}),
+	}
+
+	finished := false
+	s.runStreamingTool(ctx, "sess-1", "stream-1", req, func() { finished = true })
+
+	if !finished {
+		t.Fatal("expected cancellation tracker finish callback to run")
+	}
+	if !store.closed {
+		t.Fatal("expected canceled stream to be closed with a non-canceled storage context")
+	}
+	if len(store.appends) == 0 {
+		t.Fatal("expected terminal JSON-RPC response to be appended after cancellation")
+	}
+
+	var terminal Response
+	if err := json.Unmarshal(store.appends[len(store.appends)-1], &terminal); err != nil {
+		t.Fatalf("unmarshal terminal response: %v", err)
+	}
+	if terminal.Error == nil || terminal.Error.Code != CodeServerError {
+		t.Fatalf("expected canceled streaming tool to append server error, got %+v", terminal.Error)
+	}
+}
+
 func TestRequestIDKey_CanonicalizesJSONIDs(t *testing.T) {
 	tracker := newCancellationTracker()
 	ctx, finish := tracker.track(context.Background(), "sess-1", float64(1))
@@ -133,4 +181,46 @@ func TestRequestIDKey_CanonicalizesJSONIDs(t *testing.T) {
 	if tracker.cancel("sess-1", json.RawMessage(`null`)) {
 		t.Fatalf("expected null request id to be ignored")
 	}
+}
+
+type contextSensitiveStreamStore struct {
+	appends []json.RawMessage
+	closed  bool
+}
+
+func (s *contextSensitiveStreamStore) Create(ctx context.Context, _ string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return "stream-1", nil
+}
+
+func (s *contextSensitiveStreamStore) Append(ctx context.Context, _, _ string, data json.RawMessage) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	s.appends = append(s.appends, append(json.RawMessage(nil), data...))
+	return "event-1", nil
+}
+
+func (s *contextSensitiveStreamStore) Close(ctx context.Context, _, _ string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.closed = true
+	return nil
+}
+
+func (s *contextSensitiveStreamStore) Subscribe(context.Context, string, string, string) (<-chan StreamEvent, error) {
+	ch := make(chan StreamEvent)
+	close(ch)
+	return ch, nil
+}
+
+func (s *contextSensitiveStreamStore) StreamForEvent(context.Context, string, string) (string, error) {
+	return "", ErrEventNotFound
+}
+
+func (s *contextSensitiveStreamStore) DeleteSession(context.Context, string) error {
+	return nil
 }

--- a/runtime/mcp/cancel_test.go
+++ b/runtime/mcp/cancel_test.go
@@ -1,0 +1,136 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestCancellationNotification_CancelsBufferedRequest(t *testing.T) {
+	s := NewServer("test", "1.0.0")
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "slow",
+		Description: "waits for cancellation",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(ctx context.Context, _ json.RawMessage) (*ToolResult, error) {
+		close(started)
+		select {
+		case <-ctx.Done():
+			close(canceled)
+			return nil, ctx.Err()
+		case <-release:
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "done"}}}, nil
+		}
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+	defer close(release)
+
+	resultCh := make(chan *Response, 1)
+	go func() {
+		params := mustMarshal(t, toolsCallParams{Name: "slow", Arguments: json.RawMessage(`{}`)})
+		body := mustMarshal(t, Request{JSONRPC: "2.0", ID: "req-1", Method: methodToolsCall, Params: params})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
+		if err != nil {
+			t.Errorf("invoke tools/call: %v", err)
+			return
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Errorf("parse tools/call: %v", err)
+			return
+		}
+		resultCh <- rpcResp
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
+	}
+
+	cancelReq := mustMarshal(t, Request{
+		JSONRPC: "2.0",
+		Method:  methodNotificationsCancelled,
+		Params:  mustMarshal(t, map[string]any{"requestId": "req-1", "reason": "test"}),
+	})
+	cancelResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", cancelReq, headers)
+	if err != nil {
+		t.Fatalf("invoke cancellation notification: %v", err)
+	}
+	if cancelResp.Status != 202 {
+		t.Fatalf("cancellation status: got %d want 202 (body=%s)", cancelResp.Status, string(cancelResp.Body))
+	}
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("tool context was not canceled")
+	}
+	select {
+	case rpcResp := <-resultCh:
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeServerError {
+			t.Fatalf("expected canceled tool to return server error, got: %+v", rpcResp.Error)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tool call did not return after cancellation")
+	}
+}
+
+func TestCancellationNotification_IgnoresUnknownAndCompletedRequests(t *testing.T) {
+	s := NewServer("test", "1.0.0")
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	pingReq := mustMarshal(t, Request{JSONRPC: "2.0", ID: "done", Method: methodPing})
+	pingResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", pingReq, headers)
+	if err != nil {
+		t.Fatalf("invoke ping: %v", err)
+	}
+	if pingResp.Status != 200 {
+		t.Fatalf("ping status: got %d want 200", pingResp.Status)
+	}
+
+	for _, requestID := range []string{"missing", "done"} {
+		cancelReq := mustMarshal(t, Request{
+			JSONRPC: "2.0",
+			Method:  methodNotificationsCancelled,
+			Params:  mustMarshal(t, map[string]any{"requestId": requestID}),
+		})
+		cancelResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", cancelReq, headers)
+		if err != nil {
+			t.Fatalf("invoke cancellation notification for %q: %v", requestID, err)
+		}
+		if cancelResp.Status != 202 {
+			t.Fatalf("cancellation status for %q: got %d want 202", requestID, cancelResp.Status)
+		}
+	}
+}
+
+func TestRequestIDKey_CanonicalizesJSONIDs(t *testing.T) {
+	tracker := newCancellationTracker()
+	ctx, finish := tracker.track(context.Background(), "sess-1", float64(1))
+	defer finish()
+
+	if !tracker.cancel("sess-1", json.RawMessage(`1.0`)) {
+		t.Fatalf("expected numeric JSON-RPC ids to canonicalize")
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("tracked context was not canceled")
+	}
+
+	if tracker.cancel("sess-1", json.RawMessage(`null`)) {
+		t.Fatalf("expected null request id to be ignored")
+	}
+}

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -5,15 +5,16 @@ package mcp
 //
 // The config is intentionally limited to surfaces that AppTheory currently
 // implements. Unsupported MCP sub-capabilities such as listChanged and tasks
-// are omitted until their concrete hooks exist. Resource subscription, logging,
-// and completion support are advertised only when their explicit hooks are
-// configured. That keeps capability negotiation fail-closed instead of allowing
-// callers to overclaim unsupported behavior.
+// are omitted until their concrete hooks exist. Resource subscription and
+// logging are also omitted until AppTheory has a first-class outbound
+// notification contract for notifications/resources/updated and
+// notifications/message. Completion support is advertised only when its
+// explicit hooks are configured. That keeps capability negotiation fail-closed
+// instead of allowing callers to overclaim unsupported behavior.
 type CapabilityConfig struct {
 	Tools       bool
 	Resources   bool
 	Prompts     bool
-	Logging     bool
 	Completions bool
 }
 
@@ -23,7 +24,6 @@ const (
 	capabilitySurfaceTools     capabilitySurface = "tools"
 	capabilitySurfaceResources capabilitySurface = "resources"
 	capabilitySurfacePrompts   capabilitySurface = "prompts"
-	capabilitySurfaceLogging   capabilitySurface = "logging"
 	capabilitySurfaceComplete  capabilitySurface = "completions"
 )
 
@@ -37,7 +37,6 @@ func DefaultCapabilityConfig() CapabilityConfig {
 		Tools:       true,
 		Resources:   true,
 		Prompts:     true,
-		Logging:     true,
 		Completions: true,
 	}
 }
@@ -56,7 +55,6 @@ func (s *Server) initializeCapabilities(protocolVersion string) map[string]any {
 	s.addToolsCapability(protocolVersion, capabilities)
 	s.addResourcesCapability(protocolVersion, capabilities)
 	s.addPromptsCapability(protocolVersion, capabilities)
-	s.addLoggingCapability(protocolVersion, capabilities)
 	s.addCompletionsCapability(protocolVersion, capabilities)
 
 	return capabilities
@@ -70,23 +68,13 @@ func (s *Server) addToolsCapability(protocolVersion string, capabilities map[str
 
 func (s *Server) addResourcesCapability(protocolVersion string, capabilities map[string]any) {
 	if s.capabilities.Resources && protocolSupportsCapability(protocolVersion, capabilitySurfaceResources) && s.resourceRegistry.Len() > 0 {
-		resourceCaps := map[string]any{}
-		if s.hasResourceSubscriptionHooks() {
-			resourceCaps["subscribe"] = true
-		}
-		capabilities["resources"] = resourceCaps
+		capabilities["resources"] = map[string]any{}
 	}
 }
 
 func (s *Server) addPromptsCapability(protocolVersion string, capabilities map[string]any) {
 	if s.capabilities.Prompts && protocolSupportsCapability(protocolVersion, capabilitySurfacePrompts) && s.promptRegistry.Len() > 0 {
 		capabilities["prompts"] = map[string]any{}
-	}
-}
-
-func (s *Server) addLoggingCapability(protocolVersion string, capabilities map[string]any) {
-	if s.capabilities.Logging && protocolSupportsCapability(protocolVersion, capabilitySurfaceLogging) && s.loggingLevelHook != nil {
-		capabilities["logging"] = map[string]any{}
 	}
 }
 

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -4,10 +4,11 @@ package mcp
 // advertised during initialize.
 //
 // The config is intentionally limited to surfaces that AppTheory currently
-// implements. Optional MCP sub-capabilities such as listChanged, resource
-// subscriptions, logging, completions, and tasks are omitted until their
-// concrete hooks exist. That keeps capability negotiation fail-closed instead
-// of allowing callers to overclaim unsupported behavior.
+// implements. Optional MCP sub-capabilities such as listChanged, logging,
+// completions, and tasks are omitted until their concrete hooks exist. Resource
+// subscription support is advertised only when both subscription hooks are
+// configured. That keeps capability negotiation fail-closed instead of allowing
+// callers to overclaim unsupported behavior.
 type CapabilityConfig struct {
 	Tools     bool
 	Resources bool
@@ -50,13 +51,21 @@ func (s *Server) initializeCapabilities(protocolVersion string) map[string]any {
 		capabilities["tools"] = map[string]any{}
 	}
 	if s.capabilities.Resources && protocolSupportsCapability(protocolVersion, capabilitySurfaceResources) && s.resourceRegistry.Len() > 0 {
-		capabilities["resources"] = map[string]any{}
+		resourceCaps := map[string]any{}
+		if s.hasResourceSubscriptionHooks() {
+			resourceCaps["subscribe"] = true
+		}
+		capabilities["resources"] = resourceCaps
 	}
 	if s.capabilities.Prompts && protocolSupportsCapability(protocolVersion, capabilitySurfacePrompts) && s.promptRegistry.Len() > 0 {
 		capabilities["prompts"] = map[string]any{}
 	}
 
 	return capabilities
+}
+
+func (s *Server) hasResourceSubscriptionHooks() bool {
+	return s.resourceSubscribeHook != nil && s.resourceUnsubscribeHook != nil
 }
 
 func protocolSupportsCapability(pv string, _ capabilitySurface) bool {

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -13,6 +13,7 @@ type CapabilityConfig struct {
 	Tools     bool
 	Resources bool
 	Prompts   bool
+	Logging   bool
 }
 
 type capabilitySurface string
@@ -21,6 +22,7 @@ const (
 	capabilitySurfaceTools     capabilitySurface = "tools"
 	capabilitySurfaceResources capabilitySurface = "resources"
 	capabilitySurfacePrompts   capabilitySurface = "prompts"
+	capabilitySurfaceLogging   capabilitySurface = "logging"
 )
 
 // DefaultCapabilityConfig returns the default MCP capability policy.
@@ -33,6 +35,7 @@ func DefaultCapabilityConfig() CapabilityConfig {
 		Tools:     true,
 		Resources: true,
 		Prompts:   true,
+		Logging:   true,
 	}
 }
 
@@ -59,6 +62,9 @@ func (s *Server) initializeCapabilities(protocolVersion string) map[string]any {
 	}
 	if s.capabilities.Prompts && protocolSupportsCapability(protocolVersion, capabilitySurfacePrompts) && s.promptRegistry.Len() > 0 {
 		capabilities["prompts"] = map[string]any{}
+	}
+	if s.capabilities.Logging && protocolSupportsCapability(protocolVersion, capabilitySurfaceLogging) && s.loggingLevelHook != nil {
+		capabilities["logging"] = map[string]any{}
 	}
 
 	return capabilities

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -4,16 +4,17 @@ package mcp
 // advertised during initialize.
 //
 // The config is intentionally limited to surfaces that AppTheory currently
-// implements. Optional MCP sub-capabilities such as listChanged, logging,
-// completions, and tasks are omitted until their concrete hooks exist. Resource
-// subscription support is advertised only when both subscription hooks are
+// implements. Unsupported MCP sub-capabilities such as listChanged and tasks
+// are omitted until their concrete hooks exist. Resource subscription, logging,
+// and completion support are advertised only when their explicit hooks are
 // configured. That keeps capability negotiation fail-closed instead of allowing
 // callers to overclaim unsupported behavior.
 type CapabilityConfig struct {
-	Tools     bool
-	Resources bool
-	Prompts   bool
-	Logging   bool
+	Tools       bool
+	Resources   bool
+	Prompts     bool
+	Logging     bool
+	Completions bool
 }
 
 type capabilitySurface string
@@ -23,6 +24,7 @@ const (
 	capabilitySurfaceResources capabilitySurface = "resources"
 	capabilitySurfacePrompts   capabilitySurface = "prompts"
 	capabilitySurfaceLogging   capabilitySurface = "logging"
+	capabilitySurfaceComplete  capabilitySurface = "completions"
 )
 
 // DefaultCapabilityConfig returns the default MCP capability policy.
@@ -32,10 +34,11 @@ const (
 // registered resource, and prompts require at least one registered prompt.
 func DefaultCapabilityConfig() CapabilityConfig {
 	return CapabilityConfig{
-		Tools:     true,
-		Resources: true,
-		Prompts:   true,
-		Logging:   true,
+		Tools:       true,
+		Resources:   true,
+		Prompts:     true,
+		Logging:     true,
+		Completions: true,
 	}
 }
 
@@ -50,9 +53,22 @@ func WithCapabilityConfig(config CapabilityConfig) ServerOption {
 func (s *Server) initializeCapabilities(protocolVersion string) map[string]any {
 	capabilities := map[string]any{}
 
+	s.addToolsCapability(protocolVersion, capabilities)
+	s.addResourcesCapability(protocolVersion, capabilities)
+	s.addPromptsCapability(protocolVersion, capabilities)
+	s.addLoggingCapability(protocolVersion, capabilities)
+	s.addCompletionsCapability(protocolVersion, capabilities)
+
+	return capabilities
+}
+
+func (s *Server) addToolsCapability(protocolVersion string, capabilities map[string]any) {
 	if s.capabilities.Tools && protocolSupportsCapability(protocolVersion, capabilitySurfaceTools) && s.registry.Len() > 0 {
 		capabilities["tools"] = map[string]any{}
 	}
+}
+
+func (s *Server) addResourcesCapability(protocolVersion string, capabilities map[string]any) {
 	if s.capabilities.Resources && protocolSupportsCapability(protocolVersion, capabilitySurfaceResources) && s.resourceRegistry.Len() > 0 {
 		resourceCaps := map[string]any{}
 		if s.hasResourceSubscriptionHooks() {
@@ -60,18 +76,32 @@ func (s *Server) initializeCapabilities(protocolVersion string) map[string]any {
 		}
 		capabilities["resources"] = resourceCaps
 	}
+}
+
+func (s *Server) addPromptsCapability(protocolVersion string, capabilities map[string]any) {
 	if s.capabilities.Prompts && protocolSupportsCapability(protocolVersion, capabilitySurfacePrompts) && s.promptRegistry.Len() > 0 {
 		capabilities["prompts"] = map[string]any{}
 	}
+}
+
+func (s *Server) addLoggingCapability(protocolVersion string, capabilities map[string]any) {
 	if s.capabilities.Logging && protocolSupportsCapability(protocolVersion, capabilitySurfaceLogging) && s.loggingLevelHook != nil {
 		capabilities["logging"] = map[string]any{}
 	}
+}
 
-	return capabilities
+func (s *Server) addCompletionsCapability(protocolVersion string, capabilities map[string]any) {
+	if s.capabilities.Completions && protocolSupportsCapability(protocolVersion, capabilitySurfaceComplete) && s.hasCompletionHooks() {
+		capabilities["completions"] = map[string]any{}
+	}
 }
 
 func (s *Server) hasResourceSubscriptionHooks() bool {
 	return s.resourceSubscribeHook != nil && s.resourceUnsubscribeHook != nil
+}
+
+func (s *Server) hasCompletionHooks() bool {
+	return s.promptCompletionHook != nil || s.resourceCompletionHook != nil
 }
 
 func protocolSupportsCapability(pv string, _ capabilitySurface) bool {

--- a/runtime/mcp/capability_test.go
+++ b/runtime/mcp/capability_test.go
@@ -158,6 +158,47 @@ func TestInitializeCapabilities_ExplicitConfigCanDisableLogging(t *testing.T) {
 	}
 }
 
+func TestInitializeCapabilities_AdvertisesCompletionsOnlyWithHook(t *testing.T) {
+	s := NewServer("test", "dev", WithCompletionHooks(
+		func(context.Context, CompletionRequest) (*CompletionResult, error) {
+			return &CompletionResult{Completion: Completion{Values: []string{}}}, nil
+		},
+		nil,
+	))
+
+	caps := initializeCapabilityMap(t, s)
+	completions, ok := caps["completions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected completions capability object: %+v", caps)
+	}
+	if len(completions) != 0 {
+		t.Fatalf("expected empty completions capability object: %+v", completions)
+	}
+}
+
+func TestInitializeCapabilities_ExplicitConfigCanDisableCompletions(t *testing.T) {
+	s := NewServer("test", "dev",
+		WithCapabilityConfig(CapabilityConfig{
+			Tools:       true,
+			Resources:   true,
+			Prompts:     true,
+			Logging:     true,
+			Completions: false,
+		}),
+		WithCompletionHooks(
+			func(context.Context, CompletionRequest) (*CompletionResult, error) {
+				return &CompletionResult{Completion: Completion{Values: []string{}}}, nil
+			},
+			nil,
+		),
+	)
+
+	caps := initializeCapabilityMap(t, s)
+	if _, ok := caps["completions"]; ok {
+		t.Fatalf("expected explicitly disabled completions capability to be omitted: %+v", caps)
+	}
+}
+
 func assertNoUnsupportedSubCapabilities(t *testing.T, name string, raw any) {
 	t.Helper()
 	obj, ok := raw.(map[string]any)

--- a/runtime/mcp/capability_test.go
+++ b/runtime/mcp/capability_test.go
@@ -104,7 +104,7 @@ func TestInitializeCapabilities_ExplicitConfigCanDisableSurface(t *testing.T) {
 	}
 }
 
-func TestInitializeCapabilities_AdvertisesResourceSubscribeOnlyWithHooks(t *testing.T) {
+func TestInitializeCapabilities_OmitsResourceSubscribeUntilOutboundNotificationsExist(t *testing.T) {
 	s := NewServer("test", "dev", WithResourceSubscriptionHooks(
 		func(context.Context, ResourceSubscription) error { return nil },
 		func(context.Context, ResourceSubscription) error { return nil },
@@ -120,41 +120,20 @@ func TestInitializeCapabilities_AdvertisesResourceSubscribeOnlyWithHooks(t *test
 	if !ok {
 		t.Fatalf("expected resources capability object: %+v", caps)
 	}
-	if resources["subscribe"] != true {
-		t.Fatalf("expected resources.subscribe capability with hooks: %+v", resources)
+	if _, ok := resources["subscribe"]; ok {
+		t.Fatalf("did not expect resources.subscribe without outbound notification contract: %+v", resources)
 	}
 	if _, ok := resources["listChanged"]; ok {
 		t.Fatalf("did not expect resources.listChanged overclaim: %+v", resources)
 	}
 }
 
-func TestInitializeCapabilities_AdvertisesLoggingOnlyWithHook(t *testing.T) {
+func TestInitializeCapabilities_OmitsLoggingUntilOutboundNotificationsExist(t *testing.T) {
 	s := NewServer("test", "dev", WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error { return nil }))
 
 	caps := initializeCapabilityMap(t, s)
-	logging, ok := caps["logging"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected logging capability object: %+v", caps)
-	}
-	if len(logging) != 0 {
-		t.Fatalf("expected empty logging capability object: %+v", logging)
-	}
-}
-
-func TestInitializeCapabilities_ExplicitConfigCanDisableLogging(t *testing.T) {
-	s := NewServer("test", "dev",
-		WithCapabilityConfig(CapabilityConfig{
-			Tools:     true,
-			Resources: true,
-			Prompts:   true,
-			Logging:   false,
-		}),
-		WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error { return nil }),
-	)
-
-	caps := initializeCapabilityMap(t, s)
 	if _, ok := caps["logging"]; ok {
-		t.Fatalf("expected explicitly disabled logging capability to be omitted: %+v", caps)
+		t.Fatalf("did not expect logging without outbound notification contract: %+v", caps)
 	}
 }
 
@@ -182,7 +161,6 @@ func TestInitializeCapabilities_ExplicitConfigCanDisableCompletions(t *testing.T
 			Tools:       true,
 			Resources:   true,
 			Prompts:     true,
-			Logging:     true,
 			Completions: false,
 		}),
 		WithCompletionHooks(

--- a/runtime/mcp/capability_test.go
+++ b/runtime/mcp/capability_test.go
@@ -104,6 +104,30 @@ func TestInitializeCapabilities_ExplicitConfigCanDisableSurface(t *testing.T) {
 	}
 }
 
+func TestInitializeCapabilities_AdvertisesResourceSubscribeOnlyWithHooks(t *testing.T) {
+	s := NewServer("test", "dev", WithResourceSubscriptionHooks(
+		func(context.Context, ResourceSubscription) error { return nil },
+		func(context.Context, ResourceSubscription) error { return nil },
+	))
+	if err := s.Resources().RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, func(context.Context) ([]ResourceContent, error) {
+		return []ResourceContent{{URI: "file://x", Text: "x"}}, nil
+	}); err != nil {
+		t.Fatalf("register resource: %v", err)
+	}
+
+	caps := initializeCapabilityMap(t, s)
+	resources, ok := caps["resources"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected resources capability object: %+v", caps)
+	}
+	if resources["subscribe"] != true {
+		t.Fatalf("expected resources.subscribe capability with hooks: %+v", resources)
+	}
+	if _, ok := resources["listChanged"]; ok {
+		t.Fatalf("did not expect resources.listChanged overclaim: %+v", resources)
+	}
+}
+
 func assertNoUnsupportedSubCapabilities(t *testing.T, name string, raw any) {
 	t.Helper()
 	obj, ok := raw.(map[string]any)

--- a/runtime/mcp/capability_test.go
+++ b/runtime/mcp/capability_test.go
@@ -128,6 +128,36 @@ func TestInitializeCapabilities_AdvertisesResourceSubscribeOnlyWithHooks(t *test
 	}
 }
 
+func TestInitializeCapabilities_AdvertisesLoggingOnlyWithHook(t *testing.T) {
+	s := NewServer("test", "dev", WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error { return nil }))
+
+	caps := initializeCapabilityMap(t, s)
+	logging, ok := caps["logging"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected logging capability object: %+v", caps)
+	}
+	if len(logging) != 0 {
+		t.Fatalf("expected empty logging capability object: %+v", logging)
+	}
+}
+
+func TestInitializeCapabilities_ExplicitConfigCanDisableLogging(t *testing.T) {
+	s := NewServer("test", "dev",
+		WithCapabilityConfig(CapabilityConfig{
+			Tools:     true,
+			Resources: true,
+			Prompts:   true,
+			Logging:   false,
+		}),
+		WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error { return nil }),
+	)
+
+	caps := initializeCapabilityMap(t, s)
+	if _, ok := caps["logging"]; ok {
+		t.Fatalf("expected explicitly disabled logging capability to be omitted: %+v", caps)
+	}
+}
+
 func assertNoUnsupportedSubCapabilities(t *testing.T, name string, raw any) {
 	t.Helper()
 	obj, ok := raw.(map[string]any)

--- a/runtime/mcp/completion.go
+++ b/runtime/mcp/completion.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	completionRefPrompt   = "ref/prompt"
+	completionRefResource = "ref/resource"
+)
+
+// CompletionRef identifies the prompt or resource template being completed.
+type CompletionRef struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+	URI  string `json:"uri,omitempty"`
+}
+
+// CompletionArgument identifies the argument currently being completed.
+type CompletionArgument struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// CompletionContext carries optional previously-resolved arguments.
+type CompletionContext struct {
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+// CompletionRequest is passed to completion hooks.
+type CompletionRequest struct {
+	SessionID string             `json:"sessionId"`
+	Ref       CompletionRef      `json:"ref"`
+	Argument  CompletionArgument `json:"argument"`
+	Context   CompletionContext  `json:"context,omitempty"`
+}
+
+// Completion contains completion values returned to the client.
+type Completion struct {
+	Values  []string `json:"values"`
+	Total   *int     `json:"total,omitempty"`
+	HasMore *bool    `json:"hasMore,omitempty"`
+}
+
+// CompletionResult is the MCP completion/complete result.
+type CompletionResult struct {
+	Completion Completion `json:"completion"`
+}
+
+// CompletionHook handles a prompt or resource completion request.
+type CompletionHook func(ctx context.Context, req CompletionRequest) (*CompletionResult, error)
+
+type completionCompleteParams struct {
+	Ref      CompletionRef      `json:"ref"`
+	Argument CompletionArgument `json:"argument"`
+	Context  CompletionContext  `json:"context,omitempty"`
+}
+
+func (s *Server) handleCompletionComplete(ctx context.Context, req *Request, sessionID string) *Response {
+	if !s.hasCompletionHooks() {
+		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: "+req.Method)
+	}
+
+	var params completionCompleteParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: "+err.Error())
+	}
+	if params.Ref.Type == "" {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing ref.type")
+	}
+	if params.Argument.Name == "" {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing argument.name")
+	}
+
+	hook, errResp := s.completionHookForRef(req.ID, params.Ref)
+	if errResp != nil {
+		return errResp
+	}
+
+	result, err := hook(ctx, CompletionRequest{
+		SessionID: sessionID,
+		Ref:       params.Ref,
+		Argument:  params.Argument,
+		Context:   params.Context,
+	})
+	if err != nil {
+		return NewErrorResponse(req.ID, CodeServerError, err.Error())
+	}
+	if errResp := validateCompletionResult(req.ID, result); errResp != nil {
+		return errResp
+	}
+
+	return NewResultResponse(req.ID, result)
+}
+
+func (s *Server) completionHookForRef(reqID any, ref CompletionRef) (CompletionHook, *Response) {
+	switch ref.Type {
+	case completionRefPrompt:
+		if ref.Name == "" {
+			return nil, NewErrorResponse(reqID, CodeInvalidParams, "Invalid params: missing ref.name")
+		}
+		if s.promptCompletionHook == nil {
+			return nil, NewErrorResponse(reqID, CodeInvalidParams, "Invalid params: prompt completions not configured")
+		}
+		return s.promptCompletionHook, nil
+	case completionRefResource:
+		if ref.URI == "" {
+			return nil, NewErrorResponse(reqID, CodeInvalidParams, "Invalid params: missing ref.uri")
+		}
+		if s.resourceCompletionHook == nil {
+			return nil, NewErrorResponse(reqID, CodeInvalidParams, "Invalid params: resource completions not configured")
+		}
+		return s.resourceCompletionHook, nil
+	default:
+		return nil, NewErrorResponse(reqID, CodeInvalidParams, fmt.Sprintf("Invalid params: unknown ref.type %q", ref.Type))
+	}
+}
+
+func validateCompletionResult(reqID any, result *CompletionResult) *Response {
+	if result == nil {
+		return NewErrorResponse(reqID, CodeServerError, "completion hook returned nil result")
+	}
+	if result.Completion.Values == nil {
+		return NewErrorResponse(reqID, CodeServerError, "completion hook returned nil values")
+	}
+	if len(result.Completion.Values) > 100 {
+		return NewErrorResponse(reqID, CodeServerError, "completion hook returned too many values")
+	}
+	return nil
+}

--- a/runtime/mcp/completion_test.go
+++ b/runtime/mcp/completion_test.go
@@ -1,0 +1,249 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestCompletionHooks_RoutePromptAndResource(t *testing.T) {
+	hasMore := false
+	total := 2
+	var promptReq CompletionRequest
+	var resourceReq CompletionRequest
+	s := NewServer("test", "1.0.0", WithCompletionHooks(
+		func(_ context.Context, req CompletionRequest) (*CompletionResult, error) {
+			promptReq = req
+			return &CompletionResult{Completion: Completion{Values: []string{"go"}, Total: &total, HasMore: &hasMore}}, nil
+		},
+		func(_ context.Context, req CompletionRequest) (*CompletionResult, error) {
+			resourceReq = req
+			return &CompletionResult{Completion: Completion{Values: []string{"file://x"}}}, nil
+		},
+	))
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	promptParams := mustMarshal(t, map[string]any{
+		"ref":      map[string]any{"type": completionRefPrompt, "name": "review"},
+		"argument": map[string]any{"name": "language", "value": "g"},
+		"context":  map[string]any{"arguments": map[string]string{"mode": "strict"}},
+	})
+	promptReqBody := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodCompletionComplete, Params: promptParams})
+	promptResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", promptReqBody, headers)
+	if err != nil {
+		t.Fatalf("invoke prompt completion: %v", err)
+	}
+	rpcPrompt, err := parseJSONRPCResponse(promptResp)
+	if err != nil {
+		t.Fatalf("parse prompt completion: %v", err)
+	}
+	if rpcPrompt.Error != nil {
+		t.Fatalf("unexpected prompt completion error: %+v", rpcPrompt.Error)
+	}
+	if promptReq.SessionID != sessionID || promptReq.Ref.Name != "review" || promptReq.Argument.Name != "language" || promptReq.Argument.Value != "g" {
+		t.Fatalf("unexpected prompt hook request: %+v", promptReq)
+	}
+	if promptReq.Context.Arguments["mode"] != "strict" {
+		t.Fatalf("unexpected prompt context: %+v", promptReq.Context)
+	}
+
+	resourceParams := mustMarshal(t, map[string]any{
+		"ref":      map[string]any{"type": completionRefResource, "uri": "file:///{path}"},
+		"argument": map[string]any{"name": "path", "value": "x"},
+	})
+	resourceReqBody := mustMarshal(t, Request{JSONRPC: "2.0", ID: 2, Method: methodCompletionComplete, Params: resourceParams})
+	resourceResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", resourceReqBody, headers)
+	if err != nil {
+		t.Fatalf("invoke resource completion: %v", err)
+	}
+	rpcResource, err := parseJSONRPCResponse(resourceResp)
+	if err != nil {
+		t.Fatalf("parse resource completion: %v", err)
+	}
+	if rpcResource.Error != nil {
+		t.Fatalf("unexpected resource completion error: %+v", rpcResource.Error)
+	}
+	if resourceReq.SessionID != sessionID || resourceReq.Ref.URI != "file:///{path}" || resourceReq.Argument.Name != "path" {
+		t.Fatalf("unexpected resource hook request: %+v", resourceReq)
+	}
+}
+
+func TestCompletionHooks_FailClosedWhenUnconfigured(t *testing.T) {
+	s := NewServer("test", "1.0.0")
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	params := mustMarshal(t, map[string]any{
+		"ref":      map[string]any{"type": completionRefPrompt, "name": "review"},
+		"argument": map[string]any{"name": "language", "value": "g"},
+	})
+	req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodCompletionComplete, Params: params})
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+	if err != nil {
+		t.Fatalf("invoke completion/complete: %v", err)
+	}
+	rpcResp, err := parseJSONRPCResponse(resp)
+	if err != nil {
+		t.Fatalf("parse completion/complete: %v", err)
+	}
+	if rpcResp.Error == nil || rpcResp.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected method-not-found for unconfigured completions, got: %+v", rpcResp.Error)
+	}
+}
+
+func TestCompletionHooks_ValidateParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+	}{
+		{name: "missing ref type", params: map[string]any{
+			"ref":      map[string]any{"name": "review"},
+			"argument": map[string]any{"name": "language", "value": "g"},
+		}},
+		{name: "missing prompt name", params: map[string]any{
+			"ref":      map[string]any{"type": completionRefPrompt},
+			"argument": map[string]any{"name": "language", "value": "g"},
+		}},
+		{name: "missing resource uri", params: map[string]any{
+			"ref":      map[string]any{"type": completionRefResource},
+			"argument": map[string]any{"name": "path", "value": "x"},
+		}},
+		{name: "unknown ref type", params: map[string]any{
+			"ref":      map[string]any{"type": "ref/tool", "name": "echo"},
+			"argument": map[string]any{"name": "arg", "value": "x"},
+		}},
+		{name: "missing argument name", params: map[string]any{
+			"ref":      map[string]any{"type": completionRefPrompt, "name": "review"},
+			"argument": map[string]any{"value": "g"},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("test", "1.0.0", WithCompletionHooks(
+				func(context.Context, CompletionRequest) (*CompletionResult, error) {
+					return &CompletionResult{Completion: Completion{Values: []string{}}}, nil
+				},
+				func(context.Context, CompletionRequest) (*CompletionResult, error) {
+					return &CompletionResult{Completion: Completion{Values: []string{}}}, nil
+				},
+			))
+			sessionID := initializeSession(t, s)
+			headers := sessionHeaders(sessionID)
+			headers["accept"] = []string{"application/json, text/event-stream"}
+
+			req := mustMarshal(t, Request{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  methodCompletionComplete,
+				Params:  mustMarshal(t, tt.params),
+			})
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+			if err != nil {
+				t.Fatalf("invoke completion/complete: %v", err)
+			}
+			rpcResp, err := parseJSONRPCResponse(resp)
+			if err != nil {
+				t.Fatalf("parse completion/complete: %v", err)
+			}
+			if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams {
+				t.Fatalf("expected invalid params, got: %+v", rpcResp.Error)
+			}
+		})
+	}
+}
+
+func TestCompletionHooks_MissingSpecificHookIsInvalidParams(t *testing.T) {
+	s := NewServer("test", "1.0.0", WithCompletionHooks(
+		func(context.Context, CompletionRequest) (*CompletionResult, error) {
+			return &CompletionResult{Completion: Completion{Values: []string{}}}, nil
+		},
+		nil,
+	))
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	params := mustMarshal(t, map[string]any{
+		"ref":      map[string]any{"type": completionRefResource, "uri": "file:///{path}"},
+		"argument": map[string]any{"name": "path", "value": "x"},
+	})
+	req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodCompletionComplete, Params: params})
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+	if err != nil {
+		t.Fatalf("invoke completion/complete: %v", err)
+	}
+	rpcResp, err := parseJSONRPCResponse(resp)
+	if err != nil {
+		t.Fatalf("parse completion/complete: %v", err)
+	}
+	if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams {
+		t.Fatalf("expected invalid params for missing resource hook, got: %+v", rpcResp.Error)
+	}
+}
+
+func TestCompletionHooks_HookAndResultErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		hook CompletionHook
+	}{
+		{
+			name: "hook error",
+			hook: func(context.Context, CompletionRequest) (*CompletionResult, error) {
+				return nil, errors.New("completion denied")
+			},
+		},
+		{
+			name: "nil result",
+			hook: func(context.Context, CompletionRequest) (*CompletionResult, error) {
+				return nil, nil
+			},
+		},
+		{
+			name: "nil values",
+			hook: func(context.Context, CompletionRequest) (*CompletionResult, error) {
+				return &CompletionResult{}, nil
+			},
+		},
+		{
+			name: "too many values",
+			hook: func(context.Context, CompletionRequest) (*CompletionResult, error) {
+				values := make([]string, 101)
+				for i := range values {
+					values[i] = fmt.Sprintf("value-%d", i)
+				}
+				return &CompletionResult{Completion: Completion{Values: values}}, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("test", "1.0.0", WithCompletionHooks(tt.hook, nil))
+			sessionID := initializeSession(t, s)
+			headers := sessionHeaders(sessionID)
+			headers["accept"] = []string{"application/json, text/event-stream"}
+
+			params := mustMarshal(t, map[string]any{
+				"ref":      map[string]any{"type": completionRefPrompt, "name": "review"},
+				"argument": map[string]any{"name": "language", "value": "g"},
+			})
+			req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodCompletionComplete, Params: params})
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+			if err != nil {
+				t.Fatalf("invoke completion/complete: %v", err)
+			}
+			rpcResp, err := parseJSONRPCResponse(resp)
+			if err != nil {
+				t.Fatalf("parse completion/complete: %v", err)
+			}
+			if rpcResp.Error == nil || rpcResp.Error.Code != CodeServerError {
+				t.Fatalf("expected server error, got: %+v", rpcResp.Error)
+			}
+		})
+	}
+}

--- a/runtime/mcp/logging.go
+++ b/runtime/mcp/logging.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// LoggingLevel is an MCP logging level.
+type LoggingLevel string
+
+const (
+	LoggingLevelDebug     LoggingLevel = "debug"
+	LoggingLevelInfo      LoggingLevel = "info"
+	LoggingLevelNotice    LoggingLevel = "notice"
+	LoggingLevelWarning   LoggingLevel = "warning"
+	LoggingLevelError     LoggingLevel = "error"
+	LoggingLevelCritical  LoggingLevel = "critical"
+	LoggingLevelAlert     LoggingLevel = "alert"
+	LoggingLevelEmergency LoggingLevel = "emergency"
+)
+
+// LoggingLevelRequest identifies a logging/setLevel request for a session.
+type LoggingLevelRequest struct {
+	SessionID string       `json:"sessionId"`
+	Level     LoggingLevel `json:"level"`
+}
+
+// LoggingLevelHook handles a logging/setLevel request.
+type LoggingLevelHook func(ctx context.Context, req LoggingLevelRequest) error
+
+type loggingSetLevelParams struct {
+	Level LoggingLevel `json:"level"`
+}
+
+func validLoggingLevel(level LoggingLevel) bool {
+	switch level {
+	case LoggingLevelDebug,
+		LoggingLevelInfo,
+		LoggingLevelNotice,
+		LoggingLevelWarning,
+		LoggingLevelError,
+		LoggingLevelCritical,
+		LoggingLevelAlert,
+		LoggingLevelEmergency:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) handleLoggingSetLevel(ctx context.Context, req *Request, sessionID string) *Response {
+	if s.loggingLevelHook == nil {
+		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: "+req.Method)
+	}
+
+	var params loggingSetLevelParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: "+err.Error())
+	}
+	if params.Level == "" {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing level")
+	}
+	if !validLoggingLevel(params.Level) {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: unknown logging level")
+	}
+
+	if err := s.loggingLevelHook(ctx, LoggingLevelRequest{SessionID: sessionID, Level: params.Level}); err != nil {
+		return NewErrorResponse(req.ID, CodeServerError, err.Error())
+	}
+
+	return NewResultResponse(req.ID, map[string]any{})
+}

--- a/runtime/mcp/logging_test.go
+++ b/runtime/mcp/logging_test.go
@@ -1,0 +1,142 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestLoggingSetLevelHook_RoundTrip(t *testing.T) {
+	var got LoggingLevelRequest
+	s := NewServer("test", "1.0.0", WithLoggingLevelHook(func(_ context.Context, req LoggingLevelRequest) error {
+		got = req
+		return nil
+	}))
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	params := mustMarshal(t, map[string]any{"level": string(LoggingLevelNotice)})
+	req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodLoggingSetLevel, Params: params})
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+	if err != nil {
+		t.Fatalf("invoke logging/setLevel: %v", err)
+	}
+	rpcResp, err := parseJSONRPCResponse(resp)
+	if err != nil {
+		t.Fatalf("parse logging/setLevel: %v", err)
+	}
+	if rpcResp.Error != nil {
+		t.Fatalf("unexpected error: %+v", rpcResp.Error)
+	}
+	if got.SessionID != sessionID || got.Level != LoggingLevelNotice {
+		t.Fatalf("unexpected logging hook request: %+v", got)
+	}
+}
+
+func TestLoggingSetLevelHook_FailClosedWhenUnconfigured(t *testing.T) {
+	s := NewServer("test", "1.0.0")
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	params := mustMarshal(t, map[string]any{"level": string(LoggingLevelInfo)})
+	req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodLoggingSetLevel, Params: params})
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+	if err != nil {
+		t.Fatalf("invoke logging/setLevel: %v", err)
+	}
+	rpcResp, err := parseJSONRPCResponse(resp)
+	if err != nil {
+		t.Fatalf("parse logging/setLevel: %v", err)
+	}
+	if rpcResp.Error == nil || rpcResp.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected method-not-found for unconfigured logging, got: %+v", rpcResp.Error)
+	}
+}
+
+func TestLoggingSetLevelHook_ValidatesLevelsAndErrors(t *testing.T) {
+	t.Run("missing level", func(t *testing.T) {
+		s := NewServer("test", "1.0.0", WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error { return nil }))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodLoggingSetLevel, Params: mustMarshal(t, map[string]any{})})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke logging/setLevel: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse logging/setLevel: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams {
+			t.Fatalf("expected invalid params for missing level, got: %+v", rpcResp.Error)
+		}
+	})
+
+	t.Run("unknown level", func(t *testing.T) {
+		s := NewServer("test", "1.0.0", WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error { return nil }))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		params := mustMarshal(t, map[string]any{"level": "verbose"})
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodLoggingSetLevel, Params: params})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke logging/setLevel: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse logging/setLevel: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams {
+			t.Fatalf("expected invalid params for unknown level, got: %+v", rpcResp.Error)
+		}
+	})
+
+	t.Run("hook error", func(t *testing.T) {
+		s := NewServer("test", "1.0.0", WithLoggingLevelHook(func(context.Context, LoggingLevelRequest) error {
+			return errors.New("logging denied")
+		}))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		params := mustMarshal(t, map[string]any{"level": string(LoggingLevelError)})
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodLoggingSetLevel, Params: params})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke logging/setLevel: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse logging/setLevel: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeServerError {
+			t.Fatalf("expected server error for hook error, got: %+v", rpcResp.Error)
+		}
+	})
+}
+
+func TestValidLoggingLevel(t *testing.T) {
+	for _, level := range []LoggingLevel{
+		LoggingLevelDebug,
+		LoggingLevelInfo,
+		LoggingLevelNotice,
+		LoggingLevelWarning,
+		LoggingLevelError,
+		LoggingLevelCritical,
+		LoggingLevelAlert,
+		LoggingLevelEmergency,
+	} {
+		if !validLoggingLevel(level) {
+			t.Fatalf("expected %q to be valid", level)
+		}
+	}
+	if validLoggingLevel("verbose") {
+		t.Fatalf("expected verbose to be invalid")
+	}
+}

--- a/runtime/mcp/resource.go
+++ b/runtime/mcp/resource.go
@@ -30,6 +30,17 @@ type ResourceContent struct {
 // ResourceHandler resolves and returns the content for a resource.
 type ResourceHandler func(ctx context.Context) ([]ResourceContent, error)
 
+// ResourceSubscription identifies a resource subscription request for a
+// session.
+type ResourceSubscription struct {
+	SessionID string `json:"sessionId"`
+	URI       string `json:"uri"`
+}
+
+// ResourceSubscriptionHook handles a resources/subscribe or
+// resources/unsubscribe request.
+type ResourceSubscriptionHook func(ctx context.Context, sub ResourceSubscription) error
+
 type registeredResource struct {
 	def     ResourceDef
 	handler ResourceHandler

--- a/runtime/mcp/resources_handlers.go
+++ b/runtime/mcp/resources_handlers.go
@@ -9,6 +9,10 @@ type resourcesReadParams struct {
 	URI string `json:"uri"`
 }
 
+type resourcesSubscriptionParams struct {
+	URI string `json:"uri"`
+}
+
 func (s *Server) handleResourcesList(req *Request) *Response {
 	resources := s.resourceRegistry.List()
 	return NewResultResponse(req.ID, map[string]any{
@@ -36,4 +40,37 @@ func (s *Server) handleResourcesRead(ctx context.Context, req *Request) *Respons
 	return NewResultResponse(req.ID, map[string]any{
 		"contents": contents,
 	})
+}
+
+func (s *Server) handleResourcesSubscribe(ctx context.Context, req *Request, sessionID string) *Response {
+	return s.handleResourceSubscription(ctx, req, sessionID, s.resourceSubscribeHook)
+}
+
+func (s *Server) handleResourcesUnsubscribe(ctx context.Context, req *Request, sessionID string) *Response {
+	return s.handleResourceSubscription(ctx, req, sessionID, s.resourceUnsubscribeHook)
+}
+
+func (s *Server) handleResourceSubscription(
+	ctx context.Context,
+	req *Request,
+	sessionID string,
+	hook ResourceSubscriptionHook,
+) *Response {
+	if !s.hasResourceSubscriptionHooks() || hook == nil {
+		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: "+req.Method)
+	}
+
+	var params resourcesSubscriptionParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: "+err.Error())
+	}
+	if params.URI == "" {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing uri")
+	}
+
+	if err := hook(ctx, ResourceSubscription{SessionID: sessionID, URI: params.URI}); err != nil {
+		return NewErrorResponse(req.ID, CodeServerError, err.Error())
+	}
+
+	return NewResultResponse(req.ID, map[string]any{})
 }

--- a/runtime/mcp/resources_prompts_test.go
+++ b/runtime/mcp/resources_prompts_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 )
 
@@ -208,6 +209,145 @@ func TestResourcesRead_NotFoundIsInvalidParams(t *testing.T) {
 	if rpcRead.Error == nil || rpcRead.Error.Code != CodeInvalidParams {
 		t.Fatalf("expected invalid params error, got: %+v", rpcRead.Error)
 	}
+}
+
+func TestResourceSubscriptionHooks_RoundTrip(t *testing.T) {
+	var subscribed ResourceSubscription
+	var unsubscribed ResourceSubscription
+	s := NewServer("test", "1.0.0", WithResourceSubscriptionHooks(
+		func(_ context.Context, sub ResourceSubscription) error {
+			subscribed = sub
+			return nil
+		},
+		func(_ context.Context, sub ResourceSubscription) error {
+			unsubscribed = sub
+			return nil
+		},
+	))
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	params := mustMarshal(t, map[string]any{"uri": "file://hello.txt"})
+	subscribeReq := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})
+	subscribeResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", subscribeReq, headers)
+	if err != nil {
+		t.Fatalf("invoke resources/subscribe: %v", err)
+	}
+	rpcSubscribe, err := parseJSONRPCResponse(subscribeResp)
+	if err != nil {
+		t.Fatalf("parse resources/subscribe: %v", err)
+	}
+	if rpcSubscribe.Error != nil {
+		t.Fatalf("unexpected subscribe error: %+v", rpcSubscribe.Error)
+	}
+	if subscribed.SessionID != sessionID || subscribed.URI != "file://hello.txt" {
+		t.Fatalf("unexpected subscribe hook request: %+v", subscribed)
+	}
+
+	unsubscribeReq := mustMarshal(t, Request{JSONRPC: "2.0", ID: 2, Method: methodResourcesUnsubscribe, Params: params})
+	unsubscribeResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", unsubscribeReq, headers)
+	if err != nil {
+		t.Fatalf("invoke resources/unsubscribe: %v", err)
+	}
+	rpcUnsubscribe, err := parseJSONRPCResponse(unsubscribeResp)
+	if err != nil {
+		t.Fatalf("parse resources/unsubscribe: %v", err)
+	}
+	if rpcUnsubscribe.Error != nil {
+		t.Fatalf("unexpected unsubscribe error: %+v", rpcUnsubscribe.Error)
+	}
+	if unsubscribed.SessionID != sessionID || unsubscribed.URI != "file://hello.txt" {
+		t.Fatalf("unexpected unsubscribe hook request: %+v", unsubscribed)
+	}
+}
+
+func TestResourceSubscriptionHooks_FailClosedWhenUnconfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []ServerOption
+	}{
+		{name: "no hooks"},
+		{
+			name: "partial hooks",
+			opts: []ServerOption{WithResourceSubscriptionHooks(
+				func(context.Context, ResourceSubscription) error { return nil },
+				nil,
+			)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("test", "1.0.0", tt.opts...)
+			sessionID := initializeSession(t, s)
+			headers := sessionHeaders(sessionID)
+			headers["accept"] = []string{"application/json, text/event-stream"}
+
+			params := mustMarshal(t, map[string]any{"uri": "file://hello.txt"})
+			req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+			if err != nil {
+				t.Fatalf("invoke resources/subscribe: %v", err)
+			}
+			rpcResp, err := parseJSONRPCResponse(resp)
+			if err != nil {
+				t.Fatalf("parse resources/subscribe: %v", err)
+			}
+			if rpcResp.Error == nil || rpcResp.Error.Code != CodeMethodNotFound {
+				t.Fatalf("expected method-not-found for unconfigured subscribe, got: %+v", rpcResp.Error)
+			}
+		})
+	}
+}
+
+func TestResourceSubscriptionHooks_ValidateParamsAndErrors(t *testing.T) {
+	t.Run("missing uri", func(t *testing.T) {
+		s := NewServer("test", "1.0.0", WithResourceSubscriptionHooks(
+			func(context.Context, ResourceSubscription) error { return nil },
+			func(context.Context, ResourceSubscription) error { return nil },
+		))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: json.RawMessage(`{}`)})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke resources/subscribe: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse resources/subscribe: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams {
+			t.Fatalf("expected invalid params for missing uri, got: %+v", rpcResp.Error)
+		}
+	})
+
+	t.Run("hook error", func(t *testing.T) {
+		s := NewServer("test", "1.0.0", WithResourceSubscriptionHooks(
+			func(context.Context, ResourceSubscription) error { return errors.New("subscribe denied") },
+			func(context.Context, ResourceSubscription) error { return nil },
+		))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		params := mustMarshal(t, map[string]any{"uri": "file://hello.txt"})
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke resources/subscribe: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse resources/subscribe: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeServerError {
+			t.Fatalf("expected server error for hook error, got: %+v", rpcResp.Error)
+		}
+	})
 }
 
 func TestPromptsGet_NotFoundIsInvalidParams(t *testing.T) {

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -1311,27 +1311,28 @@ func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, re
 }
 
 func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID string, req *Request, finish func()) {
+	storeCtx := context.WithoutCancel(ctx)
 	defer finish()
 	defer func() {
-		if err := s.streamStore.Close(ctx, sessionID, streamID); err != nil {
+		if err := s.streamStore.Close(storeCtx, sessionID, streamID); err != nil {
 			s.logger.ErrorContext(ctx, "stream store close error", "sessionId", sessionID, "streamId", streamID, "error", err)
 		}
 	}()
 	defer func() {
 		if r := recover(); r != nil {
 			s.logger.ErrorContext(ctx, "streaming tool panic", "sessionId", sessionID, "streamId", streamID, "panic", r)
-			s.appendStreamResponseOrDeliveryError(ctx, sessionID, streamID, req.ID, NewErrorResponse(req.ID, CodeInternalError, "internal error"))
+			s.appendStreamResponseOrDeliveryError(storeCtx, sessionID, streamID, req.ID, NewErrorResponse(req.ID, CodeInternalError, "internal error"))
 		}
 	}()
 
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		resp := NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: "+err.Error())
-		s.appendStreamResponseOrDeliveryError(ctx, sessionID, streamID, req.ID, resp)
+		s.appendStreamResponseOrDeliveryError(storeCtx, sessionID, streamID, req.ID, resp)
 		return
 	}
 	if params.Name == "" {
-		s.appendStreamResponseOrDeliveryError(ctx, sessionID, streamID, req.ID, NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing tool name"))
+		s.appendStreamResponseOrDeliveryError(storeCtx, sessionID, streamID, req.ID, NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing tool name"))
 		return
 	}
 
@@ -1356,7 +1357,7 @@ func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID strin
 		if err != nil {
 			return
 		}
-		if _, err := s.streamStore.Append(ctx, sessionID, streamID, notificationBytes); err != nil {
+		if _, err := s.streamStore.Append(storeCtx, sessionID, streamID, notificationBytes); err != nil {
 			s.logger.ErrorContext(ctx, "stream store append error", "sessionId", sessionID, "streamId", streamID, "error", err)
 		}
 	}
@@ -1370,7 +1371,7 @@ func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID strin
 		finalResp = NewResultResponse(req.ID, result)
 	}
 
-	s.appendStreamResponseOrDeliveryError(ctx, sessionID, streamID, req.ID, finalResp)
+	s.appendStreamResponseOrDeliveryError(storeCtx, sessionID, streamID, req.ID, finalResp)
 }
 
 func progressFromSSEEvent(ev SSEEvent, fallbackProgress float64) (progress float64, total any, message string) {

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -39,6 +39,7 @@ const (
 	methodResourcesRead            = "resources/read"
 	methodResourcesSubscribe       = "resources/subscribe"
 	methodResourcesUnsubscribe     = "resources/unsubscribe"
+	methodLoggingSetLevel          = "logging/setLevel"
 	methodPromptsList              = "prompts/list"
 	methodPromptsGet               = "prompts/get"
 )
@@ -71,6 +72,7 @@ type Server struct {
 
 	resourceSubscribeHook   ResourceSubscriptionHook
 	resourceUnsubscribeHook ResourceSubscriptionHook
+	loggingLevelHook        LoggingLevelHook
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -145,6 +147,14 @@ func WithResourceSubscriptionHooks(subscribe, unsubscribe ResourceSubscriptionHo
 	return func(s *Server) {
 		s.resourceSubscribeHook = subscribe
 		s.resourceUnsubscribeHook = unsubscribe
+	}
+}
+
+// WithLoggingLevelHook enables logging/setLevel support through an explicit
+// hook.
+func WithLoggingLevelHook(hook LoggingLevelHook) ServerOption {
+	return func(s *Server) {
+		s.loggingLevelHook = hook
 	}
 }
 
@@ -548,6 +558,8 @@ func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocol
 		return s.handleResourcesSubscribe(ctx, req, sessionID)
 	case methodResourcesUnsubscribe:
 		return s.handleResourcesUnsubscribe(ctx, req, sessionID)
+	case methodLoggingSetLevel:
+		return s.handleLoggingSetLevel(ctx, req, sessionID)
 	case methodPromptsList:
 		return s.handlePromptsList(req)
 	case methodPromptsGet:
@@ -574,6 +586,7 @@ func methodAllowedForProtocol(pv string, method string) bool {
 		methodResourcesRead,
 		methodResourcesSubscribe,
 		methodResourcesUnsubscribe,
+		methodLoggingSetLevel,
 		methodPromptsList,
 		methodPromptsGet:
 		return true

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -66,6 +66,7 @@ type Server struct {
 	promptRegistry   *PromptRegistry
 	sessionStore     SessionStore
 	streamStore      StreamStore
+	cancellations    *cancellationTracker
 	idGen            apptheory.IDGenerator
 	logger           *slog.Logger
 	originValidator  OriginValidator
@@ -194,6 +195,7 @@ func NewServer(name, version string, opts ...ServerOption) *Server {
 		promptRegistry:   NewPromptRegistry(),
 		sessionStore:     NewMemorySessionStore(),
 		streamStore:      NewMemoryStreamStore(),
+		cancellations:    newCancellationTracker(),
 		idGen:            apptheory.RandomIDGenerator{},
 		logger:           slog.Default(),
 		originValidator:  AllowOrigins("https://claude.ai", "https://claude.com"),
@@ -853,7 +855,9 @@ func (s *Server) runBatchRequests(
 			}
 		}
 
-		responses = append(responses, s.dispatchForProtocol(ctx, req, sessionProtocolVersion(sess), sessionID))
+		requestCtx, finish := s.trackRequest(ctx, sessionID, req.ID)
+		responses = append(responses, s.dispatchForProtocol(requestCtx, req, sessionProtocolVersion(sess), sessionID))
+		finish()
 	}
 
 	return createdSessionID, responses
@@ -1230,8 +1234,7 @@ func (s *Server) handleNotification(ctx context.Context, sess *Session, req *Req
 			s.logger.ErrorContext(ctx, "failed to persist session", "sessionId", sess.ID, "error", err)
 		}
 	case methodNotificationsCancelled:
-		// Accepted for spec compliance; cancellation wiring is handled by higher-level
-		// async implementations (e.g. theory-mcp).
+		s.handleCancellationNotification(ctx, sess, req)
 	default:
 	}
 }
@@ -1248,7 +1251,10 @@ func (s *Server) handleRequestHTTP(
 		return s.handleToolsCallStream(ctx, sessionID, req)
 	}
 
-	resp := s.dispatchForProtocol(ctx, req, requestPV, sessionID)
+	requestCtx, finish := s.trackRequest(ctx, sessionID, req.ID)
+	defer finish()
+
+	resp := s.dispatchForProtocol(requestCtx, req, requestPV, sessionID)
 	return s.marshalSingleResponse(resp, sessionID, false)
 }
 
@@ -1273,8 +1279,10 @@ func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, re
 		return s.marshalSingleResponse(resp, sessionID, false)
 	}
 
+	toolCtx, finish := s.trackRequest(context.WithoutCancel(ctx), sessionID, req.ID)
 	streamID, err := s.streamStore.Create(ctx, sessionID)
 	if err != nil {
+		finish()
 		s.logger.ErrorContext(ctx, "stream store error", "error", err)
 		return internalServerError(), nil
 	}
@@ -1282,6 +1290,7 @@ func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, re
 	// Persist an empty-data priming event before any tool output so a client
 	// that disconnects immediately can resume this stream with Last-Event-ID.
 	if _, primeErr := s.streamStore.Append(ctx, sessionID, streamID, nil); primeErr != nil {
+		finish()
 		s.logger.ErrorContext(ctx, "stream prime error", "sessionId", sessionID, "streamId", streamID, "error", primeErr)
 		if closeErr := s.streamStore.Close(context.WithoutCancel(ctx), sessionID, streamID); closeErr != nil {
 			s.logger.WarnContext(ctx, "stream prime cleanup error", "sessionId", sessionID, "streamId", streamID, "error", closeErr)
@@ -1290,8 +1299,7 @@ func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, re
 	}
 
 	// Run the tool out-of-band so disconnects do not cancel execution.
-	toolCtx := context.WithoutCancel(ctx)
-	go s.runStreamingTool(toolCtx, sessionID, streamID, req)
+	go s.runStreamingTool(toolCtx, sessionID, streamID, req, finish)
 
 	events, err := s.streamStore.Subscribe(ctx, sessionID, streamID, "")
 	if err != nil {
@@ -1302,7 +1310,8 @@ func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, re
 	return s.streamToSSE(ctx, sessionID, events)
 }
 
-func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID string, req *Request) {
+func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID string, req *Request, finish func()) {
+	defer finish()
 	defer func() {
 		if err := s.streamStore.Close(ctx, sessionID, streamID); err != nil {
 			s.logger.ErrorContext(ctx, "stream store close error", "sessionId", sessionID, "streamId", streamID, "error", err)

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -40,6 +40,7 @@ const (
 	methodResourcesSubscribe       = "resources/subscribe"
 	methodResourcesUnsubscribe     = "resources/unsubscribe"
 	methodLoggingSetLevel          = "logging/setLevel"
+	methodCompletionComplete       = "completion/complete"
 	methodPromptsList              = "prompts/list"
 	methodPromptsGet               = "prompts/get"
 )
@@ -73,6 +74,8 @@ type Server struct {
 	resourceSubscribeHook   ResourceSubscriptionHook
 	resourceUnsubscribeHook ResourceSubscriptionHook
 	loggingLevelHook        LoggingLevelHook
+	promptCompletionHook    CompletionHook
+	resourceCompletionHook  CompletionHook
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -155,6 +158,16 @@ func WithResourceSubscriptionHooks(subscribe, unsubscribe ResourceSubscriptionHo
 func WithLoggingLevelHook(hook LoggingLevelHook) ServerOption {
 	return func(s *Server) {
 		s.loggingLevelHook = hook
+	}
+}
+
+// WithCompletionHooks enables completion/complete support through explicit
+// prompt and resource hooks. At least one hook must be non-nil before the
+// completions capability is advertised.
+func WithCompletionHooks(promptHook, resourceHook CompletionHook) ServerOption {
+	return func(s *Server) {
+		s.promptCompletionHook = promptHook
+		s.resourceCompletionHook = resourceHook
 	}
 }
 
@@ -560,6 +573,8 @@ func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocol
 		return s.handleResourcesUnsubscribe(ctx, req, sessionID)
 	case methodLoggingSetLevel:
 		return s.handleLoggingSetLevel(ctx, req, sessionID)
+	case methodCompletionComplete:
+		return s.handleCompletionComplete(ctx, req, sessionID)
 	case methodPromptsList:
 		return s.handlePromptsList(req)
 	case methodPromptsGet:
@@ -587,6 +602,7 @@ func methodAllowedForProtocol(pv string, method string) bool {
 		methodResourcesSubscribe,
 		methodResourcesUnsubscribe,
 		methodLoggingSetLevel,
+		methodCompletionComplete,
 		methodPromptsList,
 		methodPromptsGet:
 		return true

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -37,6 +37,8 @@ const (
 	methodToolsCall                = "tools/call"
 	methodResourcesList            = "resources/list"
 	methodResourcesRead            = "resources/read"
+	methodResourcesSubscribe       = "resources/subscribe"
+	methodResourcesUnsubscribe     = "resources/unsubscribe"
 	methodPromptsList              = "prompts/list"
 	methodPromptsGet               = "prompts/get"
 )
@@ -66,6 +68,9 @@ type Server struct {
 	logger           *slog.Logger
 	originValidator  OriginValidator
 	capabilities     CapabilityConfig
+
+	resourceSubscribeHook   ResourceSubscriptionHook
+	resourceUnsubscribeHook ResourceSubscriptionHook
 
 	initialSessionListenerBudget *initialSessionListenerBudgetConfig
 }
@@ -128,6 +133,18 @@ func WithLogger(logger *slog.Logger) ServerOption {
 func WithOriginValidator(v OriginValidator) ServerOption {
 	return func(s *Server) {
 		s.originValidator = v
+	}
+}
+
+// WithResourceSubscriptionHooks enables resources/subscribe and
+// resources/unsubscribe support through explicit hooks.
+//
+// Both hooks must be non-nil before the resource subscribe sub-capability is
+// advertised. The methods still fail closed if either hook is absent.
+func WithResourceSubscriptionHooks(subscribe, unsubscribe ResourceSubscriptionHook) ServerOption {
+	return func(s *Server) {
+		s.resourceSubscribeHook = subscribe
+		s.resourceUnsubscribeHook = unsubscribe
 	}
 }
 
@@ -501,10 +518,10 @@ func (s *Server) handleDELETE(c *apptheory.Context) (*apptheory.Response, error)
 
 // dispatch routes a parsed JSON-RPC request to the appropriate MCP method handler.
 func (s *Server) dispatch(ctx context.Context, req *Request) *Response {
-	return s.dispatchForProtocol(ctx, req, protocolVersion)
+	return s.dispatchForProtocol(ctx, req, protocolVersion, "")
 }
 
-func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocolVersion string) *Response {
+func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocolVersion string, sessionID string) *Response {
 	if !methodAllowedForProtocol(protocolVersion, req.Method) {
 		s.logger.ErrorContext(ctx, "method not found", "method", req.Method, "protocolVersion", protocolVersion)
 		return NewErrorResponse(req.ID, CodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method))
@@ -527,6 +544,10 @@ func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocol
 		return s.handleResourcesList(req)
 	case methodResourcesRead:
 		return s.handleResourcesRead(ctx, req)
+	case methodResourcesSubscribe:
+		return s.handleResourcesSubscribe(ctx, req, sessionID)
+	case methodResourcesUnsubscribe:
+		return s.handleResourcesUnsubscribe(ctx, req, sessionID)
 	case methodPromptsList:
 		return s.handlePromptsList(req)
 	case methodPromptsGet:
@@ -551,6 +572,8 @@ func methodAllowedForProtocol(pv string, method string) bool {
 		methodToolsCall,
 		methodResourcesList,
 		methodResourcesRead,
+		methodResourcesSubscribe,
+		methodResourcesUnsubscribe,
 		methodPromptsList,
 		methodPromptsGet:
 		return true
@@ -801,7 +824,7 @@ func (s *Server) runBatchRequests(
 			}
 		}
 
-		responses = append(responses, s.dispatchForProtocol(ctx, req, sessionProtocolVersion(sess)))
+		responses = append(responses, s.dispatchForProtocol(ctx, req, sessionProtocolVersion(sess), sessionID))
 	}
 
 	return createdSessionID, responses
@@ -1196,7 +1219,7 @@ func (s *Server) handleRequestHTTP(
 		return s.handleToolsCallStream(ctx, sessionID, req)
 	}
 
-	resp := s.dispatchForProtocol(ctx, req, requestPV)
+	resp := s.dispatchForProtocol(ctx, req, requestPV, sessionID)
 	return s.marshalSingleResponse(resp, sessionID, false)
 }
 

--- a/runtime/mcp/server_coverage_more_test.go
+++ b/runtime/mcp/server_coverage_more_test.go
@@ -388,7 +388,7 @@ func TestRunStreamingTool_InvalidParamsAndMissingName_AppendErrorResponse(t *tes
 		ID:      1,
 		Method:  methodToolsCall,
 		Params:  json.RawMessage("{"),
-	})
+	}, func() {})
 
 	ch, err := s.streamStore.Subscribe(context.Background(), sessionID, streamID, "")
 	if err != nil {
@@ -408,7 +408,7 @@ func TestRunStreamingTool_InvalidParamsAndMissingName_AppendErrorResponse(t *tes
 		ID:      2,
 		Method:  methodToolsCall,
 		Params:  mustMarshal(t, map[string]any{"name": ""}),
-	})
+	}, func() {})
 	ch2, err := s.streamStore.Subscribe(context.Background(), sessionID, streamID2, "")
 	if err != nil {
 		t.Fatalf("subscribe2: %v", err)


### PR DESCRIPTION
## Milestone
mcp-utility-hooks — Add capability-gated resource subscription, logging, completion, and cancellation hooks while preserving fail-closed omitted-capability behavior.

## Linear
https://linear.app/theorycloud/project/apptheory-mcp-runtime-prerequisites-for-issue-144-6458c5ddb11c / mcp-utility-hooks

## Tasks
- [x] THE-1009 Add resource subscription hooks
- [x] THE-1010 Add logging level hooks
- [x] THE-1011 Add completion hooks
- [x] THE-1012 Propagate cancellation notifications to in-flight requests
- [x] THE-1013 Document optional utility capability wiring

## Contract impact
Go MCP runtime public optional utility behavior and Go API snapshot updates. Changes are fixture-first within `runtime/mcp` tests for the Go MCP runtime surface; shared HTTP contract fixtures are not changed in this milestone.

## Validation
Commands run:
- Baseline on `staging` 91a8c53: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T22:14:04Z)
- THE-1009: `go test ./runtime/mcp`
- THE-1009: `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh`
- THE-1009: `make test-unit`
- THE-1009: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T22:24:22Z)
- THE-1010: `go test ./runtime/mcp`
- THE-1010: `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh`
- THE-1010: `make test-unit`
- THE-1010: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T22:37:44Z)
- THE-1011: `go test ./runtime/mcp`
- THE-1011: `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh`
- THE-1011: `make test-unit`
- THE-1011: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T22:49:19Z)
- THE-1012: `go test ./runtime/mcp`
- THE-1012: `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh`
- THE-1012: `make test-unit`
- THE-1012: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T22:59:55Z)
- THE-1013: `bash ./scripts/verify-docs-standard.sh` — PASS
- THE-1013: `make test-unit` — PASS
- THE-1013: `make rubric` — PASS on rerun (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T23:11:42Z); first attempt failed SEC-4 because npm audit returned ECONNRESET without a vulnerability report
- Final: `bash ./scripts/verify-docs-standard.sh` — PASS
- Final: `./scripts/verify-contract-tests.sh` — PASS (Go/TS/Python, 121 fixtures each)
- Final: `./scripts/verify-version-alignment.sh` — PASS (1.5.0)
- Final: `make rubric` — PASS (28 pass / 0 fail / 0 blocked, report timestamp 2026-05-14T23:18:01Z)

## Cross-repo notes
This remains AppTheory-owned runtime prerequisite work. theory-mcp-server should only consume these hooks after an AppTheory release and must continue omitting optional utility capabilities until product policy is wired.




