### PR TITLE
fix(release): run release PR gates before ready

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  statuses: write
 
 jobs:
   release-please:
@@ -94,6 +95,11 @@ jobs:
         if: steps.release_pr.outputs.exists == 'true'
         with:
           node-version: "24.13.1"
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        if: steps.release_pr.outputs.exists == 'true'
+        with:
+          python-version: "3.14"
 
       - name: Sync generated CDK artifacts on release PR
         if: steps.release_pr.outputs.exists == 'true'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  statuses: write
 
 jobs:
   release-please:
@@ -198,6 +199,11 @@ jobs:
         if: steps.release_pr.outputs.exists == 'true'
         with:
           node-version: "24.13.1"
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        if: steps.release_pr.outputs.exists == 'true'
+        with:
+          python-version: "3.14"
 
       - name: Sync generated CDK artifacts on release PR
         if: steps.release_pr.outputs.exists == 'true'

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -299,21 +299,59 @@ wait_for_pr_head() {
   done
 }
 
-trigger_release_pr_checks() {
-  # Release PRs stay draft while generated artifacts are being rewritten so they
-  # cannot be merged in an incomplete state. CI still needs a pull_request event
-  # after the generated-artifact commit is visible, so briefly move the PR to
-  # ready_for_review, then immediately draft-lock it again before waiting for
-  # the required checks to complete.
-  ensure_release_pr_is_draft "before triggering generated-artifact checks"
+set_release_pr_status() {
+  local state="$1"
+  local context="$2"
+  local description="$3"
+  local head_sha
+  head_sha="$(git rev-parse HEAD)"
 
-  echo "sync-release-pr-generated: triggering checks for PR #${pr_number}"
-  gh pr ready "${pr_number}"
+  gh api \
+    --method POST \
+    "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
+    -f "state=${state}" \
+    -f "context=${context}" \
+    -f "description=${description:0:140}" \
+    -f "target_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+    >/dev/null
+}
 
-  # Keep the PR ready only until the required check contexts exist, then
-  # immediately draft-lock it again while those checks run.
+run_release_pr_status_check() {
+  local context="$1"
+  shift
+  local command="$*"
+
+  echo "sync-release-pr-generated: running ${context}"
+  set_release_pr_status pending "${context}" "Running release PR gate"
+  if bash -c "${command}"; then
+    set_release_pr_status success "${context}" "Release PR gate passed"
+    echo "sync-release-pr-generated: ${context}: PASS"
+    return 0
+  fi
+
+  set_release_pr_status failure "${context}" "Release PR gate failed"
+  echo "sync-release-pr-generated: FAIL (${context})" >&2
+  return 1
+}
+
+run_release_pr_required_checks() {
+  # Events caused by GITHUB_TOKEN/Release Please token mutations do not
+  # reliably create pull_request CI runs for the generated release branch.
+  # Keep the PR draft, run the same gate scripts here, and publish commit
+  # statuses with the exact protected check names before the PR can become
+  # ready. This fails closed: any gate failure leaves the release PR draft.
+  ensure_release_pr_is_draft "before running generated-artifact checks"
+
+  run_release_pr_status_check "Version alignment" "scripts/verify-version-alignment.sh"
+  run_release_pr_status_check "Go (test + vet)" "scripts/verify-go.sh"
+  run_release_pr_status_check "TypeScript (npm pack)" "scripts/verify-ts-pack.sh"
+  run_release_pr_status_check "Python (build wheel + sdist)" "scripts/verify-python-build.sh"
+  run_release_pr_status_check "Verify deterministic builds" "scripts/verify-builds.sh"
+  run_release_pr_status_check "Contract tests (fixtures)" "scripts/verify-api-snapshots.sh && scripts/verify-contract-tests.sh"
+  run_release_pr_status_check "Rubric (full gate set)" "make rubric"
+
   wait_for_required_checks_to_start
-  ensure_release_pr_is_draft "after triggering generated-artifact checks"
+  ensure_release_pr_is_draft "after running generated-artifact checks"
 }
 
 # The release PR must not be mergeable while generated artifacts are still being
@@ -346,9 +384,9 @@ if [[ "${changed}" == "true" ]]; then
 fi
 
 wait_for_pr_head "$(git rev-parse HEAD)"
-# After the generated-artifact head is visible, trigger PR checks while
-# preserving the draft-lock before waiting on them.
-trigger_release_pr_checks
+# After the generated-artifact head is visible, run and publish the required
+# release PR gate statuses while preserving the draft lock.
+run_release_pr_required_checks
 wait_for_required_checks
 
 ensure_release_pr_is_draft "before marking generated-artifact-synced PR ready"

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -13,6 +13,12 @@ def require_contains(path: str, needle: str, description: str) -> None:
         raise SystemExit(f"release-workflows: FAIL ({description}; missing {needle!r} in {path})")
 
 
+def require_not_contains(path: str, needle: str, description: str) -> None:
+    text = Path(path).read_text(encoding="utf-8")
+    if needle in text:
+        raise SystemExit(f"release-workflows: FAIL ({description}; unexpected {needle!r} in {path})")
+
+
 def require_order(path: str, first: str, second: str, description: str) -> None:
     text = Path(path).read_text(encoding="utf-8")
     first_index = text.find(first)
@@ -55,14 +61,30 @@ for workflow in (".github/workflows/prerelease.yml", ".github/workflows/release.
 require_contains(
     ".github/workflows/ci.yml",
     "ready_for_review",
-    "CI must run when release PR sync briefly marks draft release PRs ready to trigger checks",
+    "CI must run when humans mark draft release PRs ready",
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
     'gh pr ready "${pr_number}" --undo',
     "release PR sync must force the release PR back to draft before generated artifact work",
 )
+require_not_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "Keep the PR ready only until the required check contexts exist",
+    "release PR sync must not depend on recursive pull_request events from bot-authored PR mutations",
+)
 for workflow in (".github/workflows/prerelease-pr.yml", ".github/workflows/release-pr.yml"):
+    require_contains(
+        workflow,
+        "statuses: write",
+        "release PR workflow must be allowed to publish protected release PR gate statuses",
+    )
+    require_order(
+        workflow,
+        "actions/setup-python",
+        "Sync generated CDK artifacts on release PR",
+        "release PR workflow must install Python before running the full release PR gate set",
+    )
     require_order(
         workflow,
         "Draft-lock release PR before artifact setup",
@@ -85,25 +107,31 @@ require_order(
     "scripts/sync-release-pr-generated.sh",
     'wait_for_pr_head "$(git rev-parse HEAD)"',
     "After the generated-artifact head is visible",
-    "release PR sync must wait for the pushed artifact commit before triggering checks",
+    "release PR sync must wait for the pushed artifact commit before running checks",
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",
     "After the generated-artifact head is visible",
-    "wait_for_required_checks\n\n",
-    "release PR sync must trigger checks before waiting on them",
+    "run_release_pr_required_checks\nwait_for_required_checks",
+    "release PR sync must run checks after the generated-artifact head is visible",
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",
-    "sync-release-pr-generated: triggering checks",
-    "Keep the PR ready only until the required check contexts exist",
-    "release PR sync must trigger checks before waiting for required check contexts",
+    "set_release_pr_status pending",
+    "set_release_pr_status success",
+    "release PR sync must publish pending statuses before passing statuses",
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",
-    "Keep the PR ready only until the required check contexts exist",
-    'ensure_release_pr_is_draft "after triggering generated-artifact checks"',
-    "release PR sync must wait for required check contexts before draft-locking again",
+    "run_release_pr_status_check \"Version alignment\"",
+    "run_release_pr_status_check \"Rubric (full gate set)\"",
+    "release PR sync must run the version gate before the full rubric status",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    "run_release_pr_status_check \"Rubric (full gate set)\" \"make rubric\"",
+    "wait_for_required_checks_to_start\n  ensure_release_pr_is_draft \"after running generated-artifact checks\"",
+    "release PR sync must publish all required statuses before verifying their contexts exist",
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",


### PR DESCRIPTION
## Summary
- promote staging release-lane fix to premain
- release PR sync no longer depends on bot-authored PR events to queue CI
- release PRs stay draft until generated artifacts and protected gate statuses pass

## Verification
- PR #548 CI green
- staging contains current main

## Release train
This is the staging → premain leg. After merge, rerun/watch `Prerelease PR (premain)` so PR #545 is processed by the fixed gate before any RC merge.