### PR TITLE
fix(mcp): harden runtime and sanitizer audit findings

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -942,12 +942,11 @@ var AllowedFields = map[string]bool{
 	"transaction_id": true,
 	"merchant_uid":   true,
 
-	"mid":              true,
-	"merchant_id":      true,
-	"acceptor_id":      true,
-	"tid":              true,
-	"terminal_id":      true,
-	"authorization_id": true,
+	"mid":         true,
+	"merchant_id": true,
+	"acceptor_id": true,
+	"tid":         true,
+	"terminal_id": true,
 }
 
 var PaymentXMLPatterns = []XMLSanitizationPattern{
@@ -1048,6 +1047,7 @@ var SensitiveFields = map[string]SanitizationType{
 	"api_key_id":           PartialMask,
 	"authorization":        FullyRedact,
 	"authorization_header": FullyRedact,
+	"authorization_id":     FullyRedact,
 }
 
 type Policy struct {

--- a/contract-tests/runners/ts/fixtures.test.cjs
+++ b/contract-tests/runners/ts/fixtures.test.cjs
@@ -636,8 +636,8 @@ test("sanitization: sanitizeFieldValue context-aware accountNumber masking", asy
 test("sanitization: sanitizeFieldValue does not substring-redact business fields", async () => {
   const { sanitizeFieldValue } = await importDist("sanitization.js");
 
-  assert.equal(sanitizeFieldValue("authorization_id", "auth_123"), "auth_123");
-  assert.equal(sanitizeFieldValue("authorizationId", "auth_123"), "auth_123");
+  assert.equal(sanitizeFieldValue("authorization_id", "auth_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("authorizationId", "auth_123"), "[REDACTED]");
   assert.equal(sanitizeFieldValue("authorizationCode", "ok_1"), "ok_1");
   assert.equal(sanitizeFieldValue("tokenization_method", "apple_pay"), "apple_pay");
 
@@ -664,7 +664,7 @@ test("sanitization: Tesouro GraphQL fixture", async () => {
   });
 
   const tx = out.data.transaction;
-  assert.equal(tx.authorizationId, "auth_123");
+  assert.equal(tx.authorizationId, "[REDACTED]");
   assert.equal(tx.authorizationCode, "ok_1");
   assert.equal(tx.tokenization_method, "apple_pay");
   assert.equal(tx.accessToken, "[REDACTED]");

--- a/pkg/sanitization/policy.go
+++ b/pkg/sanitization/policy.go
@@ -151,6 +151,9 @@ func (s *policySanitizer) sanitizeFieldValueWithParent(parentKey string, key str
 	}
 
 	parentCanonical := canonicalizeSanitizationKey(parentKey)
+	if isNeverAllowedSensitiveField(keyLower, keyCanonical) {
+		return redactedValue
+	}
 	if action, ok := s.policy.lookup(parentCanonical, keyCanonical); ok {
 		return s.applyAction(action, parentKey, keyLower, keyCanonical, value)
 	}

--- a/pkg/sanitization/policy_test.go
+++ b/pkg/sanitization/policy_test.go
@@ -33,7 +33,7 @@ func TestPolicySanitizer_RulesOverrideDefaultsAndRecurse(t *testing.T) {
 	t.Parallel()
 
 	fn, err := NewPolicySanitizer(&Policy{
-		AllowedFields:     []string{"authorization_id"},
+		AllowedFields:     []string{"authorization_id", "safe_reference"},
 		FullyRedactFields: []string{"merchant_uid"},
 		PartialMaskFields: []string{"custom_pan"},
 		Rules: []PolicyRule{
@@ -47,6 +47,7 @@ func TestPolicySanitizer_RulesOverrideDefaultsAndRecurse(t *testing.T) {
 
 	in := map[string]any{
 		"authorization_id": "auth_1",
+		"safe_reference":   "safe_1",
 		"merchant_uid":     "muid_1",
 		"custom_pan":       "4111111111111111",
 		"custom_pan2":      "4111111111111111",
@@ -66,8 +67,11 @@ func TestPolicySanitizer_RulesOverrideDefaultsAndRecurse(t *testing.T) {
 		t.Fatalf("expected map output, got %T (%#v)", out, out)
 	}
 
-	if out["authorization_id"] != "auth_1" {
-		t.Fatalf("expected authorization_id to be preserved, got %#v", out["authorization_id"])
+	if out["authorization_id"] != redactedValue {
+		t.Fatalf("expected authorization_id to remain redacted despite policy allow, got %#v", out["authorization_id"])
+	}
+	if out["safe_reference"] != "safe_1" {
+		t.Fatalf("expected safe_reference to be preserved by policy, got %#v", out["safe_reference"])
 	}
 	if out["merchant_uid"] != redactedValue {
 		t.Fatalf("expected merchant_uid to be redacted by policy, got %#v", out["merchant_uid"])

--- a/pkg/sanitization/sanitization.go
+++ b/pkg/sanitization/sanitization.go
@@ -24,12 +24,11 @@ var AllowedFields = map[string]bool{
 	"merchant_uid":   true,
 
 	// External system identifiers (MIDs, acceptor IDs, terminal IDs, etc.).
-	"mid":              true,
-	"merchant_id":      true,
-	"acceptor_id":      true,
-	"tid":              true,
-	"terminal_id":      true,
-	"authorization_id": true,
+	"mid":         true,
+	"merchant_id": true,
+	"acceptor_id": true,
+	"tid":         true,
+	"terminal_id": true,
 }
 
 // SanitizationType defines how to sanitize a field.
@@ -81,6 +80,7 @@ var SensitiveFields = map[string]SanitizationType{
 	"api_key_id":           PartialMask,
 	"authorization":        FullyRedact,
 	"authorization_header": FullyRedact,
+	"authorization_id":     FullyRedact,
 }
 
 func init() {
@@ -203,7 +203,14 @@ func sanitizeFieldValueWithParent(parentKey string, key string, value any) any {
 }
 
 func isAllowedField(keyLower, keyCanonical string) bool {
+	if isNeverAllowedSensitiveField(keyLower, keyCanonical) {
+		return false
+	}
 	return AllowedFields[keyLower] || AllowedFields[keyCanonical]
+}
+
+func isNeverAllowedSensitiveField(keyLower, keyCanonical string) bool {
+	return keyLower == "authorization_id" || keyCanonical == "authorizationid"
 }
 
 func sensitiveFieldType(keyLower, keyCanonical string) (SanitizationType, bool) {

--- a/pkg/sanitization/sanitization_additional_test.go
+++ b/pkg/sanitization/sanitization_additional_test.go
@@ -146,14 +146,14 @@ func TestSanitizeXML_RapidConnectFixture(t *testing.T) {
 	}
 }
 
-func TestSanitizeFieldValue_PreservesAuthorizationID_AndAliases(t *testing.T) {
+func TestSanitizeFieldValue_RedactsAuthorizationID_AndAliases(t *testing.T) {
 	t.Parallel()
 
-	if got := SanitizeFieldValue("authorization_id", "auth_123"); got != "auth_123" {
-		t.Fatalf("expected authorization_id to be preserved, got %#v", got)
+	if got := SanitizeFieldValue("authorization_id", "auth_123"); got != redactedValue {
+		t.Fatalf("expected authorization_id to be redacted, got %#v", got)
 	}
-	if got := SanitizeFieldValue("authorizationId", "auth_123"); got != "auth_123" {
-		t.Fatalf("expected authorizationId alias to be preserved, got %#v", got)
+	if got := SanitizeFieldValue("authorizationId", "auth_123"); got != redactedValue {
+		t.Fatalf("expected authorizationId alias to be redacted, got %#v", got)
 	}
 }
 
@@ -232,8 +232,8 @@ func TestSanitizeFieldValue_TesouroGraphQLFixture(t *testing.T) {
 		t.Fatalf("expected transaction to be map, got %T (%#v)", data["transaction"], data["transaction"])
 	}
 
-	if tx["authorizationId"] != "auth_123" {
-		t.Fatalf("expected transaction.authorizationId to be preserved, got %#v", tx["authorizationId"])
+	if tx["authorizationId"] != redactedValue {
+		t.Fatalf("expected transaction.authorizationId to be redacted, got %#v", tx["authorizationId"])
 	}
 	if tx["authorizationCode"] != "ok_1" {
 		t.Fatalf("expected transaction.authorizationCode to be preserved, got %#v", tx["authorizationCode"])

--- a/py/src/apptheory/sanitization.py
+++ b/py/src/apptheory/sanitization.py
@@ -23,7 +23,6 @@ _ALLOWED_FIELDS: set[str] = {
     "acceptor_id",
     "tid",
     "terminal_id",
-    "authorization_id",
 }
 
 _SENSITIVE_FIELDS: dict[str, str] = {
@@ -59,6 +58,7 @@ _SENSITIVE_FIELDS: dict[str, str] = {
     "api_key_id": "partial",
     "authorization": "fully",
     "authorization_header": "fully",
+    "authorization_id": "fully",
 }
 
 _CANONICALIZE_KEY_RE = re.compile(r"[_\-\s]+")

--- a/py/tests/test_sanitization.py
+++ b/py/tests/test_sanitization.py
@@ -101,8 +101,8 @@ class TestSanitization(unittest.TestCase):
         self.assertEqual(sanitize_field_value("api_key", "x"), "[REDACTED]")
         self.assertEqual(sanitize_field_value("root", b"a\nb"), "ab")
 
-        self.assertEqual(sanitize_field_value("authorization_id", "auth_123"), "auth_123")
-        self.assertEqual(sanitize_field_value("authorizationId", "auth_123"), "auth_123")
+        self.assertEqual(sanitize_field_value("authorization_id", "auth_123"), "[REDACTED]")
+        self.assertEqual(sanitize_field_value("authorizationId", "auth_123"), "[REDACTED]")
         self.assertEqual(sanitize_field_value("session_token", "tok_123"), "[REDACTED]")
         self.assertEqual(sanitize_field_value("csrfToken", "tok_123"), "[REDACTED]")
         self.assertEqual(sanitize_field_value("authorizationToken", "tok_123"), "[REDACTED]")
@@ -162,7 +162,7 @@ class TestSanitization(unittest.TestCase):
                 }
             },
         )
-        self.assertEqual(out["data"]["transaction"]["authorizationId"], "auth_123")
+        self.assertEqual(out["data"]["transaction"]["authorizationId"], "[REDACTED]")
         self.assertEqual(out["data"]["transaction"]["authorizationCode"], "ok_1")
         self.assertEqual(out["data"]["transaction"]["tokenization_method"], "apple_pay")
         self.assertEqual(out["data"]["transaction"]["accessToken"], "[REDACTED]")

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -116,6 +116,10 @@ func (s *Server) hasCompletionHooks() bool {
 	return s.promptCompletionHook != nil || s.resourceCompletionHook != nil
 }
 
+func (s *Server) tasksEnabled() bool {
+	return s != nil && s.capabilities.Tasks && s.hasTaskRuntime()
+}
+
 func protocolSupportsCapability(pv string, surface capabilitySurface) bool {
 	if surface == capabilitySurfaceTasks {
 		return pv == protocolVersion

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -120,6 +120,24 @@ func (s *Server) tasksEnabled() bool {
 	return s != nil && s.capabilities.Tasks && s.hasTaskRuntime()
 }
 
+func (s *Server) methodCapabilityEnabled(method string) bool {
+	if s == nil {
+		return false
+	}
+	switch method {
+	case methodToolsList, methodToolsCall:
+		return s.capabilities.Tools
+	case methodResourcesList, methodResourcesRead, methodResourcesSubscribe, methodResourcesUnsubscribe:
+		return s.capabilities.Resources
+	case methodPromptsList, methodPromptsGet:
+		return s.capabilities.Prompts
+	case methodCompletionComplete:
+		return s.capabilities.Completions
+	default:
+		return true
+	}
+}
+
 func protocolSupportsCapability(pv string, surface capabilitySurface) bool {
 	if surface == capabilitySurfaceTasks {
 		return pv == protocolVersion

--- a/runtime/mcp/resource.go
+++ b/runtime/mcp/resource.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"sync"
 )
 
@@ -66,8 +68,12 @@ func errDuplicateResource(uri string) error {
 
 // RegisterResource registers a resource by URI.
 func (r *ResourceRegistry) RegisterResource(def ResourceDef, handler ResourceHandler) error {
+	def.URI = strings.TrimSpace(def.URI)
 	if def.URI == "" {
 		return fmt.Errorf("resource uri must not be empty")
+	}
+	if !validResourceURI(def.URI) {
+		return fmt.Errorf("resource uri must be absolute: %s", def.URI)
 	}
 	if def.Name == "" {
 		return fmt.Errorf("resource name must not be empty")
@@ -107,6 +113,14 @@ func (r *ResourceRegistry) Len() int {
 	return len(r.resources)
 }
 
+// Exists reports whether a resource URI is registered exactly.
+func (r *ResourceRegistry) Exists(uri string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.index[uri]
+	return ok
+}
+
 // Read resolves a resource by URI and returns its content.
 func (r *ResourceRegistry) Read(ctx context.Context, uri string) ([]ResourceContent, error) {
 	r.mu.RLock()
@@ -119,4 +133,13 @@ func (r *ResourceRegistry) Read(ctx context.Context, uri string) ([]ResourceCont
 	r.mu.RUnlock()
 
 	return handler(ctx)
+}
+
+func validResourceURI(uri string) bool {
+	uri = strings.TrimSpace(uri)
+	if uri == "" || strings.ContainsAny(uri, " \t\r\n") {
+		return false
+	}
+	parsed, err := url.Parse(uri)
+	return err == nil && parsed.Scheme != ""
 }

--- a/runtime/mcp/resource.go
+++ b/runtime/mcp/resource.go
@@ -113,8 +113,7 @@ func (r *ResourceRegistry) Len() int {
 	return len(r.resources)
 }
 
-// Exists reports whether a resource URI is registered exactly.
-func (r *ResourceRegistry) Exists(uri string) bool {
+func (r *ResourceRegistry) exists(uri string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	_, ok := r.index[uri]

--- a/runtime/mcp/resources_handlers.go
+++ b/runtime/mcp/resources_handlers.go
@@ -72,7 +72,7 @@ func (s *Server) handleResourceSubscription(
 	if !validResourceURI(params.URI) {
 		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: invalid uri")
 	}
-	if !s.resourceRegistry.Exists(params.URI) {
+	if !s.resourceRegistry.exists(params.URI) {
 		return NewErrorResponse(req.ID, CodeInvalidParams, "resource not found: "+params.URI)
 	}
 

--- a/runtime/mcp/resources_handlers.go
+++ b/runtime/mcp/resources_handlers.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 )
 
 type resourcesReadParams struct {
@@ -64,8 +65,15 @@ func (s *Server) handleResourceSubscription(
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: "+err.Error())
 	}
+	params.URI = strings.TrimSpace(params.URI)
 	if params.URI == "" {
 		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing uri")
+	}
+	if !validResourceURI(params.URI) {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: invalid uri")
+	}
+	if !s.resourceRegistry.Exists(params.URI) {
+		return NewErrorResponse(req.ID, CodeInvalidParams, "resource not found: "+params.URI)
 	}
 
 	if err := hook(ctx, ResourceSubscription{SessionID: sessionID, URI: params.URI}); err != nil {

--- a/runtime/mcp/resources_prompts_test.go
+++ b/runtime/mcp/resources_prompts_test.go
@@ -190,6 +190,70 @@ func TestPromptsListAndGet_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestCapabilityDisables_RejectResourceAndPromptMethods(t *testing.T) {
+	s := NewServer("test", "1.0.0",
+		WithCapabilityConfig(CapabilityConfig{
+			Tools:       true,
+			Resources:   false,
+			Prompts:     false,
+			Completions: true,
+			Tasks:       true,
+		}),
+		WithResourceSubscriptionHooks(
+			func(context.Context, ResourceSubscription) error { return nil },
+			func(context.Context, ResourceSubscription) error { return nil },
+		),
+	)
+	if err := s.Resources().RegisterResource(ResourceDef{URI: "file://hello.txt", Name: "hello"}, func(context.Context) ([]ResourceContent, error) {
+		return []ResourceContent{{URI: "file://hello.txt", Text: "hello"}}, nil
+	}); err != nil {
+		t.Fatalf("register resource: %v", err)
+	}
+	if err := s.Prompts().RegisterPrompt(PromptDef{Name: "greet"}, func(context.Context, json.RawMessage) (*PromptResult, error) {
+		return &PromptResult{Messages: []PromptMessage{{Role: "user", Content: ContentBlock{Type: "text", Text: "hello"}}}}, nil
+	}); err != nil {
+		t.Fatalf("register prompt: %v", err)
+	}
+
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	tests := []struct {
+		name   string
+		method string
+		params any
+	}{
+		{name: "resources list", method: methodResourcesList},
+		{name: "resources read", method: methodResourcesRead, params: map[string]any{"uri": "file://hello.txt"}},
+		{name: "resources subscribe", method: methodResourcesSubscribe, params: map[string]any{"uri": "file://hello.txt"}},
+		{name: "resources unsubscribe", method: methodResourcesUnsubscribe, params: map[string]any{"uri": "file://hello.txt"}},
+		{name: "prompts list", method: methodPromptsList},
+		{name: "prompts get", method: methodPromptsGet, params: map[string]any{"name": "greet"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var params json.RawMessage
+			if tt.params != nil {
+				params = mustMarshal(t, tt.params)
+			}
+			req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: tt.method, Params: params})
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+			if err != nil {
+				t.Fatalf("invoke %s: %v", tt.method, err)
+			}
+			rpcResp, err := parseJSONRPCResponse(resp)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tt.method, err)
+			}
+			if rpcResp.Error == nil || rpcResp.Error.Code != CodeMethodNotFound {
+				t.Fatalf("expected method-not-found for disabled %s, got %+v", tt.method, rpcResp.Error)
+			}
+		})
+	}
+}
+
 func TestResourcesRead_NotFoundIsInvalidParams(t *testing.T) {
 	s := NewServer("test", "1.0.0")
 

--- a/runtime/mcp/resources_prompts_test.go
+++ b/runtime/mcp/resources_prompts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -228,6 +229,12 @@ func TestResourceSubscriptionHooks_RoundTrip(t *testing.T) {
 	headers := sessionHeaders(sessionID)
 	headers["accept"] = []string{"application/json, text/event-stream"}
 
+	if err := s.Resources().RegisterResource(ResourceDef{URI: "file://hello.txt", Name: "hello"}, func(context.Context) ([]ResourceContent, error) {
+		return []ResourceContent{{URI: "file://hello.txt", Text: "hello"}}, nil
+	}); err != nil {
+		t.Fatalf("register resource: %v", err)
+	}
+
 	params := mustMarshal(t, map[string]any{"uri": "file://hello.txt"})
 	subscribeReq := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})
 	subscribeResp, err := invokeHandlerWithMethod(context.Background(), s, "POST", subscribeReq, headers)
@@ -325,6 +332,68 @@ func TestResourceSubscriptionHooks_ValidateParamsAndErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("malformed uri", func(t *testing.T) {
+		called := false
+		s := NewServer("test", "1.0.0", WithResourceSubscriptionHooks(
+			func(context.Context, ResourceSubscription) error {
+				called = true
+				return nil
+			},
+			func(context.Context, ResourceSubscription) error { return nil },
+		))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		params := mustMarshal(t, map[string]any{"uri": "relative/path"})
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke resources/subscribe: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse resources/subscribe: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams || !strings.Contains(rpcResp.Error.Message, "invalid uri") {
+			t.Fatalf("expected invalid params for malformed uri, got: %+v", rpcResp.Error)
+		}
+		if called {
+			t.Fatalf("subscription hook ran for malformed uri")
+		}
+	})
+
+	t.Run("unregistered uri", func(t *testing.T) {
+		called := false
+		s := NewServer("test", "1.0.0", WithResourceSubscriptionHooks(
+			func(context.Context, ResourceSubscription) error {
+				called = true
+				return nil
+			},
+			func(context.Context, ResourceSubscription) error { return nil },
+		))
+		sessionID := initializeSession(t, s)
+		headers := sessionHeaders(sessionID)
+		headers["accept"] = []string{"application/json, text/event-stream"}
+
+		params := mustMarshal(t, map[string]any{"uri": "file://missing.txt"})
+		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})
+		resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+		if err != nil {
+			t.Fatalf("invoke resources/subscribe: %v", err)
+		}
+		rpcResp, err := parseJSONRPCResponse(resp)
+		if err != nil {
+			t.Fatalf("parse resources/subscribe: %v", err)
+		}
+		if rpcResp.Error == nil || rpcResp.Error.Code != CodeInvalidParams || !strings.Contains(rpcResp.Error.Message, "resource not found") {
+			t.Fatalf("expected invalid params for unregistered uri, got: %+v", rpcResp.Error)
+		}
+		if called {
+			t.Fatalf("subscription hook ran for unregistered uri")
+		}
+	})
+
 	t.Run("hook error", func(t *testing.T) {
 		s := NewServer("test", "1.0.0", WithResourceSubscriptionHooks(
 			func(context.Context, ResourceSubscription) error { return errors.New("subscribe denied") },
@@ -333,6 +402,11 @@ func TestResourceSubscriptionHooks_ValidateParamsAndErrors(t *testing.T) {
 		sessionID := initializeSession(t, s)
 		headers := sessionHeaders(sessionID)
 		headers["accept"] = []string{"application/json, text/event-stream"}
+		if err := s.Resources().RegisterResource(ResourceDef{URI: "file://hello.txt", Name: "hello"}, func(context.Context) ([]ResourceContent, error) {
+			return []ResourceContent{{URI: "file://hello.txt", Text: "hello"}}, nil
+		}); err != nil {
+			t.Fatalf("register resource: %v", err)
+		}
 
 		params := mustMarshal(t, map[string]any{"uri": "file://hello.txt"})
 		req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesSubscribe, Params: params})

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -584,6 +584,10 @@ func (s *Server) dispatchForProtocol(ctx context.Context, req *Request, protocol
 }
 
 func (s *Server) dispatchNonTaskMethod(ctx context.Context, req *Request, sessionID string) *Response {
+	if !s.methodCapabilityEnabled(req.Method) {
+		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: "+req.Method)
+	}
+
 	switch req.Method {
 	case methodInitialize:
 		selectedPV, errResp := s.negotiateInitializeProtocolVersion(req)

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -1350,6 +1350,9 @@ func (s *Server) shouldStreamToolsCall(req *Request) bool {
 	if params.Task != nil {
 		return false
 	}
+	if s.registry.taskSupport(params.Name) == TaskSupportRequired {
+		return false
+	}
 	return s.registry.supportsStreaming(params.Name)
 }
 
@@ -1413,6 +1416,10 @@ func (s *Server) runStreamingTool(ctx context.Context, sessionID, streamID strin
 	}
 	if params.Name == "" {
 		s.appendStreamResponseOrDeliveryError(storeCtx, sessionID, streamID, req.ID, NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing tool name"))
+		return
+	}
+	if params.Task != nil || s.registry.taskSupport(params.Name) == TaskSupportRequired {
+		s.appendStreamResponseOrDeliveryError(storeCtx, sessionID, streamID, req.ID, NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: tool requires task execution"))
 		return
 	}
 

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -620,7 +620,7 @@ func (s *Server) dispatchNonTaskMethod(ctx context.Context, req *Request, sessio
 }
 
 func (s *Server) dispatchTaskMethod(ctx context.Context, req *Request, sessionID string) *Response {
-	if !s.hasTaskRuntime() {
+	if !s.tasksEnabled() {
 		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: "+req.Method)
 	}
 
@@ -753,10 +753,14 @@ func (s *Server) handleToolsCall(ctx context.Context, req *Request, sessionID st
 	if params.Name == "" {
 		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing tool name")
 	}
-	if params.Task != nil && s.hasTaskRuntime() {
+	taskSupport := s.registry.taskSupport(params.Name)
+	if params.Task != nil {
+		if !s.tasksEnabled() {
+			return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: tasks not enabled")
+		}
 		return s.handleTaskToolsCall(ctx, req, sessionID, params)
 	}
-	if s.hasTaskRuntime() && s.registry.taskSupport(params.Name) == TaskSupportRequired {
+	if taskSupport == TaskSupportRequired {
 		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: tool requires task execution")
 	}
 

--- a/runtime/mcp/streaming_test.go
+++ b/runtime/mcp/streaming_test.go
@@ -256,6 +256,51 @@ func TestToolsCallStreaming_ProgressToken_NumberIsPreserved(t *testing.T) {
 	}
 }
 
+func TestToolsCallStreaming_RequiredTaskToolUsesJSONErrorPath(t *testing.T) {
+	s := NewServer("test-server", "1.0.0", WithTaskRuntime(TaskRuntimeOptions{Store: NewMemoryTaskStore()}))
+	sessionID := initializeSession(t, s)
+
+	called := false
+	if err := s.registry.RegisterStreamingTool(
+		ToolDef{
+			Name:        "required_stream",
+			Description: "Requires task execution",
+			Execution:   &ToolExecution{TaskSupport: TaskSupportRequired},
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		func(context.Context, json.RawMessage, func(SSEEvent)) (*ToolResult, error) {
+			called = true
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "should not run"}}}, nil
+		},
+	); err != nil {
+		t.Fatalf("register streaming tool: %v", err)
+	}
+
+	params := toolsCallParams{Name: "required_stream", Arguments: json.RawMessage(`{}`)}
+	body := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodToolsCall, Params: mustMarshal(t, params)})
+
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if resp.BodyReader != nil {
+		t.Fatalf("expected required-task streaming call to stay on JSON error path")
+	}
+	rpcResp, err := parseJSONRPCResponse(resp)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if rpcResp.Error == nil || rpcResp.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected required task tool to reject non-task streaming call, got %+v", rpcResp.Error)
+	}
+	if called {
+		t.Fatalf("required-task streaming handler ran without task execution")
+	}
+}
+
 func TestToolsCallStreaming_CanResumeViaGETWithLastEventID(t *testing.T) {
 	s := NewServer("test-server", "1.0.0")
 	sessionID := initializeSession(t, s)

--- a/runtime/mcp/task.go
+++ b/runtime/mcp/task.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	defaultTaskTTL          = 10 * time.Minute
-	defaultTaskMaxTTL       = time.Hour
-	defaultTaskPollInterval = 5 * time.Second
-	defaultTaskResultWait   = 100 * time.Millisecond
-	defaultTaskListLimit    = 100
-	maxTaskListLimit        = 500
+	defaultTaskTTL           = 10 * time.Minute
+	defaultTaskMaxTTL        = time.Hour
+	defaultTaskPollInterval  = 5 * time.Second
+	defaultTaskResultWait    = 100 * time.Millisecond
+	defaultTaskResultMaxWait = 30 * time.Second
+	defaultTaskListLimit     = 100
+	maxTaskListLimit         = 500
 )
 
 const (
@@ -129,6 +130,7 @@ var ErrTaskNotFound = errors.New("task not found")
 var ErrTaskTerminal = errors.New("task already terminal")
 
 var errTaskInvalidCursor = errors.New("invalid task list cursor")
+var errTaskResultWaitTimeout = errors.New("task result wait timeout")
 
 // TaskRuntimeOptions configures task-augmented MCP execution.
 type TaskRuntimeOptions struct {
@@ -375,6 +377,7 @@ func (s *Server) handleTasksResult(ctx context.Context, req *Request, sessionID 
 }
 
 func (s *Server) waitForTaskTerminal(ctx context.Context, lookup TaskLookup) (*TaskRecord, error) {
+	maxWaitDeadline := time.Now().UTC().Add(defaultTaskResultMaxWait)
 	for {
 		record, err := s.taskRuntime.store.Get(ctx, lookup)
 		if err != nil {
@@ -384,7 +387,19 @@ func (s *Server) waitForTaskTerminal(ctx context.Context, lookup TaskLookup) (*T
 			return record, nil
 		}
 
+		deadline := maxWaitDeadline
+		if taskDeadline, ok := taskResultDeadline(record); ok && taskDeadline.Before(deadline) {
+			deadline = taskDeadline
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, errTaskResultWaitTimeout
+		}
+
 		interval := s.taskResultWaitInterval(record)
+		if interval > remaining {
+			interval = remaining
+		}
 		timer := time.NewTimer(interval)
 		select {
 		case <-ctx.Done():
@@ -414,7 +429,20 @@ func (s *Server) taskResultWaitInterval(record *TaskRecord) time.Duration {
 	if interval <= 0 {
 		return defaultTaskResultWait
 	}
+	if interval < defaultTaskResultWait {
+		return defaultTaskResultWait
+	}
+	if interval > defaultTaskPollInterval {
+		return defaultTaskPollInterval
+	}
 	return interval
+}
+
+func taskResultDeadline(record *TaskRecord) (time.Time, bool) {
+	if record == nil || record.Task.TTL == nil || *record.Task.TTL <= 0 || record.Task.CreatedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return record.Task.CreatedAt.UTC().Add(time.Duration(*record.Task.TTL) * time.Millisecond), true
 }
 
 func (s *Server) handleTasksList(ctx context.Context, req *Request, sessionID string) *Response {

--- a/runtime/mcp/task.go
+++ b/runtime/mcp/task.go
@@ -203,8 +203,8 @@ func (s *Server) hasTaskRuntime() bool {
 }
 
 func (s *Server) handleTaskToolsCall(ctx context.Context, req *Request, sessionID string, params toolsCallParams) *Response {
-	if !s.hasTaskRuntime() {
-		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: task runtime not configured")
+	if !s.tasksEnabled() {
+		return NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: tasks not enabled")
 	}
 	if strings.TrimSpace(sessionID) == "" {
 		return NewErrorResponse(req.ID, CodeInvalidParams, "Invalid params: missing session id")

--- a/runtime/mcp/task_dynamo.go
+++ b/runtime/mcp/task_dynamo.go
@@ -19,6 +19,20 @@ const (
 	envTaskTableName           = "MCP_TASK_TABLE"
 )
 
+var dynamoTaskListProjection = []string{
+	"SessionID",
+	"TaskID",
+	"Method",
+	"ToolName",
+	"Status",
+	"StatusMessage",
+	"CreatedAt",
+	"LastUpdatedAt",
+	"ExpiresAt",
+	"TTLMillis",
+	"PollIntervalMillis",
+}
+
 type dynamoTaskRecord struct {
 	SessionID          string          `theorydb:"pk,attr:sessionId" json:"sessionId"`
 	TaskID             string          `theorydb:"sk,attr:taskId" json:"taskId"`
@@ -117,11 +131,21 @@ func (d *DynamoTaskStore) List(ctx context.Context, req TaskListRequest) (*TaskL
 	if sessionID == "" {
 		return &TaskListResult{Tasks: []Task{}}, nil
 	}
+	limit := taskListLimit(req.Limit)
+	start, err := taskListCursor(req.Cursor)
+	if err != nil {
+		return nil, err
+	}
 
 	var records []dynamoTaskRecord
-	err := d.db.Model(&dynamoTaskRecord{}).
+	err = d.db.Model(&dynamoTaskRecord{}).
 		WithContext(ctx).
 		Where("SessionID", "=", sessionID).
+		OrderBy("CreatedAt", "ASC").
+		OrderBy("TaskID", "ASC").
+		Limit(limit + 1).
+		Offset(start).
+		Select(dynamoTaskListProjection...).
 		All(&records)
 	if err != nil {
 		if tableerrors.IsNotFound(err) {
@@ -130,7 +154,7 @@ func (d *DynamoTaskStore) List(ctx context.Context, req TaskListRequest) (*TaskL
 		return nil, err
 	}
 
-	return d.listResult(req, records)
+	return d.listQueryResult(start, limit, records), nil
 }
 
 func (d *DynamoTaskStore) Cancel(ctx context.Context, lookup TaskLookup) (*TaskRecord, error) {
@@ -252,6 +276,43 @@ func (d *DynamoTaskStore) listResult(req TaskListRequest, records []dynamoTaskRe
 		result.NextCursor = strconv.Itoa(end)
 	}
 	return result, nil
+}
+
+func (d *DynamoTaskStore) listQueryResult(start int, limit int, records []dynamoTaskRecord) *TaskListResult {
+	if limit <= 0 {
+		limit = defaultTaskListLimit
+	}
+	if limit > maxTaskListLimit {
+		limit = maxTaskListLimit
+	}
+
+	hasMore := len(records) > limit
+	if hasMore {
+		records = records[:limit]
+	}
+
+	active := records[:0]
+	for _, record := range records {
+		if !d.expired(record) {
+			active = append(active, record)
+		}
+	}
+	sort.SliceStable(active, func(i, j int) bool {
+		if active[i].CreatedAt.Equal(active[j].CreatedAt) {
+			return active[i].TaskID < active[j].TaskID
+		}
+		return active[i].CreatedAt.Before(active[j].CreatedAt)
+	})
+
+	tasks := make([]Task, 0, len(active))
+	for _, record := range active {
+		tasks = append(tasks, dynamoTaskToTask(record))
+	}
+	result := &TaskListResult{Tasks: tasks}
+	if hasMore {
+		result.NextCursor = strconv.Itoa(start + limit)
+	}
+	return result
 }
 
 func taskListLimit(limit int) int {

--- a/runtime/mcp/task_dynamo_test.go
+++ b/runtime/mcp/task_dynamo_test.go
@@ -57,6 +57,16 @@ func expectTaskNonTerminalWriteGuard(q *tablemocks.MockQuery) {
 	q.On("WithCondition", "Status", "<>", TaskStatusCanceled).Return(q).Once()
 }
 
+func expectDynamoTaskListQuery(q *tablemocks.MockQuery, sessionID string, limit int, offset int) {
+	q.On("WithContext", mock.Anything).Return(q)
+	q.On("Where", "SessionID", "=", sessionID).Return(q)
+	q.On("OrderBy", "CreatedAt", "ASC").Return(q)
+	q.On("OrderBy", "TaskID", "ASC").Return(q)
+	q.On("Limit", limit).Return(q)
+	q.On("Offset", offset).Return(q)
+	q.On("Select", dynamoTaskListProjection).Return(q)
+}
+
 func TestDynamoTaskStore_CreatePersistsTaskRecord(t *testing.T) {
 	db := new(tablemocks.MockDB)
 	q := new(tablemocks.MockQuery)
@@ -440,32 +450,11 @@ func TestDynamoTaskStore_ListFiltersSortsAndPaginates(t *testing.T) {
 	now := time.Date(2026, 5, 15, 1, 33, 0, 0, time.UTC)
 
 	db.On("Model", mock.Anything).Return(q)
-	q.On("WithContext", mock.Anything).Return(q)
-	q.On("Where", "SessionID", "=", "sess-1").Return(q)
+	expectDynamoTaskListQuery(q, "sess-1", 3, 0)
 	q.On("All", mock.Anything).Run(func(args mock.Arguments) {
 		out, ok := args.Get(0).(*[]dynamoTaskRecord)
 		require.True(t, ok)
 		*out = []dynamoTaskRecord{
-			{
-				SessionID:     "sess-1",
-				TaskID:        "task-3",
-				Method:        methodToolsCall,
-				Status:        TaskStatusWorking,
-				CreatedAt:     now.Add(3 * time.Second),
-				LastUpdatedAt: now.Add(3 * time.Second),
-				ExpiresAt:     now.Add(time.Hour).Unix(),
-				TTLMillis:     int64(time.Hour / time.Millisecond),
-			},
-			{
-				SessionID:     "sess-1",
-				TaskID:        "expired",
-				Method:        methodToolsCall,
-				Status:        TaskStatusWorking,
-				CreatedAt:     now.Add(time.Second),
-				LastUpdatedAt: now.Add(time.Second),
-				ExpiresAt:     now.Add(-time.Second).Unix(),
-				TTLMillis:     int64(time.Hour / time.Millisecond),
-			},
 			{
 				SessionID:     "sess-1",
 				TaskID:        "task-1",
@@ -483,6 +472,16 @@ func TestDynamoTaskStore_ListFiltersSortsAndPaginates(t *testing.T) {
 				Status:        TaskStatusWorking,
 				CreatedAt:     now.Add(2 * time.Second),
 				LastUpdatedAt: now.Add(2 * time.Second),
+				ExpiresAt:     now.Add(time.Hour).Unix(),
+				TTLMillis:     int64(time.Hour / time.Millisecond),
+			},
+			{
+				SessionID:     "sess-1",
+				TaskID:        "task-3",
+				Method:        methodToolsCall,
+				Status:        TaskStatusWorking,
+				CreatedAt:     now.Add(3 * time.Second),
+				LastUpdatedAt: now.Add(3 * time.Second),
 				ExpiresAt:     now.Add(time.Hour).Unix(),
 				TTLMillis:     int64(time.Hour / time.Millisecond),
 			},
@@ -508,6 +507,15 @@ func TestDynamoTaskStore_ListFiltersSortsAndPaginates(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, next.Tasks, 1)
 	require.Equal(t, "task-3", next.Tasks[0].TaskID)
+
+	paged := store.listQueryResult(2, 2, []dynamoTaskRecord{
+		{TaskID: "task-3", Status: TaskStatusWorking, CreatedAt: now.Add(2 * time.Second), LastUpdatedAt: now.Add(2 * time.Second), ExpiresAt: now.Add(time.Hour).Unix()},
+		{TaskID: "expired", Status: TaskStatusWorking, CreatedAt: now.Add(3 * time.Second), LastUpdatedAt: now.Add(3 * time.Second), ExpiresAt: now.Add(-time.Second).Unix()},
+		{TaskID: "task-4", Status: TaskStatusWorking, CreatedAt: now.Add(4 * time.Second), LastUpdatedAt: now.Add(4 * time.Second), ExpiresAt: now.Add(time.Hour).Unix()},
+	})
+	require.Len(t, paged.Tasks, 1)
+	require.Equal(t, "task-3", paged.Tasks[0].TaskID)
+	require.Equal(t, "4", paged.NextCursor)
 }
 
 func TestDynamoTaskStore_DeleteSessionAndInvalidWrites(t *testing.T) {
@@ -547,8 +555,7 @@ func TestDynamoTaskStore_ListAndDeleteErrorBranches(t *testing.T) {
 	q := new(tablemocks.MockQuery)
 	expected := errors.New("list failed")
 	db.On("Model", mock.Anything).Return(q)
-	q.On("WithContext", mock.Anything).Return(q)
-	q.On("Where", "SessionID", "=", "sess-1").Return(q)
+	expectDynamoTaskListQuery(q, "sess-1", defaultTaskListLimit+1, 0)
 	q.On("All", mock.Anything).Return(expected)
 
 	_, err = NewDynamoTaskStore(db).List(context.Background(), TaskListRequest{SessionID: "sess-1"})
@@ -594,8 +601,7 @@ func TestDynamoTaskStore_ListNotFoundReturnsEmpty(t *testing.T) {
 	q := new(tablemocks.MockQuery)
 
 	db.On("Model", mock.Anything).Return(q)
-	q.On("WithContext", mock.Anything).Return(q)
-	q.On("Where", "SessionID", "=", "sess-1").Return(q)
+	expectDynamoTaskListQuery(q, "sess-1", defaultTaskListLimit+1, 0)
 	q.On("All", mock.Anything).Return(tableerrors.ErrItemNotFound)
 
 	store := NewDynamoTaskStore(db)

--- a/runtime/mcp/task_dynamo_test.go
+++ b/runtime/mcp/task_dynamo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -516,6 +517,99 @@ func TestDynamoTaskStore_ListFiltersSortsAndPaginates(t *testing.T) {
 	require.Len(t, paged.Tasks, 1)
 	require.Equal(t, "task-3", paged.Tasks[0].TaskID)
 	require.Equal(t, "4", paged.NextCursor)
+}
+
+func TestDynamoTaskStore_ListPaginatesHighCardinalityPartition(t *testing.T) {
+	const (
+		sessionID      = "sess-high"
+		pageLimit      = 3
+		queryPageLimit = pageLimit + 1
+		recordCount    = 1000
+	)
+	db := new(tablemocks.MockDB)
+	now := time.Date(2026, 5, 15, 1, 34, 0, 0, time.UTC)
+	backing := make([]dynamoTaskRecord, recordCount)
+	for i := range backing {
+		createdAt := now.Add(time.Duration(i/2) * time.Second)
+		backing[i] = dynamoTaskRecord{
+			SessionID:          sessionID,
+			TaskID:             fmt.Sprintf("task-%04d", i+1),
+			Method:             methodToolsCall,
+			ToolName:           "slow",
+			Status:             TaskStatusWorking,
+			StatusMessage:      "working",
+			CreatedAt:          createdAt,
+			LastUpdatedAt:      createdAt,
+			ExpiresAt:          now.Add(time.Hour).Unix(),
+			TTLMillis:          int64(time.Hour / time.Millisecond),
+			PollIntervalMillis: int64(defaultTaskPollInterval / time.Millisecond),
+			Result:             json.RawMessage(`{"content":[{"type":"text","text":"large payload must not be projected"}]}`),
+			ErrorCode:          CodeServerError,
+			ErrorMessage:       "large error must not be projected",
+			ErrorData:          json.RawMessage(`{"secret":"must not be projected"}`),
+		}
+	}
+	backing[1].ExpiresAt = now.Add(-time.Second).Unix()
+	backing[5].ExpiresAt = now.Add(-time.Second).Unix()
+
+	for _, field := range []string{"Result", "ErrorCode", "ErrorMessage", "ErrorData"} {
+		require.NotContains(t, dynamoTaskListProjection, field, "tasks/list projection must not read result/error payload fields")
+	}
+
+	expectListPage := func(offset int) {
+		t.Helper()
+		q := new(tablemocks.MockQuery)
+		t.Cleanup(func() {
+			q.AssertExpectations(t)
+		})
+		db.On("Model", mock.Anything).Return(q).Once()
+		expectDynamoTaskListQuery(q, sessionID, queryPageLimit, offset)
+		q.On("All", mock.Anything).Run(func(args mock.Arguments) {
+			end := offset + queryPageLimit
+			if end > len(backing) {
+				end = len(backing)
+			}
+			page := append([]dynamoTaskRecord(nil), backing[offset:end]...)
+			require.LessOrEqual(t, len(page), queryPageLimit)
+			require.Less(t, len(page), len(backing), "mock must emulate storage-layer paging instead of materializing the full partition")
+			out, ok := args.Get(0).(*[]dynamoTaskRecord)
+			require.True(t, ok)
+			*out = page
+		}).Return(nil).Once()
+	}
+
+	expectListPage(0)
+	expectListPage(3)
+	expectListPage(6)
+
+	store, ok := NewDynamoTaskStore(db).(*DynamoTaskStore)
+	require.True(t, ok)
+	store.now = func() time.Time { return now }
+
+	first, err := store.List(context.Background(), TaskListRequest{SessionID: " " + sessionID + " ", Limit: pageLimit})
+	require.NoError(t, err)
+	require.Equal(t, []string{"task-0001", "task-0003"}, taskIDs(first.Tasks))
+	require.Equal(t, "3", first.NextCursor)
+
+	second, err := store.List(context.Background(), TaskListRequest{SessionID: sessionID, Limit: pageLimit, Cursor: first.NextCursor})
+	require.NoError(t, err)
+	require.Equal(t, []string{"task-0004", "task-0005"}, taskIDs(second.Tasks))
+	require.Equal(t, "6", second.NextCursor)
+
+	third, err := store.List(context.Background(), TaskListRequest{SessionID: sessionID, Limit: pageLimit, Cursor: second.NextCursor})
+	require.NoError(t, err)
+	require.Equal(t, []string{"task-0007", "task-0008", "task-0009"}, taskIDs(third.Tasks))
+	require.Equal(t, "9", third.NextCursor)
+
+	db.AssertExpectations(t)
+}
+
+func taskIDs(tasks []Task) []string {
+	out := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		out = append(out, task.TaskID)
+	}
+	return out
 }
 
 func TestDynamoTaskStore_DeleteSessionAndInvalidWrites(t *testing.T) {

--- a/runtime/mcp/task_test.go
+++ b/runtime/mcp/task_test.go
@@ -85,7 +85,7 @@ func TestTaskRuntimeContract_ProtocolGatesTasks(t *testing.T) {
 func TestTaskRuntimeContract_ExplicitConfigCanDisableTasks(t *testing.T) {
 	s := NewServer("test", "dev",
 		WithTaskRuntime(TaskRuntimeOptions{Store: noopTaskStore{}}),
-		WithCapabilityConfig(CapabilityConfig{Tasks: false}),
+		WithCapabilityConfig(CapabilityConfig{Tools: true, Tasks: false}),
 	)
 	if err := s.Registry().RegisterTool(taskCapableToolDef(), func(context.Context, json.RawMessage) (*ToolResult, error) {
 		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
@@ -96,6 +96,21 @@ func TestTaskRuntimeContract_ExplicitConfigCanDisableTasks(t *testing.T) {
 	caps := initializeCapabilityMap(t, s)
 	if _, ok := caps["tasks"]; ok {
 		t.Fatalf("expected explicitly disabled tasks capability to be omitted: %+v", caps)
+	}
+
+	taskMethod := s.dispatchForProtocol(context.Background(), taskRequest(1, methodTasksList, "task-1"), protocolVersion, "sess-1")
+	if taskMethod.Error == nil || taskMethod.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected disabled tasks method to fail closed, got %+v", taskMethod.Error)
+	}
+
+	taskCall := s.dispatchForProtocol(context.Background(), toolsCallTaskRequest(2, "slow"), protocolVersion, "sess-1")
+	if taskCall.Error == nil || taskCall.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected disabled task-augmented tool call to fail closed, got %+v", taskCall.Error)
+	}
+
+	syncCall := s.dispatchForProtocol(context.Background(), toolsCallRequest(3, "slow"), protocolVersion, "sess-1")
+	if syncCall.Error != nil {
+		t.Fatalf("expected optional task tool to allow sync execution when tasks disabled, got %+v", syncCall.Error)
 	}
 }
 
@@ -632,6 +647,22 @@ func TestTaskRuntimeToolsCall_EnforcesToolSupport(t *testing.T) {
 	if plainSync.Error != nil {
 		t.Fatalf("expected plain sync call to work, got %+v", plainSync.Error)
 	}
+
+	noRuntime := NewServer("test", "dev")
+	if err := noRuntime.Registry().RegisterTool(ToolDef{
+		Name:        "required",
+		Description: "requires tasks",
+		Execution:   &ToolExecution{TaskSupport: TaskSupportRequired},
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(context.Context, json.RawMessage) (*ToolResult, error) {
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+	}); err != nil {
+		t.Fatalf("register required tool without runtime: %v", err)
+	}
+	noRuntimeRequired := noRuntime.dispatchForProtocol(context.Background(), toolsCallRequest(4, "required"), protocolVersion, "sess-1")
+	if noRuntimeRequired.Error == nil || noRuntimeRequired.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected required task tool to reject sync call without runtime, got %+v", noRuntimeRequired.Error)
+	}
 }
 
 func TestTaskRuntimeToolsCall_FailsClosedOnRuntimeErrors(t *testing.T) {
@@ -642,8 +673,8 @@ func TestTaskRuntimeToolsCall_FailsClosedOnRuntimeErrors(t *testing.T) {
 		t.Fatalf("register task tool: %v", err)
 	}
 	resp := s.dispatchForProtocol(context.Background(), toolsCallTaskRequest(1, "slow"), protocolVersion, "sess-1")
-	if resp.Error != nil {
-		t.Fatalf("expected task metadata to be ignored without advertised task runtime, got %+v", resp.Error)
+	if resp.Error == nil || resp.Error.Code != CodeMethodNotFound {
+		t.Fatalf("expected task metadata to fail closed without advertised task runtime, got %+v", resp.Error)
 	}
 
 	s = NewServer("test", "dev", WithTaskRuntime(TaskRuntimeOptions{Store: NewMemoryTaskStore()}))

--- a/runtime/mcp/task_test.go
+++ b/runtime/mcp/task_test.go
@@ -566,7 +566,7 @@ func TestTaskRuntimeToolsCall_ConcurrentResultWaitersBoundReadPressure(t *testin
 	base := NewMemoryTaskStore()
 	record := taskTestRecord("sess-1", "task-result-read-pressure", TaskStatusWorking)
 	record.Result = nil
-	poll := int64(time.Millisecond / time.Millisecond)
+	poll := int64(1)
 	record.Task.PollInterval = &poll
 	if _, err := base.Create(context.Background(), record); err != nil {
 		t.Fatalf("create working task: %v", err)

--- a/runtime/mcp/task_test.go
+++ b/runtime/mcp/task_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -524,6 +525,101 @@ func TestTaskRuntimeToolsCall_ResultWaitIsBoundedByTTL(t *testing.T) {
 	}
 }
 
+func TestTaskRuntimeToolsCall_ResultReturnsWhenContextCanceled(t *testing.T) {
+	store := NewMemoryTaskStore()
+	record := taskTestRecord("sess-1", "task-result-context-cancel", TaskStatusWorking)
+	record.Result = nil
+	if _, err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("create working task: %v", err)
+	}
+
+	s := NewServer("test", "dev", WithTaskRuntime(TaskRuntimeOptions{Store: store, PollInterval: time.Millisecond}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan *Response, 1)
+	go func() {
+		done <- s.dispatchForProtocol(ctx, taskRequest(1, methodTasksResult, "task-result-context-cancel"), protocolVersion, "sess-1")
+	}()
+
+	select {
+	case resp := <-done:
+		t.Fatalf("tasks/result returned before request context was canceled: %+v", resp)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case resp := <-done:
+		if resp.Error == nil || resp.Error.Code != CodeServerError || !strings.Contains(resp.Error.Message, context.Canceled.Error()) {
+			t.Fatalf("expected context-canceled server error, got %+v", resp.Error)
+		}
+		if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+			t.Fatalf("expected tasks/result to return promptly after context cancellation, elapsed %s", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tasks/result did not return after request context cancellation")
+	}
+}
+
+func TestTaskRuntimeToolsCall_ConcurrentResultWaitersBoundReadPressure(t *testing.T) {
+	base := NewMemoryTaskStore()
+	record := taskTestRecord("sess-1", "task-result-read-pressure", TaskStatusWorking)
+	record.Result = nil
+	poll := int64(time.Millisecond / time.Millisecond)
+	record.Task.PollInterval = &poll
+	if _, err := base.Create(context.Background(), record); err != nil {
+		t.Fatalf("create working task: %v", err)
+	}
+
+	store := &countingTaskStore{TaskStore: base}
+	s := NewServer("test", "dev", WithTaskRuntime(TaskRuntimeOptions{Store: store, PollInterval: time.Millisecond}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const waiters = 8
+	done := make(chan *Response, waiters)
+	for i := 0; i < waiters; i++ {
+		go func(id int) {
+			done <- s.dispatchForProtocol(ctx, taskRequest(id+1, methodTasksResult, "task-result-read-pressure"), protocolVersion, "sess-1")
+		}(i)
+	}
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for store.gets.Load() < waiters {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d initial task reads; got %d", waiters, store.gets.Load())
+		case <-ticker.C:
+		}
+	}
+
+	initialReads := store.gets.Load()
+	time.Sleep(defaultTaskResultWait / 2)
+	if got := store.gets.Load(); got != initialReads {
+		t.Fatalf("expected no additional reads before %s poll floor, got initial=%d current=%d", defaultTaskResultWait, initialReads, got)
+	}
+
+	cancel()
+	for i := 0; i < waiters; i++ {
+		select {
+		case resp := <-done:
+			if resp.Error == nil || resp.Error.Code != CodeServerError || !strings.Contains(resp.Error.Message, context.Canceled.Error()) {
+				t.Fatalf("expected waiter %d to return context-canceled server error, got %+v", i, resp.Error)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("waiter %d did not return after context cancellation", i)
+		}
+	}
+
+	if got := store.gets.Load(); got != initialReads {
+		t.Fatalf("expected cancellation before poll interval to avoid extra reads, got initial=%d final=%d", initialReads, got)
+	}
+}
+
 func TestTaskRuntimeToolsCall_ErrorResultFailsTaskButReturnsToolResult(t *testing.T) {
 	store := NewMemoryTaskStore()
 	s := NewServer("test", "dev",
@@ -916,6 +1012,16 @@ type nilListTaskStore struct {
 
 func (s *nilListTaskStore) List(context.Context, TaskListRequest) (*TaskListResult, error) {
 	return &TaskListResult{}, nil
+}
+
+type countingTaskStore struct {
+	TaskStore
+	gets atomic.Int64
+}
+
+func (s *countingTaskStore) Get(ctx context.Context, lookup TaskLookup) (*TaskRecord, error) {
+	s.gets.Add(1)
+	return s.TaskStore.Get(ctx, lookup)
 }
 
 func TestTaskRuntimeHelpers_ErrorBranches(t *testing.T) {

--- a/runtime/mcp/task_test.go
+++ b/runtime/mcp/task_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -472,6 +473,39 @@ func TestTaskRuntimeToolsCall_ResultBlocksUntilTerminal(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("tasks/result did not return after task completion")
+	}
+}
+
+func TestTaskRuntimeToolsCall_ResultWaitIsBoundedByTTL(t *testing.T) {
+	store := NewMemoryTaskStore()
+	record := taskTestRecord("sess-1", "task-result-timeout", TaskStatusWorking)
+	record.Result = nil
+	record.Task.CreatedAt = time.Now().UTC()
+	record.Task.LastUpdatedAt = record.Task.CreatedAt
+	ttl := int64(80)
+	poll := int64(1)
+	record.Task.TTL = &ttl
+	record.Task.PollInterval = &poll
+	if _, err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("create working task: %v", err)
+	}
+
+	s := NewServer("test", "dev", WithTaskRuntime(TaskRuntimeOptions{Store: store, PollInterval: time.Millisecond}))
+	start := time.Now()
+	resp := s.dispatchForProtocol(context.Background(), taskRequest(1, methodTasksResult, "task-result-timeout"), protocolVersion, "sess-1")
+	elapsed := time.Since(start)
+
+	if resp.Error == nil || resp.Error.Code != CodeServerError {
+		t.Fatalf("expected bounded wait timeout, got %+v", resp.Error)
+	}
+	if !strings.Contains(resp.Error.Message, errTaskResultWaitTimeout.Error()) {
+		t.Fatalf("expected timeout message, got %+v", resp.Error)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected task result wait to stop near TTL, elapsed %s", elapsed)
+	}
+	if got := s.taskResultWaitInterval(&record); got != defaultTaskResultWait {
+		t.Fatalf("expected task poll interval to floor at %s, got %s", defaultTaskResultWait, got)
 	}
 }
 

--- a/ts/dist/sanitization.js
+++ b/ts/dist/sanitization.js
@@ -16,7 +16,6 @@ const allowedSanitizeFields = new Set([
     "acceptor_id",
     "tid",
     "terminal_id",
-    "authorization_id",
 ]);
 const sensitiveSanitizeFields = new Map([
     ["cvv", "fully"],
@@ -51,6 +50,7 @@ const sensitiveSanitizeFields = new Map([
     ["api_key_id", "partial"],
     ["authorization", "fully"],
     ["authorization_header", "fully"],
+    ["authorization_id", "fully"],
 ]);
 function canonicalizeSanitizationKey(key) {
     return String(key ?? "")

--- a/ts/src/sanitization.ts
+++ b/ts/src/sanitization.ts
@@ -21,7 +21,6 @@ const allowedSanitizeFields = new Set([
   "acceptor_id",
   "tid",
   "terminal_id",
-  "authorization_id",
 ]);
 
 const sensitiveSanitizeFields = new Map<string, "fully" | "partial">([
@@ -62,6 +61,7 @@ const sensitiveSanitizeFields = new Map<string, "fully" | "partial">([
   ["api_key_id", "partial"],
   ["authorization", "fully"],
   ["authorization_header", "fully"],
+  ["authorization_id", "fully"],
 ]);
 
 function canonicalizeSanitizationKey(key: string): string {

--- a/ts/test/sanitization.test.mjs
+++ b/ts/test/sanitization.test.mjs
@@ -3,9 +3,9 @@ import assert from "node:assert/strict";
 
 import { sanitizeFieldValue } from "../dist/index.js";
 
-test("sanitizeFieldValue preserves authorization identifiers and redacts token-like keys", () => {
-  assert.equal(sanitizeFieldValue("authorization_id", "auth_123"), "auth_123");
-  assert.equal(sanitizeFieldValue("authorizationId", "auth_123"), "auth_123");
+test("sanitizeFieldValue redacts authorization identifiers and token-like keys", () => {
+  assert.equal(sanitizeFieldValue("authorization_id", "auth_123"), "[REDACTED]");
+  assert.equal(sanitizeFieldValue("authorizationId", "auth_123"), "[REDACTED]");
   assert.equal(sanitizeFieldValue("session_token", "tok_123"), "[REDACTED]");
   assert.equal(sanitizeFieldValue("csrfToken", "tok_123"), "[REDACTED]");
   assert.equal(sanitizeFieldValue("authorizationToken", "tok_123"), "[REDACTED]");
@@ -18,4 +18,3 @@ test("sanitizeFieldValue preserves business keys while masking known sensitive a
   assert.equal(sanitizeFieldValue("mid", "mid_1"), "mid_1");
   assert.equal(sanitizeFieldValue("acceptorId", "acceptor_1"), "acceptor_1");
 });
-


### PR DESCRIPTION
## Summary
- Hardened MCP task runtime behavior: bounded `tasks/result` polling, paged Dynamo task listing queries, enforced task capability policy, and blocked streaming required-task bypasses.
- Hardened MCP resources/prompts: resource subscription now requires registered absolute URIs, and disabled resource/prompt capabilities fail closed at handler entry.
- Restored cross-runtime sanitizer redaction for `authorization_id`/`authorizationId`, updated TS contract fixtures, regenerated API snapshots, and rebuilt checked-in TS dist output.

## Issues
- THE-1173 — bounded MCP `tasks/result` polling
- THE-1176 — Dynamo task list query paging/projection
- THE-1177 — required-task streaming bypass blocked
- THE-1178 — taskSupport/capability enforcement
- THE-1179 — registered resource URI subscription validation
- THE-1180 — resource/prompt capability disables enforced
- THE-1181 — authorization identifier sanitizer redaction

## Validation
- Baseline before edits: ancestry checks, `./scripts/verify-version-alignment.sh`, `make test`
- `git diff --check`
- `git merge-base --is-ancestor origin/main HEAD`
- `git merge-base --is-ancestor origin/staging HEAD`
- `git merge-base --is-ancestor origin/audit/apptheory-remediation-20260517 HEAD`
- `./scripts/verify-version-alignment.sh`
- `go test ./runtime/mcp`
- `go test ./pkg/sanitization`
- `python -m unittest discover -s py/tests -p 'test_sanitization.py'`
- `node --test ts/test/sanitization.test.mjs`
- `node --test contract-tests/runners/ts/fixtures.test.cjs`
- `./scripts/verify-api-snapshots.sh`
- `(cd ts && npm run check)`
- `make test`
- `make rubric` (PASS 28/0/0)


## Factory follow-up coverage
- Added THE-1173 tests for `tasks/result` request-context cancellation while non-terminal, plus concurrent waiter/read-pressure bounds against the poll interval floor.
- Added THE-1176 high-cardinality Dynamo task-list pagination coverage using a 1000-record backing partition with explicit `Limit`, `Offset`, and projection expectations plus deterministic cursor/expiry/sort assertions across multiple pages.
- Follow-up head: 2735b0851a5d (after lint fix for test code).
- Follow-up validation: targeted `go test ./runtime/mcp -run 'TestTaskRuntimeToolsCall_ResultReturnsWhenContextCanceled|TestTaskRuntimeToolsCall_ConcurrentResultWaitersBoundReadPressure|TestDynamoTaskStore_ListPaginatesHighCardinalityPartition'`; `go test ./runtime/mcp`; `make test`; `make rubric` (PASS 28/0/0).
