### PR TITLE
fix(release): trigger draft release PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - staging

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -224,6 +224,20 @@ wait_for_pr_head() {
   done
 }
 
+trigger_release_pr_checks() {
+  # Release PRs stay draft while generated artifacts are being rewritten so they
+  # cannot be merged in an incomplete state. CI still needs a pull_request event
+  # after the generated-artifact commit is visible, so briefly move the PR to
+  # ready_for_review, then immediately draft-lock it again before waiting for
+  # the required checks to complete.
+  ensure_release_pr_is_draft "before triggering generated-artifact checks"
+
+  echo "sync-release-pr-generated: triggering checks for PR #${pr_number}"
+  gh pr ready "${pr_number}"
+
+  ensure_release_pr_is_draft "after triggering generated-artifact checks"
+}
+
 # The release PR must not be mergeable while generated artifacts are still being
 # rewritten. This is the release-lane invariant: release-please version files and
 # generated CDK/jsii artifacts land in the same release PR before it becomes
@@ -254,6 +268,9 @@ if [[ "${changed}" == "true" ]]; then
 fi
 
 wait_for_pr_head "$(git rev-parse HEAD)"
+# After the generated-artifact head is visible, trigger PR checks while
+# preserving the draft-lock before waiting on them.
+trigger_release_pr_checks
 wait_for_required_checks
 
 ensure_release_pr_is_draft "before marking generated-artifact-synced PR ready"

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -40,6 +40,11 @@ require_order(
     "stable release must pass rubric before release-please can create a draft release",
 )
 require_contains(
+    ".github/workflows/ci.yml",
+    "ready_for_review",
+    "CI must run when release PR sync briefly marks draft release PRs ready to trigger checks",
+)
+require_contains(
     "scripts/sync-release-pr-generated.sh",
     'gh pr ready "${pr_number}" --undo',
     "release PR sync must force the release PR back to draft before generated artifact work",
@@ -66,8 +71,14 @@ require_order(
 require_order(
     "scripts/sync-release-pr-generated.sh",
     'wait_for_pr_head "$(git rev-parse HEAD)"',
+    "After the generated-artifact head is visible",
+    "release PR sync must wait for the pushed artifact commit before triggering checks",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    "After the generated-artifact head is visible",
     "wait_for_required_checks\n\n",
-    "release PR sync must wait for the pushed artifact commit before reading checks",
+    "release PR sync must trigger checks before waiting on them",
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",


### PR DESCRIPTION
## Summary
- run CI on `pull_request.ready_for_review`
- make release PR artifact sync briefly emit `ready_for_review` after the generated-artifact head is visible, then immediately draft-lock again
- extend the release workflow verifier so this check-trigger invariant stays covered by rubric

## Why
The repaired RC release PR (#539) is correctly draft-locked and has generated artifacts synced, but draft PRs created/updated by the release workflow did not get CI checks attached before the sync job started waiting. This keeps the no-merge-during-sync invariant while making the required checks observable.

## Validation
- `bash -n scripts/sync-release-pr-generated.sh scripts/verify-release-workflows.sh`
- `bash scripts/verify-release-workflows.sh`
- `git diff --check`
- `make test`
- `make rubric`
- `git merge-base --is-ancestor origin/main HEAD`
