### PR TITLE
fix(release): enforce release PR artifact gates

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,6 +14,35 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (release preflight)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main + premain (release preflight)
+        run: git fetch origin main premain --force
+
+      - name: Set SOURCE_DATE_EPOCH (release preflight)
+        run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: "1.26.3"
+
+      - name: Install golangci-lint (pinned) (release preflight)
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24.13.1"
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.14.3"
+
+      - name: Build + verify before prerelease creation
+        run: make rubric
+
       - name: Release Please (Prerelease)
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,43 @@ jobs:
           # On workflow_dispatch, allow publishing/uploading assets for an existing tag by checking out that tag.
           ref: ${{ inputs.tag_name || github.ref }}
 
+      - name: Checkout (stable release preflight)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main + premain (stable release preflight)
+        if: github.ref == 'refs/heads/main'
+        run: git fetch origin main premain --force
+
+      - name: Set SOURCE_DATE_EPOCH (stable release preflight)
+        if: github.ref == 'refs/heads/main'
+        run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        if: github.ref == 'refs/heads/main'
+        with:
+          go-version: "1.26.3"
+
+      - name: Install golangci-lint (pinned) (stable release preflight)
+        if: github.ref == 'refs/heads/main'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        if: github.ref == 'refs/heads/main'
+        with:
+          node-version: "24.13.1"
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        if: github.ref == 'refs/heads/main'
+        with:
+          python-version: "3.14.3"
+
+      - name: Build + verify before stable release creation
+        if: github.ref == 'refs/heads/main'
+        run: make rubric
+
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
         with:

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -32,10 +32,203 @@ pr_number="${pr_line%%$'\t'*}"
 
 pr_state_line() {
   gh pr view "${pr_number}" \
-    --json state,isDraft \
-    --jq '"\(.state)	\(.isDraft)"' \
+    --json state,isDraft,headRefOid \
+    --jq '"\(.state)	\(.isDraft)	\(.headRefOid)"' \
     2>/dev/null || true
 }
+
+ensure_release_pr_is_draft() {
+  local context="$1"
+  local current_pr_line
+  current_pr_line="$(pr_state_line)"
+  if [[ -z "${current_pr_line}" ]]; then
+    echo "sync-release-pr-generated: FAIL (PR #${pr_number} disappeared ${context})"
+    exit 1
+  fi
+
+  local current_pr_state
+  local current_pr_is_draft
+  current_pr_state="${current_pr_line%%$'\t'*}"
+  current_pr_is_draft="${current_pr_line#*$'\t'}"
+  current_pr_is_draft="${current_pr_is_draft%%$'\t'*}"
+
+  if [[ "${current_pr_state}" != "OPEN" ]]; then
+    echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} ${context})"
+    exit 1
+  fi
+
+  if [[ "${current_pr_is_draft}" != "true" ]]; then
+    echo "sync-release-pr-generated: drafting PR #${pr_number} ${context}"
+    gh pr ready "${pr_number}" --undo
+
+    current_pr_line="$(pr_state_line)"
+    current_pr_is_draft="${current_pr_line#*$'\t'}"
+    current_pr_is_draft="${current_pr_is_draft%%$'\t'*}"
+    if [[ "${current_pr_is_draft}" != "true" ]]; then
+      echo "sync-release-pr-generated: FAIL (PR #${pr_number} could not be made draft ${context})"
+      exit 1
+    fi
+  fi
+}
+
+wait_for_required_checks() {
+  local timeout_seconds="${RELEASE_PR_CHECK_TIMEOUT_SECONDS:-2400}"
+  local interval_seconds="${RELEASE_PR_CHECK_INTERVAL_SECONDS:-15}"
+  local required_checks="${RELEASE_PR_READY_CHECKS:-}"
+  if [[ -z "${required_checks}" ]]; then
+    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)\nRubric (full gate set)'
+  fi
+
+  local deadline=$((SECONDS + timeout_seconds))
+
+  while true; do
+    local checks_json
+    local checks_file
+    checks_file="$(mktemp)"
+    if ! gh pr checks "${pr_number}" --json name,bucket,startedAt,completedAt,workflow >"${checks_file}" 2>/dev/null; then
+      # `gh pr checks` exits 8 while checks are pending, but still prints the
+      # JSON payload. Only synthesize an empty payload when no JSON was emitted.
+      if [[ ! -s "${checks_file}" ]]; then
+        printf '[]' >"${checks_file}"
+      fi
+    fi
+    checks_json="$(cat "${checks_file}")"
+    rm -f "${checks_file}"
+
+    local status_file
+    status_file="$(mktemp)"
+    CHECKS_JSON="${checks_json}" REQUIRED_CHECKS="${required_checks}" python3 - >"${status_file}" <<'PY'
+import json
+import os
+
+checks = json.loads(os.environ.get("CHECKS_JSON") or "[]")
+required = [line for line in os.environ["REQUIRED_CHECKS"].splitlines() if line]
+
+latest = {}
+for check in checks:
+    name = check.get("name", "")
+    if name not in required:
+        continue
+    # `gh pr checks` can report multiple workflow runs for the same PR head.
+    # Keep the newest status per required check.
+    timestamp = check.get("startedAt") or check.get("completedAt") or ""
+    if name not in latest or timestamp >= latest[name][0]:
+        latest[name] = (timestamp, check)
+
+missing = []
+pending = []
+failed = []
+
+for name in required:
+    record = latest.get(name)
+    if record is None:
+        missing.append(name)
+        continue
+    bucket = record[1].get("bucket", "")
+    if bucket == "pass":
+        continue
+    if bucket in {"pending", "skipping", ""}:
+        pending.append(f"{name}={bucket or 'pending'}")
+        continue
+    failed.append(f"{name}={bucket}")
+
+if failed:
+    print("fail")
+    print("failed: " + ", ".join(failed))
+elif missing or pending:
+    print("pending")
+    if missing:
+        print("missing: " + ", ".join(missing))
+    if pending:
+        print("pending: " + ", ".join(pending))
+else:
+    print("pass")
+PY
+
+    local status
+    status="$(head -n 1 "${status_file}")"
+    local details
+    details="$(tail -n +2 "${status_file}")"
+    rm -f "${status_file}"
+
+    case "${status}" in
+      pass)
+        echo "sync-release-pr-generated: required checks passed for PR #${pr_number}"
+        return 0
+        ;;
+      fail)
+        echo "sync-release-pr-generated: FAIL (required checks failed for PR #${pr_number})"
+        if [[ -n "${details}" ]]; then
+          echo "${details}"
+        fi
+        return 1
+        ;;
+      pending)
+        if (( SECONDS >= deadline )); then
+          echo "sync-release-pr-generated: FAIL (timed out waiting for required checks on PR #${pr_number})"
+          if [[ -n "${details}" ]]; then
+            echo "${details}"
+          fi
+          return 1
+        fi
+        echo "sync-release-pr-generated: waiting for required checks on PR #${pr_number}"
+        if [[ -n "${details}" ]]; then
+          echo "${details}"
+        fi
+        sleep "${interval_seconds}"
+        ;;
+      *)
+        echo "sync-release-pr-generated: FAIL (could not read required check status for PR #${pr_number})"
+        return 1
+        ;;
+    esac
+  done
+}
+
+wait_for_pr_head() {
+  local expected_head="$1"
+  local timeout_seconds="${RELEASE_PR_HEAD_TIMEOUT_SECONDS:-300}"
+  local interval_seconds="${RELEASE_PR_CHECK_INTERVAL_SECONDS:-15}"
+  local deadline=$((SECONDS + timeout_seconds))
+
+  while true; do
+    local current_pr_line
+    current_pr_line="$(pr_state_line)"
+    if [[ -z "${current_pr_line}" ]]; then
+      echo "sync-release-pr-generated: FAIL (PR #${pr_number} disappeared before head ${expected_head} was visible)"
+      exit 1
+    fi
+
+    local current_pr_state
+    local current_pr_head
+    current_pr_state="${current_pr_line%%$'\t'*}"
+    current_pr_head="${current_pr_line##*$'\t'}"
+
+    if [[ "${current_pr_state}" != "OPEN" ]]; then
+      echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} before head ${expected_head} was visible)"
+      exit 1
+    fi
+
+    if [[ "${current_pr_head}" == "${expected_head}" ]]; then
+      echo "sync-release-pr-generated: PR #${pr_number} head is ${expected_head}"
+      return 0
+    fi
+
+    if (( SECONDS >= deadline )); then
+      echo "sync-release-pr-generated: FAIL (timed out waiting for PR #${pr_number} head ${expected_head}; current ${current_pr_head})"
+      exit 1
+    fi
+
+    echo "sync-release-pr-generated: waiting for PR #${pr_number} head ${expected_head} (current ${current_pr_head})"
+    sleep "${interval_seconds}"
+  done
+}
+
+# The release PR must not be mergeable while generated artifacts are still being
+# rewritten. This is the release-lane invariant: release-please version files and
+# generated CDK/jsii artifacts land in the same release PR before it becomes
+# ready for review.
+ensure_release_pr_is_draft "before generated artifacts are synced"
 
 git fetch origin "${release_branch}"
 git switch --detach FETCH_HEAD
@@ -54,26 +247,16 @@ fi
 
 go test ./cdk-go/apptheorycdk
 
-current_pr_line="$(pr_state_line)"
-if [[ -z "${current_pr_line}" ]]; then
-  echo "sync-release-pr-generated: FAIL (PR #${pr_number} disappeared before generated artifacts could be synced)"
-  exit 1
-fi
-
-current_pr_state="${current_pr_line%%$'\t'*}"
-current_pr_is_draft="${current_pr_line#*$'\t'}"
-
-if [[ "${current_pr_state}" != "OPEN" ]]; then
-  echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} before generated artifacts could be synced)"
-  exit 1
-fi
+ensure_release_pr_is_draft "before generated artifacts are pushed"
 
 if [[ "${changed}" == "true" ]]; then
   git push origin HEAD:"${release_branch}"
 fi
 
-if [[ "${current_pr_is_draft}" == "true" ]]; then
-  gh pr ready "${pr_number}"
-fi
+wait_for_pr_head "$(git rev-parse HEAD)"
+wait_for_required_checks
+
+ensure_release_pr_is_draft "before marking generated-artifact-synced PR ready"
+gh pr ready "${pr_number}"
 
 echo "sync-release-pr-generated: PASS (${release_branch} updated)"

--- a/scripts/verify-release-gates.sh
+++ b/scripts/verify-release-gates.sh
@@ -25,6 +25,7 @@ bash ./scripts/verify-branch-version-sync.sh
 ./scripts/verify-contract-tests.sh
 ./scripts/verify-testkit-examples.sh
 bash ./scripts/verify-docs-standard.sh
+bash ./scripts/verify-release-workflows.sh
 bash ./scripts/verify-theorycloud-publish-workflow.sh
 
 echo "release-gates: PASS"

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+python3 - <<'PY'
+from pathlib import Path
+
+
+def require_contains(path: str, needle: str, description: str) -> None:
+    text = Path(path).read_text(encoding="utf-8")
+    if needle not in text:
+        raise SystemExit(f"release-workflows: FAIL ({description}; missing {needle!r} in {path})")
+
+
+def require_order(path: str, first: str, second: str, description: str) -> None:
+    text = Path(path).read_text(encoding="utf-8")
+    first_index = text.find(first)
+    second_index = text.find(second)
+    if first_index == -1:
+        raise SystemExit(f"release-workflows: FAIL ({description}; missing {first!r} in {path})")
+    if second_index == -1:
+        raise SystemExit(f"release-workflows: FAIL ({description}; missing {second!r} in {path})")
+    if first_index >= second_index:
+        raise SystemExit(
+            f"release-workflows: FAIL ({description}; {first!r} must appear before {second!r} in {path})"
+        )
+
+
+require_order(
+    ".github/workflows/prerelease.yml",
+    "Build + verify before prerelease creation",
+    "Release Please (Prerelease)",
+    "prerelease must pass rubric before release-please can create a draft release",
+)
+require_order(
+    ".github/workflows/release.yml",
+    "Build + verify before stable release creation",
+    "Release Please (Stable)",
+    "stable release must pass rubric before release-please can create a draft release",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'gh pr ready "${pr_number}" --undo',
+    "release PR sync must force the release PR back to draft before generated artifact work",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    'ensure_release_pr_is_draft "before generated artifacts are synced"',
+    "scripts/update-cdk-generated.sh",
+    "generated artifact sync must draft-lock the release PR before regenerating artifacts",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    'wait_for_pr_head "$(git rev-parse HEAD)"',
+    "wait_for_required_checks\n\n",
+    "release PR sync must wait for the pushed artifact commit before reading checks",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    "wait_for_required_checks",
+    'gh pr ready "${pr_number}"\n\n',
+    "release PR must wait for required checks before becoming ready",
+)
+
+print("release-workflows: PASS")
+PY


### PR DESCRIPTION
## Summary
- keep release-please PRs draft-locked while generated CDK/jsii artifacts are synchronized
- wait for the release PR head commit and required CI checks before marking the release PR ready
- run full rubric before Release Please can create prerelease/stable draft releases
- add a release workflow verifier to keep these invariants in the rubric gate

## Incident addressed
PR #535 was merged before `scripts/sync-release-pr-generated.sh` could push generated CDK artifacts. That left `premain` at `1.5.0-rc.1` while `cdk-go` and `cdk/lib` still referenced `1.5.0`, causing Go/Rubric failures and creating a draft RC release with no assets.

This PR goes through `staging` and makes the release lane fail closed instead of relying on human timing.

## Validation
- `bash -n scripts/sync-release-pr-generated.sh`
- `bash scripts/verify-release-workflows.sh`
- `make test`
- `make rubric`
- `git diff --check`