### PR TITLE
fix(release): build assets before checksums

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -96,6 +96,10 @@ jobs:
         if: steps.release.outputs.release_created == 'true'
         run: make rubric
 
+      - name: Build release assets
+        if: steps.release.outputs.release_created == 'true'
+        run: make build
+
       - name: Generate SHA-256 checksums
         if: steps.release.outputs.release_created == 'true'
         run: scripts/generate-checksums.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,10 @@ jobs:
         if: steps.release.outputs.release_created == 'true'
         run: make rubric
 
+      - name: Build release assets
+        if: steps.release.outputs.release_created == 'true'
+        run: make build
+
       - name: Generate SHA-256 checksums
         if: steps.release.outputs.release_created == 'true'
         run: scripts/generate-checksums.sh

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -39,6 +39,19 @@ require_order(
     "Release Please (Stable)",
     "stable release must pass rubric before release-please can create a draft release",
 )
+for workflow in (".github/workflows/prerelease.yml", ".github/workflows/release.yml"):
+    require_order(
+        workflow,
+        "Build + verify\n        if: steps.release.outputs.release_created == 'true'",
+        "Build release assets",
+        "release workflows must run rubric before building release assets",
+    )
+    require_order(
+        workflow,
+        "Build release assets",
+        "Generate SHA-256 checksums",
+        "release workflows must build dist artifacts before generating checksums",
+    )
 require_contains(
     ".github/workflows/ci.yml",
     "ready_for_review",


### PR DESCRIPTION
## Summary
- build release artifacts before checksum generation in prerelease and stable release workflows
- verify this ordering in `scripts/verify-release-workflows.sh`

## Why
The `v1.5.0-rc.2` prerelease workflow passed rubric, then failed at checksum generation because `dist/` had never been produced in the release-asset workspace. `make rubric` verifies the repository but does not leave release assets in `dist/`; the release workflow must explicitly run `make build` before `scripts/generate-checksums.sh`.

## Validation
- `bash scripts/verify-release-workflows.sh`
- `git diff --check`
- `make test`
- `make build`
- `scripts/generate-checksums.sh`
- `make rubric`
- `git merge-base --is-ancestor origin/main HEAD`
