### PR TITLE
test(contract): pin logging profile fixtures

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -48,6 +48,11 @@ Each fixture is a single JSON object.
 - `expect.error` (object, optional): expected thrown error (for example: fail-closed `m1` routing).
   - `message` (string): error message to match.
 - `expect.logs` (array, optional): expected structured log records (P2 portable envelope).
+- `expect.profile_logs` (array, optional): expected structured JSON log objects emitted by a configured
+  AppTheory logging profile.
+- `expect.profile_validation_errors` (array, optional): expected fail-closed validation errors for an invalid
+  AppTheory logging profile config.
+- `expect.logging_profile_catalog` (object, optional): expected built-in logging profile catalog.
 - `expect.metrics` (array, optional): expected metric emissions (portable subset).
 - `expect.spans` (array, optional): expected trace span emissions (portable subset).
 
@@ -144,6 +149,36 @@ Non-HTTP observability fixtures use the existing `expect.logs`, `expect.metrics`
 - Spans use trigger-specific names and attributes; raw event details, DynamoDB keys, and image values are not emitted.
 
 The safe-panic fixture pins the posture for non-HTTP handler panics/errors: observability records carry `error_code = "app.internal"`, while the surfaced error is the safe message `apptheory: event workload failed`.
+
+## P2 logging profile fixtures
+
+Logging profile fixtures pin the additive `apptheory.logging/v1` contract. They do not introduce a second
+observability path: profile-backed logging is the configured encoder/logger behavior for the existing P2
+observability surface.
+
+The contract-owned pieces are:
+
+- Profile schema version: `apptheory.logging/v1`.
+- Built-in profile names, sorted canonically: `cloudwatch-json`, `legacy`, `local-dev`, `paytheory-alert-v1`.
+- Encoding defaults and validation for JSON output.
+- Required and recommended field validation.
+- Field mapping from canonical AppTheory log event fields to profile output fields.
+- Static/env enrichment and request/job context enrichment.
+- Error type, error code, optional stack trace, and deterministic stack hash capture.
+- Sanitization-preserving behavior: profile fixtures may include safe structured fields, but raw payload fields must
+  not appear in `expect.profile_logs`.
+
+`setup.logging_profile` carries the profile config under test. `setup.environment` supplies deterministic values for
+`${ENV_VAR}` placeholders used by profile enrichment. `input.logging_event` is a synthetic canonical log event used by
+contract runners to exercise profile encoding without depending on a real provider backend.
+
+`expect.profile_logs` contains the exact structured JSON objects the profile must emit. For `paytheory-alert-v1`,
+the fixture requires enough context for alert-decisioner and Keeper lookup: partner, stage, account family, AWS region,
+service, function, request ID, trace ID, error type/code, stack hash, and normalized message.
+
+Validation-only fixtures use `expect.profile_validation_errors` and may omit `input.request`; runtimes must fail
+closed with deterministic validation messages for unsupported schema versions, profile names, encodings, field names,
+context sources, or stack hash algorithms.
 
 ## Bytes in JSON
 

--- a/contract-tests/fixtures/p2/logging-profile-catalog.json
+++ b/contract-tests/fixtures/p2/logging-profile-catalog.json
@@ -1,0 +1,19 @@
+{
+  "id": "p2.logging_profile.catalog",
+  "tier": "p2",
+  "name": "Logging profile: built-in profile catalog",
+  "input": {
+    "logging_profile_catalog": true
+  },
+  "expect": {
+    "logging_profile_catalog": {
+      "schema_version": "apptheory.logging/v1",
+      "profiles": [
+        "cloudwatch-json",
+        "legacy",
+        "local-dev",
+        "paytheory-alert-v1"
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/p2/logging-profile-paytheory-alert-error.json
+++ b/contract-tests/fixtures/p2/logging-profile-paytheory-alert-error.json
@@ -1,0 +1,180 @@
+{
+  "id": "p2.logging_profile.paytheory_alert_error",
+  "tier": "p2",
+  "name": "Logging profile: paytheory-alert-v1 ERROR output",
+  "setup": {
+    "logging_profile": {
+      "schema_version": "apptheory.logging/v1",
+      "profile": "paytheory-alert-v1",
+      "encoding": {
+        "format": "json",
+        "timestamp_field": "ts",
+        "timestamp_format": "rfc3339nano",
+        "level_field": "level",
+        "message_field": "message"
+      },
+      "levels": {
+        "error": "ERROR",
+        "info": "INFO",
+        "debug": "DEBUG",
+        "warn": "WARN"
+      },
+      "required_fields": [
+        "ts",
+        "level",
+        "message",
+        "service",
+        "stage",
+        "partner",
+        "function",
+        "aws_region"
+      ],
+      "recommended_fields": [
+        "source_account_id",
+        "account_family",
+        "request_id",
+        "trace_id",
+        "correlation_id",
+        "error_type",
+        "error_code",
+        "normalized_message",
+        "stack_hash",
+        "route",
+        "job_name"
+      ],
+      "field_map": {
+        "timestamp": "ts",
+        "severity": "level",
+        "message": "message",
+        "normalized_message": "normalized_message",
+        "error_type": "error_type",
+        "error_code": "error_code",
+        "request_id": "request_id",
+        "trace_id": "trace_id",
+        "correlation_id": "correlation_id",
+        "stack_trace": "stack_trace",
+        "stack_hash": "stack_hash",
+        "service": "service",
+        "stage": "stage",
+        "partner": "partner",
+        "function": "function",
+        "account_family": "account_family",
+        "source_account_id": "source_account_id",
+        "aws_region": "aws_region",
+        "route": "route",
+        "job_name": "job_name"
+      },
+      "enrichment": {
+        "static": {
+          "service": "${SERVICE_NAME}",
+          "stage": "${STAGE}",
+          "partner": "${PARTNER}",
+          "function": "${AWS_LAMBDA_FUNCTION_NAME}",
+          "aws_region": "${AWS_REGION}",
+          "source_account_id": "${SOURCE_ACCOUNT_ID}",
+          "account_family": "${ACCOUNT_FAMILY}"
+        },
+        "context": {
+          "request_id": "request.request_id",
+          "trace_id": "request.trace_id",
+          "correlation_id": "request.correlation_id",
+          "route": "request.route",
+          "job_name": "job.name"
+        }
+      },
+      "error_capture": {
+        "include_error_type": true,
+        "include_error_code": true,
+        "include_stack_trace": true,
+        "stack_trace_field": "stack_trace",
+        "stack_hash_field": "stack_hash",
+        "stack_hash_algorithm": "sha256"
+      },
+      "sanitization": {
+        "existing_sanitized_logging": true,
+        "notes": "Application fields must already be sanitized before they reach the profile; profile encoding must not introduce raw payload fields."
+      },
+      "alerting_hints": {
+        "fingerprint_fields": [
+          "service",
+          "normalized_message",
+          "error_type",
+          "stack_hash"
+        ],
+        "keeper_lookup_fields": [
+          "partner",
+          "stage",
+          "account_family",
+          "aws_region",
+          "service",
+          "function",
+          "request_id",
+          "trace_id"
+        ]
+      }
+    },
+    "environment": {
+      "SERVICE_NAME": "payments-api",
+      "STAGE": "live",
+      "PARTNER": "paytheory",
+      "AWS_LAMBDA_FUNCTION_NAME": "payments-live-authorize",
+      "AWS_REGION": "us-east-1",
+      "SOURCE_ACCOUNT_ID": "111122223333",
+      "ACCOUNT_FAMILY": "paytheory-live"
+    }
+  },
+  "input": {
+    "logging_event": {
+      "timestamp": "1970-01-01T00:00:00Z",
+      "level": "error",
+      "message": "charge authorization failed",
+      "normalized_message": "charge authorization failed",
+      "request": {
+        "request_id": "req_test_123",
+        "trace_id": "trace-profile-123",
+        "correlation_id": "corr-profile-123",
+        "route": "POST /payments/{payment_id}/authorize"
+      },
+      "job": {
+        "name": "authorize-payment"
+      },
+      "error": {
+        "type": "ProcessorError",
+        "code": "processor.declined",
+        "message": "processor declined",
+        "stack_trace": "processor.go:42\nhandler.go:7"
+      },
+      "fields": {
+        "safe_processor": "tesouro",
+        "raw_payload": "must-not-appear"
+      }
+    }
+  },
+  "expect": {
+    "profile_logs": [
+      {
+        "ts": "1970-01-01T00:00:00Z",
+        "level": "ERROR",
+        "message": "charge authorization failed",
+        "service": "payments-api",
+        "stage": "live",
+        "partner": "paytheory",
+        "function": "payments-live-authorize",
+        "aws_region": "us-east-1",
+        "source_account_id": "111122223333",
+        "account_family": "paytheory-live",
+        "request_id": "req_test_123",
+        "trace_id": "trace-profile-123",
+        "correlation_id": "corr-profile-123",
+        "error_type": "ProcessorError",
+        "error_code": "processor.declined",
+        "normalized_message": "charge authorization failed",
+        "stack_trace": "processor.go:42\nhandler.go:7",
+        "stack_hash": "sha256:d3d3dd723c56522d25492427bf8ca94b80feed197d55aa42e9bab0c1b5031bdc",
+        "route": "POST /payments/{payment_id}/authorize",
+        "job_name": "authorize-payment",
+        "safe_processor": "tesouro"
+      }
+    ]
+  }
+}

--- a/contract-tests/fixtures/p2/logging-profile-validation-errors.json
+++ b/contract-tests/fixtures/p2/logging-profile-validation-errors.json
@@ -1,0 +1,38 @@
+{
+  "id": "p2.logging_profile.validation_errors",
+  "tier": "p2",
+  "name": "Logging profile: fail closed validation errors",
+  "setup": {
+    "logging_profile": {
+      "schema_version": "apptheory.logging/v2",
+      "profile": "custom-alert",
+      "encoding": {
+        "format": "xml",
+        "timestamp_format": "epoch_ms"
+      },
+      "required_fields": [
+        "raw_payload"
+      ],
+      "enrichment": {
+        "context": {
+          "request_id": "lambda.raw_event.requestContext.requestId"
+        }
+      },
+      "error_capture": {
+        "include_stack_trace": true,
+        "stack_hash_algorithm": "md5"
+      }
+    }
+  },
+  "expect": {
+    "profile_validation_errors": [
+      "schema_version: unsupported value apptheory.logging/v2",
+      "profile: unsupported value custom-alert",
+      "encoding.format: unsupported value xml",
+      "encoding.timestamp_format: unsupported value epoch_ms",
+      "required_fields[0]: unsupported field raw_payload",
+      "enrichment.context.request_id: unsupported source lambda.raw_event.requestContext.requestId",
+      "error_capture.stack_hash_algorithm: unsupported value md5"
+    ]
+  }
+}

--- a/contract-tests/runners/go/apptheory_p2.go
+++ b/contract-tests/runners/go/apptheory_p2.go
@@ -10,6 +10,10 @@ import (
 )
 
 func runFixtureP2(f Fixture) error {
+	if isLoggingProfileContractFixture(f) {
+		return compareLoggingProfileContract(f)
+	}
+
 	now := time.Unix(0, 0).UTC()
 
 	var logs []FixtureLogRecord
@@ -138,4 +142,26 @@ func runFixtureP2(f Fixture) error {
 
 	actual := app.Serve(ctx, req)
 	return compareFixtureResponse(f, actual, logs, metrics, spans)
+}
+
+func isLoggingProfileContractFixture(f Fixture) bool {
+	return len(f.Setup.LoggingProfile) > 0 ||
+		len(f.Input.LoggingEvent) > 0 ||
+		f.Input.LoggingProfileCatalog ||
+		len(f.Expect.ProfileLogs) > 0 ||
+		len(f.Expect.ProfileValidationErrors) > 0 ||
+		len(f.Expect.LoggingProfileCatalog) > 0
+}
+
+func compareLoggingProfileContract(f Fixture) error {
+	if len(f.Expect.LoggingProfileCatalog) > 0 {
+		return fmt.Errorf("logging_profile_catalog mismatch")
+	}
+	if len(f.Expect.ProfileValidationErrors) > 0 {
+		return fmt.Errorf("profile_validation_errors mismatch")
+	}
+	if len(f.Expect.ProfileLogs) > 0 {
+		return fmt.Errorf("profile_logs mismatch")
+	}
+	return nil
 }

--- a/contract-tests/runners/go/fixture.go
+++ b/contract-tests/runners/go/fixture.go
@@ -25,6 +25,8 @@ type FixtureSetup struct {
 	Routes          []FixtureRoute            `json:"routes,omitempty"`
 	Middlewares     []string                  `json:"middlewares,omitempty"`
 	CORS            FixtureCORSConfig         `json:"cors,omitempty"`
+	Environment     map[string]string         `json:"environment,omitempty"`
+	LoggingProfile  json.RawMessage           `json:"logging_profile,omitempty"`
 	WebSockets      []FixtureWebSocketRoute   `json:"websockets,omitempty"`
 	SQS             []FixtureSQSRoute         `json:"sqs,omitempty"`
 	Kinesis         []FixtureKinesisRoute     `json:"kinesis,omitempty"`
@@ -79,9 +81,11 @@ type FixtureDynamoDBRoute struct {
 }
 
 type FixtureInput struct {
-	Context  FixtureContext   `json:"context,omitempty"`
-	Request  *FixtureRequest  `json:"request,omitempty"`
-	AWSEvent *FixtureAWSEvent `json:"aws_event,omitempty"`
+	Context               FixtureContext   `json:"context,omitempty"`
+	Request               *FixtureRequest  `json:"request,omitempty"`
+	AWSEvent              *FixtureAWSEvent `json:"aws_event,omitempty"`
+	LoggingEvent          json.RawMessage  `json:"logging_event,omitempty"`
+	LoggingProfileCatalog bool             `json:"logging_profile_catalog,omitempty"`
 }
 
 type FixtureAWSEvent struct {
@@ -104,13 +108,16 @@ type FixtureRequest struct {
 }
 
 type FixtureExpect struct {
-	Response       *FixtureResponse       `json:"response,omitempty"`
-	Output         json.RawMessage        `json:"output_json,omitempty"`
-	Error          *FixtureError          `json:"error,omitempty"`
-	WebSocketCalls []FixtureWebSocketCall `json:"ws_calls,omitempty"`
-	Logs           []FixtureLogRecord     `json:"logs,omitempty"`
-	Metrics        []FixtureMetricRecord  `json:"metrics,omitempty"`
-	Spans          []FixtureSpanRecord    `json:"spans,omitempty"`
+	Response                *FixtureResponse       `json:"response,omitempty"`
+	Output                  json.RawMessage        `json:"output_json,omitempty"`
+	Error                   *FixtureError          `json:"error,omitempty"`
+	WebSocketCalls          []FixtureWebSocketCall `json:"ws_calls,omitempty"`
+	Logs                    []FixtureLogRecord     `json:"logs,omitempty"`
+	Metrics                 []FixtureMetricRecord  `json:"metrics,omitempty"`
+	Spans                   []FixtureSpanRecord    `json:"spans,omitempty"`
+	ProfileLogs             []map[string]any       `json:"profile_logs,omitempty"`
+	ProfileValidationErrors []string               `json:"profile_validation_errors,omitempty"`
+	LoggingProfileCatalog   map[string]any         `json:"logging_profile_catalog,omitempty"`
 }
 
 type FixtureError struct {

--- a/contract-tests/runners/go/runner.go
+++ b/contract-tests/runners/go/runner.go
@@ -153,6 +153,25 @@ func printFailure(f Fixture, err error) {
 	fmt.Fprintf(os.Stderr, "FAIL %s — %s\n", f.ID, f.Name)
 	fmt.Fprintf(os.Stderr, "  %v\n", err)
 
+	if isLoggingProfileContractFixture(f) {
+		if len(f.Expect.LoggingProfileCatalog) > 0 {
+			expected := marshalIndentOrPlaceholder(f.Expect.LoggingProfileCatalog)
+			fmt.Fprintf(os.Stderr, "  expected.logging_profile_catalog: %s\n", string(expected))
+			fmt.Fprintf(os.Stderr, "  got.logging_profile_catalog: null\n")
+		}
+		if len(f.Expect.ProfileValidationErrors) > 0 {
+			expected := marshalIndentOrPlaceholder(f.Expect.ProfileValidationErrors)
+			fmt.Fprintf(os.Stderr, "  expected.profile_validation_errors: %s\n", string(expected))
+			fmt.Fprintf(os.Stderr, "  got.profile_validation_errors: []\n")
+		}
+		if len(f.Expect.ProfileLogs) > 0 {
+			expected := marshalIndentOrPlaceholder(f.Expect.ProfileLogs)
+			fmt.Fprintf(os.Stderr, "  expected.profile_logs: %s\n", string(expected))
+			fmt.Fprintf(os.Stderr, "  got.profile_logs: []\n")
+		}
+		return
+	}
+
 	if strings.EqualFold(strings.TrimSpace(f.Tier), "p0") {
 		printFailureP0(f)
 		return

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -691,6 +691,38 @@ def compare_headers(expected: dict[str, Any] | None, actual: dict[str, Any] | No
     return canonicalize_headers(expected) == canonicalize_headers(actual)
 
 
+def is_logging_profile_contract_fixture(fixture: dict[str, Any]) -> bool:
+    setup = fixture.get("setup", {}) or {}
+    input_obj = fixture.get("input", {}) or {}
+    expect_obj = fixture.get("expect", {}) or {}
+    return (
+        "logging_profile" in setup
+        or "logging_event" in input_obj
+        or "logging_profile_catalog" in input_obj
+        or "profile_logs" in expect_obj
+        or "profile_validation_errors" in expect_obj
+        or "logging_profile_catalog" in expect_obj
+    )
+
+
+def compare_logging_profile_contract(
+    fixture: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any], dict[str, Any], _DummyEffectsApp]:
+    expect_obj = fixture.get("expect", {}) or {}
+    actual: dict[str, Any] = {
+        "logging_profile_catalog": None,
+        "profile_validation_errors": [],
+        "profile_logs": [],
+    }
+    if "logging_profile_catalog" in expect_obj:
+        return False, "logging_profile_catalog mismatch", actual, expect_obj, _DummyEffectsApp()
+    if "profile_validation_errors" in expect_obj:
+        return False, "profile_validation_errors mismatch", actual, expect_obj, _DummyEffectsApp()
+    if "profile_logs" in expect_obj:
+        return False, "profile_logs mismatch", actual, expect_obj, _DummyEffectsApp()
+    return True, "", actual, expect_obj, _DummyEffectsApp()
+
+
 def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, dict[str, Any], FixtureApp]:
     tier = str(fixture.get("tier", "")).strip().lower()
     if tier == "p0":
@@ -698,6 +730,8 @@ def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, 
     if tier == "p1":
         return run_fixture_p1(fixture)
     if tier == "p2":
+        if is_logging_profile_contract_fixture(fixture):
+            return compare_logging_profile_contract(fixture)
         expect_obj = fixture.get("expect", {}) or {}
         if "output_json" in expect_obj or "error" in expect_obj:
             return run_fixture_p2_output(fixture)
@@ -2507,6 +2541,32 @@ def main() -> int:
                     print(f"  got.error: {stable_json(actual)}", file=sys.stderr)
                 else:
                     print(f"  got.output_json: {stable_json(actual)}", file=sys.stderr)
+        elif (
+            "logging_profile_catalog" in expect_obj
+            or "profile_validation_errors" in expect_obj
+            or "profile_logs" in expect_obj
+        ):
+            if "logging_profile_catalog" in expect_obj:
+                print(
+                    f"  expected.logging_profile_catalog: {stable_json(expect_obj.get('logging_profile_catalog'))}",
+                    file=sys.stderr,
+                )
+                print(
+                    f"  got.logging_profile_catalog: {stable_json(actual.get('logging_profile_catalog'))}",
+                    file=sys.stderr,
+                )
+            if "profile_validation_errors" in expect_obj:
+                print(
+                    f"  expected.profile_validation_errors: {stable_json(expect_obj.get('profile_validation_errors'))}",
+                    file=sys.stderr,
+                )
+                print(
+                    f"  got.profile_validation_errors: {stable_json(actual.get('profile_validation_errors'))}",
+                    file=sys.stderr,
+                )
+            if "profile_logs" in expect_obj:
+                print(f"  expected.profile_logs: {stable_json(expect_obj.get('profile_logs'))}", file=sys.stderr)
+                print(f"  got.profile_logs: {stable_json(actual.get('profile_logs'))}", file=sys.stderr)
         else:
             print(f"  expected: {stable_json(expected)}", file=sys.stderr)
             print(f"  got: {stable_json(debug_actual_for_expected(actual, expected))}", file=sys.stderr)

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -50,6 +50,49 @@ function deepEqual(a, b) {
   return util.isDeepStrictEqual(a, b);
 }
 
+function isLoggingProfileContractFixture(fixture) {
+  const setup = fixture.setup ?? {};
+  const input = fixture.input ?? {};
+  const expect = fixture.expect ?? {};
+  return (
+    Object.prototype.hasOwnProperty.call(setup, "logging_profile") ||
+    Object.prototype.hasOwnProperty.call(input, "logging_event") ||
+    Object.prototype.hasOwnProperty.call(input, "logging_profile_catalog") ||
+    Object.prototype.hasOwnProperty.call(expect, "profile_logs") ||
+    Object.prototype.hasOwnProperty.call(expect, "profile_validation_errors") ||
+    Object.prototype.hasOwnProperty.call(expect, "logging_profile_catalog")
+  );
+}
+
+function compareLoggingProfileContract(fixture) {
+  const expect = fixture.expect ?? {};
+  if (Object.prototype.hasOwnProperty.call(expect, "logging_profile_catalog")) {
+    return {
+      ok: false,
+      reason: "logging_profile_catalog mismatch",
+      expected_logging_profile_catalog: expect.logging_profile_catalog,
+      actual_logging_profile_catalog: null,
+    };
+  }
+  if (Object.prototype.hasOwnProperty.call(expect, "profile_validation_errors")) {
+    return {
+      ok: false,
+      reason: "profile_validation_errors mismatch",
+      expected_profile_validation_errors: expect.profile_validation_errors ?? [],
+      actual_profile_validation_errors: [],
+    };
+  }
+  if (Object.prototype.hasOwnProperty.call(expect, "profile_logs")) {
+    return {
+      ok: false,
+      reason: "profile_logs mismatch",
+      expected_profile_logs: expect.profile_logs ?? [],
+      actual_profile_logs: [],
+    };
+  }
+  return { ok: true };
+}
+
 function listFixtureFiles(fixturesRoot) {
   const tiers = ["p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14"];
   const files = [];
@@ -617,6 +660,9 @@ async function runFixture(fixture) {
     return compareFixture(fixture, actual, effects);
   }
   if (tier === "p2") {
+    if (isLoggingProfileContractFixture(fixture)) {
+      return compareLoggingProfileContract(fixture);
+    }
     const expect = fixture.expect ?? {};
     if (
       Object.prototype.hasOwnProperty.call(expect, "output_json") ||
@@ -2636,8 +2682,19 @@ async function main() {
         console.error(`  got.error: ${stableStringify(result.actual_error)}`);
       }
     } else {
-      console.error(`  expected: ${stableStringify(result.expected)}`);
-      console.error(`  got: ${stableStringify(debugActualForExpected(result.actual, result.expected))}`);
+      if ("expected_logging_profile_catalog" in result) {
+        console.error(`  expected.logging_profile_catalog: ${stableStringify(result.expected_logging_profile_catalog)}`);
+        console.error(`  got.logging_profile_catalog: ${stableStringify(result.actual_logging_profile_catalog)}`);
+      } else if ("expected_profile_validation_errors" in result) {
+        console.error(`  expected.profile_validation_errors: ${stableStringify(result.expected_profile_validation_errors)}`);
+        console.error(`  got.profile_validation_errors: ${stableStringify(result.actual_profile_validation_errors)}`);
+      } else if ("expected_profile_logs" in result) {
+        console.error(`  expected.profile_logs: ${stableStringify(result.expected_profile_logs)}`);
+        console.error(`  got.profile_logs: ${stableStringify(result.actual_profile_logs)}`);
+      } else {
+        console.error(`  expected: ${stableStringify(result.expected)}`);
+        console.error(`  got: ${stableStringify(debugActualForExpected(result.actual, result.expected))}`);
+      }
     }
     if ("expected_logs" in result) {
       console.error(`  expected.logs: ${stableStringify(result.expected_logs)}`);


### PR DESCRIPTION
## Milestone
logging-profile-contract — Define the portable logging profile contract and fixtures before runtime implementation.

## Linear
Project: https://linear.app/theorycloud/project/apptheory-configurable-logging-profiles-d8dc550453aa
Milestone: logging-profile-contract
Issue: https://linear.app/theorycloud/issue/THE-1495/pin-logging-profile-contract-fixtures

## Tasks
- [x] THE-1495 Pin logging profile contract fixtures

## Contract impact
Fixture-first contract growth for `apptheory.logging/v1` logging profiles.

This draft PR intentionally pins the contract before runtime implementation exists. The new fixtures are expected to fail in Go, TypeScript, and Python until the dependent `go-profile-runtime` and `profile-runtime-parity` milestones implement the profile schema, validator, encoder, and hooks.

## Validation
Commands run:
- `make rubric` on clean `origin/staging` baseline before this commit: PASS
- `python3 -m py_compile contract-tests/runners/py/run.py`: PASS
- `node --check contract-tests/runners/ts/run.cjs`: PASS
- `go test ./contract-tests/runners/go -run TestLoadFixtures -count=1`: PASS
- `go run ./contract-tests/runners/go`: expected FAIL on the three new `p2.logging_profile.*` fixtures
- `node contract-tests/runners/ts/run.cjs`: expected FAIL on the three new `p2.logging_profile.*` fixtures
- `python3 contract-tests/runners/py/run.py`: expected FAIL on the three new `p2.logging_profile.*` fixtures
- `./scripts/verify-contract-tests.sh`: expected FAIL at the new Go logging-profile fixtures

## Cross-repo notes
None. This is AppTheory-owned contract work.

## Release notes
Do not merge this PR by itself. It is a fixture-first branch for stacked implementation work; staging should only receive the logging profile feature once the dependent runtime milestones make the contract green across Go, TypeScript, and Python.
