### PR TITLE
feat(observability): add Go logging profile runtime

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -774,6 +774,13 @@ type LoggingProfileEnrichment struct {
 	Context map[string]string `json:"context,omitempty" yaml:"context,omitempty"`
 }
 
+type LoggingProfileError struct {
+	Type       string `json:"type,omitempty"`
+	Code       string `json:"code,omitempty"`
+	Message    string `json:"message,omitempty"`
+	StackTrace string `json:"stack_trace,omitempty"`
+}
+
 type LoggingProfileErrorCapture struct {
 	IncludeErrorType   bool   `json:"include_error_type" yaml:"include_error_type"`
 	IncludeErrorCode   bool   `json:"include_error_code" yaml:"include_error_code"`
@@ -781,6 +788,35 @@ type LoggingProfileErrorCapture struct {
 	StackTraceField    string `json:"stack_trace_field,omitempty" yaml:"stack_trace_field,omitempty"`
 	StackHashField     string `json:"stack_hash_field,omitempty" yaml:"stack_hash_field,omitempty"`
 	StackHashAlgorithm string `json:"stack_hash_algorithm,omitempty" yaml:"stack_hash_algorithm,omitempty"`
+}
+
+type LoggingProfileEvent struct {
+	Timestamp         time.Time                    `json:"timestamp"`
+	Level             string                       `json:"level"`
+	Event             string                       `json:"event,omitempty"`
+	Message           string                       `json:"message"`
+	NormalizedMessage string                       `json:"normalized_message,omitempty"`
+	Request           LoggingProfileRequestContext `json:"request,omitempty"`
+	Job               LoggingProfileJobContext     `json:"job,omitempty"`
+	Error             LoggingProfileError          `json:"error,omitempty"`
+	Fields            map[string]any               `json:"fields,omitempty"`
+}
+
+type LoggingProfileJobContext struct {
+	Name string `json:"name,omitempty"`
+}
+
+type LoggingProfileRequestContext struct {
+	RequestID     string `json:"request_id,omitempty"`
+	TenantID      string `json:"tenant_id,omitempty"`
+	UserID        string `json:"user_id,omitempty"`
+	TraceID       string `json:"trace_id,omitempty"`
+	SpanID        string `json:"span_id,omitempty"`
+	CorrelationID string `json:"correlation_id,omitempty"`
+	Route         string `json:"route,omitempty"`
+	Method        string `json:"method,omitempty"`
+	Path          string `json:"path,omitempty"`
+	Status        int    `json:"status,omitempty"`
 }
 
 type LoggingProfileSanitization struct {
@@ -791,6 +827,32 @@ type LoggingProfileSanitization struct {
 type LoggingProfileValidationError struct {
 	Errors []string
 }
+
+type ProfileLogger struct {
+	root *ProfileLogger
+
+	config      LoggingProfileConfig
+	environment map[string]string
+	writer      io.Writer
+	sanitizer   SanitizerFunc
+	clock       func() time.Time
+
+	mu      sync.Mutex
+	entries []map[string]any
+	fields  map[string]any
+
+	requestID string
+	tenantID  string
+	userID    string
+	traceID   string
+	spanID    string
+
+	closed        atomic.Bool
+	entriesLogged atomic.Int64
+	lastError     atomic.Value
+}
+
+type ProfileLoggerOption func(*profileLoggerOptions)
 
 type SanitizerFunc func(string, any) any
 
@@ -834,7 +896,13 @@ func BuiltInLoggingProfileNames() []string
 
 func DefaultLoggingProfile(string) (LoggingProfileConfig, error)
 
+func EncodeLoggingProfileEvent(LoggingProfileConfig, map[string]string, LoggingProfileEvent) (map[string]any, error)
+
+func EncodeLoggingProfileEventWithSanitizer(LoggingProfileConfig, map[string]string, LoggingProfileEvent, SanitizerFunc) (map[string]any, error)
+
 func HooksFromLogger(StructuredLogger) apptheory.ObservabilityHooks
+
+func HooksFromProfileLogger(LoggingProfileConfig, ...ProfileLoggerOption) (apptheory.ObservabilityHooks, *ProfileLogger, error)
 
 func LoggingProfileCatalog() map[string]any
 
@@ -842,11 +910,53 @@ func LoggingProfileValidationErrors(LoggingProfileConfig) []string
 
 func NewNoOpLogger() StructuredLogger
 
+func NewProfileLogger(LoggingProfileConfig, ...ProfileLoggerOption) (*ProfileLogger, error)
+
 func NewTestLogger() *TestLogger
 
 func ValidateLoggingProfile(LoggingProfileConfig) error
 
+func WithProfileClock(func() time.Time) ProfileLoggerOption
+
+func WithProfileEnvironment(map[string]string) ProfileLoggerOption
+
+func WithProfileSanitizer(SanitizerFunc) ProfileLoggerOption
+
+func WithProfileWriter(io.Writer) ProfileLoggerOption
+
 func (*LoggingProfileValidationError) Error() string
+
+func (*ProfileLogger) Close() error
+
+func (*ProfileLogger) Debug(string, ...map[string]any)
+
+func (*ProfileLogger) Entries() []map[string]any
+
+func (*ProfileLogger) Error(string, ...map[string]any)
+
+func (*ProfileLogger) Flush(context.Context) error
+
+func (*ProfileLogger) GetStats() LoggerStats
+
+func (*ProfileLogger) Info(string, ...map[string]any)
+
+func (*ProfileLogger) IsHealthy() bool
+
+func (*ProfileLogger) Warn(string, ...map[string]any)
+
+func (*ProfileLogger) WithField(string, any) StructuredLogger
+
+func (*ProfileLogger) WithFields(map[string]any) StructuredLogger
+
+func (*ProfileLogger) WithRequestID(string) StructuredLogger
+
+func (*ProfileLogger) WithSpanID(string) StructuredLogger
+
+func (*ProfileLogger) WithTenantID(string) StructuredLogger
+
+func (*ProfileLogger) WithTraceID(string) StructuredLogger
+
+func (*ProfileLogger) WithUserID(string) StructuredLogger
 
 func (*TestLogger) Close() error
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -687,6 +687,16 @@ func ResourceName(string, string, string, string) string
 
 ## github.com/theory-cloud/apptheory/pkg/observability
 
+const LoggingProfileCloudWatchJSON = "cloudwatch-json"
+
+const LoggingProfileLegacy = "legacy"
+
+const LoggingProfileLocalDev = "local-dev"
+
+const LoggingProfilePayTheoryAlertV1 = "paytheory-alert-v1"
+
+const LoggingProfileSchemaVersion = "apptheory.logging/v1"
+
 type ErrorNotifier interface {
 	Notify(context.Context, LogEntry) error
 }
@@ -732,6 +742,56 @@ type LoggerStats struct {
 	AverageFlush   time.Duration `json:"average_flush_time"`
 }
 
+type LoggingProfileAlertingHints struct {
+	FingerprintFields  []string `json:"fingerprint_fields,omitempty" yaml:"fingerprint_fields,omitempty"`
+	KeeperLookupFields []string `json:"keeper_lookup_fields,omitempty" yaml:"keeper_lookup_fields,omitempty"`
+}
+
+type LoggingProfileConfig struct {
+	SchemaVersion     string                      `json:"schema_version" yaml:"schema_version"`
+	Profile           string                      `json:"profile" yaml:"profile"`
+	Encoding          LoggingProfileEncoding      `json:"encoding" yaml:"encoding"`
+	Levels            map[string]string           `json:"levels,omitempty" yaml:"levels,omitempty"`
+	RequiredFields    []string                    `json:"required_fields,omitempty" yaml:"required_fields,omitempty"`
+	RecommendedFields []string                    `json:"recommended_fields,omitempty" yaml:"recommended_fields,omitempty"`
+	FieldMap          map[string]string           `json:"field_map,omitempty" yaml:"field_map,omitempty"`
+	Enrichment        LoggingProfileEnrichment    `json:"enrichment,omitempty" yaml:"enrichment,omitempty"`
+	ErrorCapture      LoggingProfileErrorCapture  `json:"error_capture,omitempty" yaml:"error_capture,omitempty"`
+	Sanitization      LoggingProfileSanitization  `json:"sanitization,omitempty" yaml:"sanitization,omitempty"`
+	AlertingHints     LoggingProfileAlertingHints `json:"alerting_hints,omitempty" yaml:"alerting_hints,omitempty"`
+}
+
+type LoggingProfileEncoding struct {
+	Format          string `json:"format" yaml:"format"`
+	TimestampField  string `json:"timestamp_field,omitempty" yaml:"timestamp_field,omitempty"`
+	TimestampFormat string `json:"timestamp_format,omitempty" yaml:"timestamp_format,omitempty"`
+	LevelField      string `json:"level_field,omitempty" yaml:"level_field,omitempty"`
+	MessageField    string `json:"message_field,omitempty" yaml:"message_field,omitempty"`
+}
+
+type LoggingProfileEnrichment struct {
+	Static  map[string]string `json:"static,omitempty" yaml:"static,omitempty"`
+	Context map[string]string `json:"context,omitempty" yaml:"context,omitempty"`
+}
+
+type LoggingProfileErrorCapture struct {
+	IncludeErrorType   bool   `json:"include_error_type" yaml:"include_error_type"`
+	IncludeErrorCode   bool   `json:"include_error_code" yaml:"include_error_code"`
+	IncludeStackTrace  bool   `json:"include_stack_trace" yaml:"include_stack_trace"`
+	StackTraceField    string `json:"stack_trace_field,omitempty" yaml:"stack_trace_field,omitempty"`
+	StackHashField     string `json:"stack_hash_field,omitempty" yaml:"stack_hash_field,omitempty"`
+	StackHashAlgorithm string `json:"stack_hash_algorithm,omitempty" yaml:"stack_hash_algorithm,omitempty"`
+}
+
+type LoggingProfileSanitization struct {
+	ExistingSanitizedLogging bool   `json:"existing_sanitized_logging" yaml:"existing_sanitized_logging"`
+	Notes                    string `json:"notes,omitempty" yaml:"notes,omitempty"`
+}
+
+type LoggingProfileValidationError struct {
+	Errors []string
+}
+
 type SanitizerFunc func(string, any) any
 
 type StructuredLogger interface {
@@ -770,11 +830,23 @@ type TestLogger struct {
 	closed atomic.Bool
 }
 
+func BuiltInLoggingProfileNames() []string
+
+func DefaultLoggingProfile(string) (LoggingProfileConfig, error)
+
 func HooksFromLogger(StructuredLogger) apptheory.ObservabilityHooks
+
+func LoggingProfileCatalog() map[string]any
+
+func LoggingProfileValidationErrors(LoggingProfileConfig) []string
 
 func NewNoOpLogger() StructuredLogger
 
 func NewTestLogger() *TestLogger
+
+func ValidateLoggingProfile(LoggingProfileConfig) error
+
+func (*LoggingProfileValidationError) Error() string
 
 func (*TestLogger) Close() error
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -894,6 +894,10 @@ type TestLogger struct {
 
 func BuiltInLoggingProfileNames() []string
 
+func DecodeLoggingProfileJSON([]byte) (LoggingProfileConfig, error)
+
+func DecodeLoggingProfileYAML([]byte) (LoggingProfileConfig, error)
+
 func DefaultLoggingProfile(string) (LoggingProfileConfig, error)
 
 func EncodeLoggingProfileEvent(LoggingProfileConfig, map[string]string, LoggingProfileEvent) (map[string]any, error)

--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -48,6 +48,11 @@ Each fixture is a single JSON object.
 - `expect.error` (object, optional): expected thrown error (for example: fail-closed `m1` routing).
   - `message` (string): error message to match.
 - `expect.logs` (array, optional): expected structured log records (P2 portable envelope).
+- `expect.profile_logs` (array, optional): expected structured JSON log objects emitted by a configured
+  AppTheory logging profile.
+- `expect.profile_validation_errors` (array, optional): expected fail-closed validation errors for an invalid
+  AppTheory logging profile config.
+- `expect.logging_profile_catalog` (object, optional): expected built-in logging profile catalog.
 - `expect.metrics` (array, optional): expected metric emissions (portable subset).
 - `expect.spans` (array, optional): expected trace span emissions (portable subset).
 
@@ -144,6 +149,36 @@ Non-HTTP observability fixtures use the existing `expect.logs`, `expect.metrics`
 - Spans use trigger-specific names and attributes; raw event details, DynamoDB keys, and image values are not emitted.
 
 The safe-panic fixture pins the posture for non-HTTP handler panics/errors: observability records carry `error_code = "app.internal"`, while the surfaced error is the safe message `apptheory: event workload failed`.
+
+## P2 logging profile fixtures
+
+Logging profile fixtures pin the additive `apptheory.logging/v1` contract. They do not introduce a second
+observability path: profile-backed logging is the configured encoder/logger behavior for the existing P2
+observability surface.
+
+The contract-owned pieces are:
+
+- Profile schema version: `apptheory.logging/v1`.
+- Built-in profile names, sorted canonically: `cloudwatch-json`, `legacy`, `local-dev`, `paytheory-alert-v1`.
+- Encoding defaults and validation for JSON output.
+- Required and recommended field validation.
+- Field mapping from canonical AppTheory log event fields to profile output fields.
+- Static/env enrichment and request/job context enrichment.
+- Error type, error code, optional stack trace, and deterministic stack hash capture.
+- Sanitization-preserving behavior: profile fixtures may include safe structured fields, but raw payload fields must
+  not appear in `expect.profile_logs`.
+
+`setup.logging_profile` carries the profile config under test. `setup.environment` supplies deterministic values for
+`${ENV_VAR}` placeholders used by profile enrichment. `input.logging_event` is a synthetic canonical log event used by
+contract runners to exercise profile encoding without depending on a real provider backend.
+
+`expect.profile_logs` contains the exact structured JSON objects the profile must emit. For `paytheory-alert-v1`,
+the fixture requires enough context for alert-decisioner and Keeper lookup: partner, stage, account family, AWS region,
+service, function, request ID, trace ID, error type/code, stack hash, and normalized message.
+
+Validation-only fixtures use `expect.profile_validation_errors` and may omit `input.request`; runtimes must fail
+closed with deterministic validation messages for unsupported schema versions, profile names, encodings, field names,
+context sources, or stack hash algorithms.
 
 ## Bytes in JSON
 

--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -161,12 +161,14 @@ The contract-owned pieces are:
 - Profile schema version: `apptheory.logging/v1`.
 - Built-in profile names, sorted canonically: `cloudwatch-json`, `legacy`, `local-dev`, `paytheory-alert-v1`.
 - Encoding defaults and validation for JSON output.
+- Strict profile config decoding: unsupported top-level or nested profile options fail closed.
 - Required and recommended field validation.
 - Field mapping from canonical AppTheory log event fields to profile output fields.
 - Static/env enrichment and request/job context enrichment.
 - Error type, error code, optional stack trace, and deterministic stack hash capture.
 - Sanitization-preserving behavior: profile fixtures may include safe structured fields, but raw payload fields must
-  not appear in `expect.profile_logs`.
+  not appear in `expect.profile_logs`. Caller-provided fields must not overwrite profile-owned fields such as
+  timestamp, level, message, or static enrichment values.
 
 `setup.logging_profile` carries the profile config under test. `setup.environment` supplies deterministic values for
 `${ENV_VAR}` placeholders used by profile enrichment. `input.logging_event` is a synthetic canonical log event used by
@@ -177,8 +179,8 @@ the fixture requires enough context for alert-decisioner and Keeper lookup: part
 service, function, request ID, trace ID, error type/code, stack hash, and normalized message.
 
 Validation-only fixtures use `expect.profile_validation_errors` and may omit `input.request`; runtimes must fail
-closed with deterministic validation messages for unsupported schema versions, profile names, encodings, field names,
-context sources, or stack hash algorithms.
+closed with deterministic validation messages for unsupported schema versions, profile names, encodings, config options,
+field names, context sources, or stack hash algorithms.
 
 ## Bytes in JSON
 

--- a/contract-tests/fixtures/p2/logging-profile-catalog.json
+++ b/contract-tests/fixtures/p2/logging-profile-catalog.json
@@ -1,0 +1,19 @@
+{
+  "id": "p2.logging_profile.catalog",
+  "tier": "p2",
+  "name": "Logging profile: built-in profile catalog",
+  "input": {
+    "logging_profile_catalog": true
+  },
+  "expect": {
+    "logging_profile_catalog": {
+      "schema_version": "apptheory.logging/v1",
+      "profiles": [
+        "cloudwatch-json",
+        "legacy",
+        "local-dev",
+        "paytheory-alert-v1"
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/p2/logging-profile-field-collisions.json
+++ b/contract-tests/fixtures/p2/logging-profile-field-collisions.json
@@ -1,0 +1,73 @@
+{
+  "id": "p2.logging_profile.field_collisions",
+  "tier": "p2",
+  "name": "Logging profile: caller fields do not override profile-owned fields",
+  "setup": {
+    "environment": {
+      "SERVICE_NAME": "payments-api",
+      "STAGE": "live",
+      "PARTNER": "paytheory",
+      "AWS_LAMBDA_FUNCTION_NAME": "payments-live-authorize",
+      "AWS_REGION": "us-east-1"
+    },
+    "logging_profile": {
+      "schema_version": "apptheory.logging/v1",
+      "profile": "paytheory-alert-v1",
+      "encoding": {
+        "format": "json",
+        "timestamp_field": "ts",
+        "timestamp_format": "rfc3339nano",
+        "level_field": "level",
+        "message_field": "message"
+      },
+      "required_fields": [
+        "ts",
+        "level",
+        "message",
+        "service",
+        "stage",
+        "partner",
+        "function",
+        "aws_region"
+      ],
+      "enrichment": {
+        "static": {
+          "service": "${SERVICE_NAME}",
+          "stage": "${STAGE}",
+          "partner": "${PARTNER}",
+          "function": "${AWS_LAMBDA_FUNCTION_NAME}",
+          "aws_region": "${AWS_REGION}"
+        }
+      }
+    }
+  },
+  "input": {
+    "logging_event": {
+      "timestamp": "1970-01-01T00:00:00Z",
+      "level": "error",
+      "message": "profile-owned message",
+      "fields": {
+        "ts": "2099-01-01T00:00:00Z",
+        "level": "INFO",
+        "message": "override-msg",
+        "service": "override-service",
+        "safe_processor": "tesouro"
+      }
+    }
+  },
+  "expect": {
+    "profile_logs": [
+      {
+        "ts": "1970-01-01T00:00:00Z",
+        "level": "ERROR",
+        "message": "profile-owned message",
+        "service": "payments-api",
+        "stage": "live",
+        "partner": "paytheory",
+        "function": "payments-live-authorize",
+        "aws_region": "us-east-1",
+        "safe_processor": "tesouro"
+      }
+    ]
+  }
+}

--- a/contract-tests/fixtures/p2/logging-profile-paytheory-alert-error.json
+++ b/contract-tests/fixtures/p2/logging-profile-paytheory-alert-error.json
@@ -1,0 +1,180 @@
+{
+  "id": "p2.logging_profile.paytheory_alert_error",
+  "tier": "p2",
+  "name": "Logging profile: paytheory-alert-v1 ERROR output",
+  "setup": {
+    "logging_profile": {
+      "schema_version": "apptheory.logging/v1",
+      "profile": "paytheory-alert-v1",
+      "encoding": {
+        "format": "json",
+        "timestamp_field": "ts",
+        "timestamp_format": "rfc3339nano",
+        "level_field": "level",
+        "message_field": "message"
+      },
+      "levels": {
+        "error": "ERROR",
+        "info": "INFO",
+        "debug": "DEBUG",
+        "warn": "WARN"
+      },
+      "required_fields": [
+        "ts",
+        "level",
+        "message",
+        "service",
+        "stage",
+        "partner",
+        "function",
+        "aws_region"
+      ],
+      "recommended_fields": [
+        "source_account_id",
+        "account_family",
+        "request_id",
+        "trace_id",
+        "correlation_id",
+        "error_type",
+        "error_code",
+        "normalized_message",
+        "stack_hash",
+        "route",
+        "job_name"
+      ],
+      "field_map": {
+        "timestamp": "ts",
+        "severity": "level",
+        "message": "message",
+        "normalized_message": "normalized_message",
+        "error_type": "error_type",
+        "error_code": "error_code",
+        "request_id": "request_id",
+        "trace_id": "trace_id",
+        "correlation_id": "correlation_id",
+        "stack_trace": "stack_trace",
+        "stack_hash": "stack_hash",
+        "service": "service",
+        "stage": "stage",
+        "partner": "partner",
+        "function": "function",
+        "account_family": "account_family",
+        "source_account_id": "source_account_id",
+        "aws_region": "aws_region",
+        "route": "route",
+        "job_name": "job_name"
+      },
+      "enrichment": {
+        "static": {
+          "service": "${SERVICE_NAME}",
+          "stage": "${STAGE}",
+          "partner": "${PARTNER}",
+          "function": "${AWS_LAMBDA_FUNCTION_NAME}",
+          "aws_region": "${AWS_REGION}",
+          "source_account_id": "${SOURCE_ACCOUNT_ID}",
+          "account_family": "${ACCOUNT_FAMILY}"
+        },
+        "context": {
+          "request_id": "request.request_id",
+          "trace_id": "request.trace_id",
+          "correlation_id": "request.correlation_id",
+          "route": "request.route",
+          "job_name": "job.name"
+        }
+      },
+      "error_capture": {
+        "include_error_type": true,
+        "include_error_code": true,
+        "include_stack_trace": true,
+        "stack_trace_field": "stack_trace",
+        "stack_hash_field": "stack_hash",
+        "stack_hash_algorithm": "sha256"
+      },
+      "sanitization": {
+        "existing_sanitized_logging": true,
+        "notes": "Application fields must already be sanitized before they reach the profile; profile encoding must not introduce raw payload fields."
+      },
+      "alerting_hints": {
+        "fingerprint_fields": [
+          "service",
+          "normalized_message",
+          "error_type",
+          "stack_hash"
+        ],
+        "keeper_lookup_fields": [
+          "partner",
+          "stage",
+          "account_family",
+          "aws_region",
+          "service",
+          "function",
+          "request_id",
+          "trace_id"
+        ]
+      }
+    },
+    "environment": {
+      "SERVICE_NAME": "payments-api",
+      "STAGE": "live",
+      "PARTNER": "paytheory",
+      "AWS_LAMBDA_FUNCTION_NAME": "payments-live-authorize",
+      "AWS_REGION": "us-east-1",
+      "SOURCE_ACCOUNT_ID": "111122223333",
+      "ACCOUNT_FAMILY": "paytheory-live"
+    }
+  },
+  "input": {
+    "logging_event": {
+      "timestamp": "1970-01-01T00:00:00Z",
+      "level": "error",
+      "message": "charge authorization failed",
+      "normalized_message": "charge authorization failed",
+      "request": {
+        "request_id": "req_test_123",
+        "trace_id": "trace-profile-123",
+        "correlation_id": "corr-profile-123",
+        "route": "POST /payments/{payment_id}/authorize"
+      },
+      "job": {
+        "name": "authorize-payment"
+      },
+      "error": {
+        "type": "ProcessorError",
+        "code": "processor.declined",
+        "message": "processor declined",
+        "stack_trace": "processor.go:42\nhandler.go:7"
+      },
+      "fields": {
+        "safe_processor": "tesouro",
+        "raw_payload": "must-not-appear"
+      }
+    }
+  },
+  "expect": {
+    "profile_logs": [
+      {
+        "ts": "1970-01-01T00:00:00Z",
+        "level": "ERROR",
+        "message": "charge authorization failed",
+        "service": "payments-api",
+        "stage": "live",
+        "partner": "paytheory",
+        "function": "payments-live-authorize",
+        "aws_region": "us-east-1",
+        "source_account_id": "111122223333",
+        "account_family": "paytheory-live",
+        "request_id": "req_test_123",
+        "trace_id": "trace-profile-123",
+        "correlation_id": "corr-profile-123",
+        "error_type": "ProcessorError",
+        "error_code": "processor.declined",
+        "normalized_message": "charge authorization failed",
+        "stack_trace": "processor.go:42\nhandler.go:7",
+        "stack_hash": "sha256:d3d3dd723c56522d25492427bf8ca94b80feed197d55aa42e9bab0c1b5031bdc",
+        "route": "POST /payments/{payment_id}/authorize",
+        "job_name": "authorize-payment",
+        "safe_processor": "tesouro"
+      }
+    ]
+  }
+}

--- a/contract-tests/fixtures/p2/logging-profile-unknown-options.json
+++ b/contract-tests/fixtures/p2/logging-profile-unknown-options.json
@@ -1,0 +1,26 @@
+{
+  "id": "p2.logging_profile.unknown_options",
+  "tier": "p2",
+  "name": "Logging profile: fail closed unknown config options",
+  "setup": {
+    "logging_profile": {
+      "schema_version": "apptheory.logging/v1",
+      "profile": "paytheory-alert-v1",
+      "encoding": {
+        "format": "json",
+        "timestamp_field": "ts",
+        "timestamp_format": "rfc3339nano",
+        "level_field": "level",
+        "message_field": "message",
+        "unknown_encoding_option": true
+      },
+      "unknown_top_level": true
+    }
+  },
+  "expect": {
+    "profile_validation_errors": [
+      "encoding.unknown_encoding_option: unsupported option",
+      "unknown_top_level: unsupported option"
+    ]
+  }
+}

--- a/contract-tests/fixtures/p2/logging-profile-validation-errors.json
+++ b/contract-tests/fixtures/p2/logging-profile-validation-errors.json
@@ -1,0 +1,38 @@
+{
+  "id": "p2.logging_profile.validation_errors",
+  "tier": "p2",
+  "name": "Logging profile: fail closed validation errors",
+  "setup": {
+    "logging_profile": {
+      "schema_version": "apptheory.logging/v2",
+      "profile": "custom-alert",
+      "encoding": {
+        "format": "xml",
+        "timestamp_format": "epoch_ms"
+      },
+      "required_fields": [
+        "raw_payload"
+      ],
+      "enrichment": {
+        "context": {
+          "request_id": "lambda.raw_event.requestContext.requestId"
+        }
+      },
+      "error_capture": {
+        "include_stack_trace": true,
+        "stack_hash_algorithm": "md5"
+      }
+    }
+  },
+  "expect": {
+    "profile_validation_errors": [
+      "schema_version: unsupported value apptheory.logging/v2",
+      "profile: unsupported value custom-alert",
+      "encoding.format: unsupported value xml",
+      "encoding.timestamp_format: unsupported value epoch_ms",
+      "required_fields[0]: unsupported field raw_payload",
+      "enrichment.context.request_id: unsupported source lambda.raw_event.requestContext.requestId",
+      "error_capture.stack_hash_algorithm: unsupported value md5"
+    ]
+  }
+}

--- a/contract-tests/runners/go/apptheory_p2.go
+++ b/contract-tests/runners/go/apptheory_p2.go
@@ -10,6 +10,10 @@ import (
 )
 
 func runFixtureP2(f Fixture) error {
+	if isLoggingProfileContractFixture(f) {
+		return compareLoggingProfileContract(f)
+	}
+
 	now := time.Unix(0, 0).UTC()
 
 	var logs []FixtureLogRecord
@@ -138,4 +142,26 @@ func runFixtureP2(f Fixture) error {
 
 	actual := app.Serve(ctx, req)
 	return compareFixtureResponse(f, actual, logs, metrics, spans)
+}
+
+func isLoggingProfileContractFixture(f Fixture) bool {
+	return len(f.Setup.LoggingProfile) > 0 ||
+		len(f.Input.LoggingEvent) > 0 ||
+		f.Input.LoggingProfileCatalog ||
+		len(f.Expect.ProfileLogs) > 0 ||
+		len(f.Expect.ProfileValidationErrors) > 0 ||
+		len(f.Expect.LoggingProfileCatalog) > 0
+}
+
+func compareLoggingProfileContract(f Fixture) error {
+	if len(f.Expect.LoggingProfileCatalog) > 0 {
+		return fmt.Errorf("logging_profile_catalog mismatch")
+	}
+	if len(f.Expect.ProfileValidationErrors) > 0 {
+		return fmt.Errorf("profile_validation_errors mismatch")
+	}
+	if len(f.Expect.ProfileLogs) > 0 {
+		return fmt.Errorf("profile_logs mismatch")
+	}
+	return nil
 }

--- a/contract-tests/runners/go/apptheory_p2.go
+++ b/contract-tests/runners/go/apptheory_p2.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -164,24 +165,20 @@ func compareLoggingProfileContract(f Fixture) error {
 		return nil
 	}
 	if len(f.Expect.ProfileValidationErrors) > 0 {
-		var config observability.LoggingProfileConfig
-		if err := json.Unmarshal(f.Setup.LoggingProfile, &config); err != nil {
-			return fmt.Errorf("parse setup.logging_profile: %w", err)
-		}
-		actual := observability.LoggingProfileValidationErrors(config)
+		actual := decodeLoggingProfileValidationErrors(f.Setup.LoggingProfile)
 		if !reflect.DeepEqual(f.Expect.ProfileValidationErrors, actual) {
 			return fmt.Errorf("profile_validation_errors mismatch")
 		}
 		return nil
 	}
 	if len(f.Expect.ProfileLogs) > 0 {
-		var config observability.LoggingProfileConfig
-		if err := json.Unmarshal(f.Setup.LoggingProfile, &config); err != nil {
+		config, err := observability.DecodeLoggingProfileJSON(f.Setup.LoggingProfile)
+		if err != nil {
 			return fmt.Errorf("parse setup.logging_profile: %w", err)
 		}
 		var event observability.LoggingProfileEvent
-		if err := json.Unmarshal(f.Input.LoggingEvent, &event); err != nil {
-			return fmt.Errorf("parse input.logging_event: %w", err)
+		if parseErr := json.Unmarshal(f.Input.LoggingEvent, &event); parseErr != nil {
+			return fmt.Errorf("parse input.logging_event: %w", parseErr)
 		}
 		actual, err := observability.EncodeLoggingProfileEvent(config, f.Setup.Environment, event)
 		if err != nil {
@@ -198,6 +195,18 @@ func compareLoggingProfileContract(f Fixture) error {
 		return nil
 	}
 	return nil
+}
+
+func decodeLoggingProfileValidationErrors(raw json.RawMessage) []string {
+	_, err := observability.DecodeLoggingProfileJSON(raw)
+	if err == nil {
+		return nil
+	}
+	var profileErr *observability.LoggingProfileValidationError
+	if errors.As(err, &profileErr) {
+		return profileErr.Errors
+	}
+	return []string{err.Error()}
 }
 
 func canonicalJSONValue(value any) any {

--- a/contract-tests/runners/go/apptheory_p2.go
+++ b/contract-tests/runners/go/apptheory_p2.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
+	"github.com/theory-cloud/apptheory/pkg/observability"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
@@ -155,13 +158,56 @@ func isLoggingProfileContractFixture(f Fixture) bool {
 
 func compareLoggingProfileContract(f Fixture) error {
 	if len(f.Expect.LoggingProfileCatalog) > 0 {
-		return fmt.Errorf("logging_profile_catalog mismatch")
+		if !reflect.DeepEqual(canonicalJSONValue(observability.LoggingProfileCatalog()), canonicalJSONValue(f.Expect.LoggingProfileCatalog)) {
+			return fmt.Errorf("logging_profile_catalog mismatch")
+		}
+		return nil
 	}
 	if len(f.Expect.ProfileValidationErrors) > 0 {
-		return fmt.Errorf("profile_validation_errors mismatch")
+		var config observability.LoggingProfileConfig
+		if err := json.Unmarshal(f.Setup.LoggingProfile, &config); err != nil {
+			return fmt.Errorf("parse setup.logging_profile: %w", err)
+		}
+		actual := observability.LoggingProfileValidationErrors(config)
+		if !reflect.DeepEqual(f.Expect.ProfileValidationErrors, actual) {
+			return fmt.Errorf("profile_validation_errors mismatch")
+		}
+		return nil
 	}
 	if len(f.Expect.ProfileLogs) > 0 {
-		return fmt.Errorf("profile_logs mismatch")
+		var config observability.LoggingProfileConfig
+		if err := json.Unmarshal(f.Setup.LoggingProfile, &config); err != nil {
+			return fmt.Errorf("parse setup.logging_profile: %w", err)
+		}
+		var event observability.LoggingProfileEvent
+		if err := json.Unmarshal(f.Input.LoggingEvent, &event); err != nil {
+			return fmt.Errorf("parse input.logging_event: %w", err)
+		}
+		actual, err := observability.EncodeLoggingProfileEvent(config, f.Setup.Environment, event)
+		if err != nil {
+			return fmt.Errorf("encode logging profile event: %w", err)
+		}
+		canonicalActual, ok := canonicalJSONValue(actual).(map[string]any)
+		if !ok {
+			return fmt.Errorf("profile_logs mismatch")
+		}
+		actualLogs := []map[string]any{canonicalActual}
+		if !reflect.DeepEqual(canonicalJSONValue(f.Expect.ProfileLogs), canonicalJSONValue(actualLogs)) {
+			return fmt.Errorf("profile_logs mismatch")
+		}
+		return nil
 	}
 	return nil
+}
+
+func canonicalJSONValue(value any) any {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return value
+	}
+	return out
 }

--- a/contract-tests/runners/go/fixture.go
+++ b/contract-tests/runners/go/fixture.go
@@ -25,6 +25,8 @@ type FixtureSetup struct {
 	Routes          []FixtureRoute            `json:"routes,omitempty"`
 	Middlewares     []string                  `json:"middlewares,omitempty"`
 	CORS            FixtureCORSConfig         `json:"cors,omitempty"`
+	Environment     map[string]string         `json:"environment,omitempty"`
+	LoggingProfile  json.RawMessage           `json:"logging_profile,omitempty"`
 	WebSockets      []FixtureWebSocketRoute   `json:"websockets,omitempty"`
 	SQS             []FixtureSQSRoute         `json:"sqs,omitempty"`
 	Kinesis         []FixtureKinesisRoute     `json:"kinesis,omitempty"`
@@ -79,9 +81,11 @@ type FixtureDynamoDBRoute struct {
 }
 
 type FixtureInput struct {
-	Context  FixtureContext   `json:"context,omitempty"`
-	Request  *FixtureRequest  `json:"request,omitempty"`
-	AWSEvent *FixtureAWSEvent `json:"aws_event,omitempty"`
+	Context               FixtureContext   `json:"context,omitempty"`
+	Request               *FixtureRequest  `json:"request,omitempty"`
+	AWSEvent              *FixtureAWSEvent `json:"aws_event,omitempty"`
+	LoggingEvent          json.RawMessage  `json:"logging_event,omitempty"`
+	LoggingProfileCatalog bool             `json:"logging_profile_catalog,omitempty"`
 }
 
 type FixtureAWSEvent struct {
@@ -104,13 +108,16 @@ type FixtureRequest struct {
 }
 
 type FixtureExpect struct {
-	Response       *FixtureResponse       `json:"response,omitempty"`
-	Output         json.RawMessage        `json:"output_json,omitempty"`
-	Error          *FixtureError          `json:"error,omitempty"`
-	WebSocketCalls []FixtureWebSocketCall `json:"ws_calls,omitempty"`
-	Logs           []FixtureLogRecord     `json:"logs,omitempty"`
-	Metrics        []FixtureMetricRecord  `json:"metrics,omitempty"`
-	Spans          []FixtureSpanRecord    `json:"spans,omitempty"`
+	Response                *FixtureResponse       `json:"response,omitempty"`
+	Output                  json.RawMessage        `json:"output_json,omitempty"`
+	Error                   *FixtureError          `json:"error,omitempty"`
+	WebSocketCalls          []FixtureWebSocketCall `json:"ws_calls,omitempty"`
+	Logs                    []FixtureLogRecord     `json:"logs,omitempty"`
+	Metrics                 []FixtureMetricRecord  `json:"metrics,omitempty"`
+	Spans                   []FixtureSpanRecord    `json:"spans,omitempty"`
+	ProfileLogs             []map[string]any       `json:"profile_logs,omitempty"`
+	ProfileValidationErrors []string               `json:"profile_validation_errors,omitempty"`
+	LoggingProfileCatalog   map[string]any         `json:"logging_profile_catalog,omitempty"`
 }
 
 type FixtureError struct {

--- a/contract-tests/runners/go/runner.go
+++ b/contract-tests/runners/go/runner.go
@@ -153,6 +153,25 @@ func printFailure(f Fixture, err error) {
 	fmt.Fprintf(os.Stderr, "FAIL %s — %s\n", f.ID, f.Name)
 	fmt.Fprintf(os.Stderr, "  %v\n", err)
 
+	if isLoggingProfileContractFixture(f) {
+		if len(f.Expect.LoggingProfileCatalog) > 0 {
+			expected := marshalIndentOrPlaceholder(f.Expect.LoggingProfileCatalog)
+			fmt.Fprintf(os.Stderr, "  expected.logging_profile_catalog: %s\n", string(expected))
+			fmt.Fprintf(os.Stderr, "  got.logging_profile_catalog: null\n")
+		}
+		if len(f.Expect.ProfileValidationErrors) > 0 {
+			expected := marshalIndentOrPlaceholder(f.Expect.ProfileValidationErrors)
+			fmt.Fprintf(os.Stderr, "  expected.profile_validation_errors: %s\n", string(expected))
+			fmt.Fprintf(os.Stderr, "  got.profile_validation_errors: []\n")
+		}
+		if len(f.Expect.ProfileLogs) > 0 {
+			expected := marshalIndentOrPlaceholder(f.Expect.ProfileLogs)
+			fmt.Fprintf(os.Stderr, "  expected.profile_logs: %s\n", string(expected))
+			fmt.Fprintf(os.Stderr, "  got.profile_logs: []\n")
+		}
+		return
+	}
+
 	if strings.EqualFold(strings.TrimSpace(f.Tier), "p0") {
 		printFailureP0(f)
 		return

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -691,6 +691,38 @@ def compare_headers(expected: dict[str, Any] | None, actual: dict[str, Any] | No
     return canonicalize_headers(expected) == canonicalize_headers(actual)
 
 
+def is_logging_profile_contract_fixture(fixture: dict[str, Any]) -> bool:
+    setup = fixture.get("setup", {}) or {}
+    input_obj = fixture.get("input", {}) or {}
+    expect_obj = fixture.get("expect", {}) or {}
+    return (
+        "logging_profile" in setup
+        or "logging_event" in input_obj
+        or "logging_profile_catalog" in input_obj
+        or "profile_logs" in expect_obj
+        or "profile_validation_errors" in expect_obj
+        or "logging_profile_catalog" in expect_obj
+    )
+
+
+def compare_logging_profile_contract(
+    fixture: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any], dict[str, Any], _DummyEffectsApp]:
+    expect_obj = fixture.get("expect", {}) or {}
+    actual: dict[str, Any] = {
+        "logging_profile_catalog": None,
+        "profile_validation_errors": [],
+        "profile_logs": [],
+    }
+    if "logging_profile_catalog" in expect_obj:
+        return False, "logging_profile_catalog mismatch", actual, expect_obj, _DummyEffectsApp()
+    if "profile_validation_errors" in expect_obj:
+        return False, "profile_validation_errors mismatch", actual, expect_obj, _DummyEffectsApp()
+    if "profile_logs" in expect_obj:
+        return False, "profile_logs mismatch", actual, expect_obj, _DummyEffectsApp()
+    return True, "", actual, expect_obj, _DummyEffectsApp()
+
+
 def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, dict[str, Any], FixtureApp]:
     tier = str(fixture.get("tier", "")).strip().lower()
     if tier == "p0":
@@ -698,6 +730,8 @@ def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, 
     if tier == "p1":
         return run_fixture_p1(fixture)
     if tier == "p2":
+        if is_logging_profile_contract_fixture(fixture):
+            return compare_logging_profile_contract(fixture)
         expect_obj = fixture.get("expect", {}) or {}
         if "output_json" in expect_obj or "error" in expect_obj:
             return run_fixture_p2_output(fixture)
@@ -2507,6 +2541,32 @@ def main() -> int:
                     print(f"  got.error: {stable_json(actual)}", file=sys.stderr)
                 else:
                     print(f"  got.output_json: {stable_json(actual)}", file=sys.stderr)
+        elif (
+            "logging_profile_catalog" in expect_obj
+            or "profile_validation_errors" in expect_obj
+            or "profile_logs" in expect_obj
+        ):
+            if "logging_profile_catalog" in expect_obj:
+                print(
+                    f"  expected.logging_profile_catalog: {stable_json(expect_obj.get('logging_profile_catalog'))}",
+                    file=sys.stderr,
+                )
+                print(
+                    f"  got.logging_profile_catalog: {stable_json(actual.get('logging_profile_catalog'))}",
+                    file=sys.stderr,
+                )
+            if "profile_validation_errors" in expect_obj:
+                print(
+                    f"  expected.profile_validation_errors: {stable_json(expect_obj.get('profile_validation_errors'))}",
+                    file=sys.stderr,
+                )
+                print(
+                    f"  got.profile_validation_errors: {stable_json(actual.get('profile_validation_errors'))}",
+                    file=sys.stderr,
+                )
+            if "profile_logs" in expect_obj:
+                print(f"  expected.profile_logs: {stable_json(expect_obj.get('profile_logs'))}", file=sys.stderr)
+                print(f"  got.profile_logs: {stable_json(actual.get('profile_logs'))}", file=sys.stderr)
         else:
             print(f"  expected: {stable_json(expected)}", file=sys.stderr)
             print(f"  got: {stable_json(debug_actual_for_expected(actual, expected))}", file=sys.stderr)

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -50,6 +50,49 @@ function deepEqual(a, b) {
   return util.isDeepStrictEqual(a, b);
 }
 
+function isLoggingProfileContractFixture(fixture) {
+  const setup = fixture.setup ?? {};
+  const input = fixture.input ?? {};
+  const expect = fixture.expect ?? {};
+  return (
+    Object.prototype.hasOwnProperty.call(setup, "logging_profile") ||
+    Object.prototype.hasOwnProperty.call(input, "logging_event") ||
+    Object.prototype.hasOwnProperty.call(input, "logging_profile_catalog") ||
+    Object.prototype.hasOwnProperty.call(expect, "profile_logs") ||
+    Object.prototype.hasOwnProperty.call(expect, "profile_validation_errors") ||
+    Object.prototype.hasOwnProperty.call(expect, "logging_profile_catalog")
+  );
+}
+
+function compareLoggingProfileContract(fixture) {
+  const expect = fixture.expect ?? {};
+  if (Object.prototype.hasOwnProperty.call(expect, "logging_profile_catalog")) {
+    return {
+      ok: false,
+      reason: "logging_profile_catalog mismatch",
+      expected_logging_profile_catalog: expect.logging_profile_catalog,
+      actual_logging_profile_catalog: null,
+    };
+  }
+  if (Object.prototype.hasOwnProperty.call(expect, "profile_validation_errors")) {
+    return {
+      ok: false,
+      reason: "profile_validation_errors mismatch",
+      expected_profile_validation_errors: expect.profile_validation_errors ?? [],
+      actual_profile_validation_errors: [],
+    };
+  }
+  if (Object.prototype.hasOwnProperty.call(expect, "profile_logs")) {
+    return {
+      ok: false,
+      reason: "profile_logs mismatch",
+      expected_profile_logs: expect.profile_logs ?? [],
+      actual_profile_logs: [],
+    };
+  }
+  return { ok: true };
+}
+
 function listFixtureFiles(fixturesRoot) {
   const tiers = ["p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14"];
   const files = [];
@@ -617,6 +660,9 @@ async function runFixture(fixture) {
     return compareFixture(fixture, actual, effects);
   }
   if (tier === "p2") {
+    if (isLoggingProfileContractFixture(fixture)) {
+      return compareLoggingProfileContract(fixture);
+    }
     const expect = fixture.expect ?? {};
     if (
       Object.prototype.hasOwnProperty.call(expect, "output_json") ||
@@ -2636,8 +2682,19 @@ async function main() {
         console.error(`  got.error: ${stableStringify(result.actual_error)}`);
       }
     } else {
-      console.error(`  expected: ${stableStringify(result.expected)}`);
-      console.error(`  got: ${stableStringify(debugActualForExpected(result.actual, result.expected))}`);
+      if ("expected_logging_profile_catalog" in result) {
+        console.error(`  expected.logging_profile_catalog: ${stableStringify(result.expected_logging_profile_catalog)}`);
+        console.error(`  got.logging_profile_catalog: ${stableStringify(result.actual_logging_profile_catalog)}`);
+      } else if ("expected_profile_validation_errors" in result) {
+        console.error(`  expected.profile_validation_errors: ${stableStringify(result.expected_profile_validation_errors)}`);
+        console.error(`  got.profile_validation_errors: ${stableStringify(result.actual_profile_validation_errors)}`);
+      } else if ("expected_profile_logs" in result) {
+        console.error(`  expected.profile_logs: ${stableStringify(result.expected_profile_logs)}`);
+        console.error(`  got.profile_logs: ${stableStringify(result.actual_profile_logs)}`);
+      } else {
+        console.error(`  expected: ${stableStringify(result.expected)}`);
+        console.error(`  got: ${stableStringify(debugActualForExpected(result.actual, result.expected))}`);
+      }
     }
     if ("expected_logs" in result) {
       console.error(`  expected.logs: ${stableStringify(result.expected_logs)}`);

--- a/pkg/observability/profile_config.go
+++ b/pkg/observability/profile_config.go
@@ -343,7 +343,7 @@ func validateErrorCapture(capture LoggingProfileErrorCapture) []string {
 }
 
 func validateAlertingHints(hints LoggingProfileAlertingHints) []string {
-	var errs []string
+	errs := make([]string, 0, len(hints.FingerprintFields)+len(hints.KeeperLookupFields))
 	errs = append(errs, validateProfileFieldList("alerting_hints.fingerprint_fields", hints.FingerprintFields)...)
 	errs = append(errs, validateProfileFieldList("alerting_hints.keeper_lookup_fields", hints.KeeperLookupFields)...)
 	return errs

--- a/pkg/observability/profile_config.go
+++ b/pkg/observability/profile_config.go
@@ -1,9 +1,13 @@
 package observability
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 const LoggingProfileSchemaVersion = "apptheory.logging/v1"
@@ -114,6 +118,37 @@ func DefaultLoggingProfile(profile string) (LoggingProfileConfig, error) {
 	}
 }
 
+func DecodeLoggingProfileJSON(raw []byte) (LoggingProfileConfig, error) {
+	var config LoggingProfileConfig
+	strictErrs, err := strictLoggingProfileJSONOptionErrors(raw)
+	if err != nil {
+		return config, err
+	}
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return config, fmt.Errorf("logging profile json: %w", err)
+	}
+	errs := make([]string, 0, len(strictErrs))
+	errs = append(errs, strictErrs...)
+	errs = append(errs, LoggingProfileValidationErrors(config)...)
+	if len(errs) > 0 {
+		return config, &LoggingProfileValidationError{Errors: errs}
+	}
+	return config, nil
+}
+
+func DecodeLoggingProfileYAML(raw []byte) (LoggingProfileConfig, error) {
+	var config LoggingProfileConfig
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&config); err != nil {
+		return config, fmt.Errorf("logging profile yaml: %w", err)
+	}
+	if err := ValidateLoggingProfile(config); err != nil {
+		return config, err
+	}
+	return config, nil
+}
+
 func ValidateLoggingProfile(config LoggingProfileConfig) error {
 	errs := LoggingProfileValidationErrors(config)
 	if len(errs) == 0 {
@@ -164,6 +199,72 @@ func LoggingProfileValidationErrors(config LoggingProfileConfig) []string {
 	errs = append(errs, validateAlertingHints(config.AlertingHints)...)
 
 	return errs
+}
+
+type loggingProfileJSONOptionSchema struct {
+	allowed map[string]struct{}
+	nested  map[string]loggingProfileJSONOptionSchema
+}
+
+var loggingProfileJSONOptions = loggingProfileJSONOptionSchema{
+	allowed: optionNameSet(
+		"schema_version", "profile", "encoding", "levels", "required_fields", "recommended_fields",
+		"field_map", "enrichment", "error_capture", "sanitization", "alerting_hints",
+	),
+	nested: map[string]loggingProfileJSONOptionSchema{
+		"encoding":   {allowed: optionNameSet("format", "timestamp_field", "timestamp_format", "level_field", "message_field")},
+		"enrichment": {allowed: optionNameSet("static", "context")},
+		"error_capture": {allowed: optionNameSet(
+			"include_error_type", "include_error_code", "include_stack_trace",
+			"stack_trace_field", "stack_hash_field", "stack_hash_algorithm",
+		)},
+		"sanitization":   {allowed: optionNameSet("existing_sanitized_logging", "notes")},
+		"alerting_hints": {allowed: optionNameSet("fingerprint_fields", "keeper_lookup_fields")},
+	},
+}
+
+func strictLoggingProfileJSONOptionErrors(raw []byte) ([]string, error) {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("logging profile json: %w", err)
+	}
+	return validateLoggingProfileJSONOptions("", root, loggingProfileJSONOptions), nil
+}
+
+func validateLoggingProfileJSONOptions(path string, object map[string]json.RawMessage, schema loggingProfileJSONOptionSchema) []string {
+	var errs []string
+	for _, key := range sortedMapKeys(object) {
+		childPath := profileJSONOptionPath(path, key)
+		if !stringInSet(key, schema.allowed) {
+			errs = append(errs, childPath+": unsupported option")
+			continue
+		}
+		childSchema, ok := schema.nested[key]
+		if !ok {
+			continue
+		}
+		var child map[string]json.RawMessage
+		if err := json.Unmarshal(object[key], &child); err != nil {
+			continue
+		}
+		errs = append(errs, validateLoggingProfileJSONOptions(childPath, child, childSchema)...)
+	}
+	return errs
+}
+
+func profileJSONOptionPath(parent string, key string) string {
+	if parent == "" {
+		return key
+	}
+	return parent + "." + key
+}
+
+func optionNameSet(names ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		out[name] = struct{}{}
+	}
+	return out
 }
 
 func baseJSONProfile(profile string) LoggingProfileConfig {

--- a/pkg/observability/profile_config.go
+++ b/pkg/observability/profile_config.go
@@ -1,0 +1,407 @@
+package observability
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const LoggingProfileSchemaVersion = "apptheory.logging/v1"
+
+const (
+	LoggingProfilePayTheoryAlertV1 = "paytheory-alert-v1"
+	LoggingProfileCloudWatchJSON   = "cloudwatch-json"
+	LoggingProfileLegacy           = "legacy"
+	LoggingProfileLocalDev         = "local-dev"
+)
+
+type LoggingProfileConfig struct {
+	SchemaVersion     string                      `json:"schema_version" yaml:"schema_version"`
+	Profile           string                      `json:"profile" yaml:"profile"`
+	Encoding          LoggingProfileEncoding      `json:"encoding" yaml:"encoding"`
+	Levels            map[string]string           `json:"levels,omitempty" yaml:"levels,omitempty"`
+	RequiredFields    []string                    `json:"required_fields,omitempty" yaml:"required_fields,omitempty"`
+	RecommendedFields []string                    `json:"recommended_fields,omitempty" yaml:"recommended_fields,omitempty"`
+	FieldMap          map[string]string           `json:"field_map,omitempty" yaml:"field_map,omitempty"`
+	Enrichment        LoggingProfileEnrichment    `json:"enrichment,omitempty" yaml:"enrichment,omitempty"`
+	ErrorCapture      LoggingProfileErrorCapture  `json:"error_capture,omitempty" yaml:"error_capture,omitempty"`
+	Sanitization      LoggingProfileSanitization  `json:"sanitization,omitempty" yaml:"sanitization,omitempty"`
+	AlertingHints     LoggingProfileAlertingHints `json:"alerting_hints,omitempty" yaml:"alerting_hints,omitempty"`
+}
+
+type LoggingProfileEncoding struct {
+	Format          string `json:"format" yaml:"format"`
+	TimestampField  string `json:"timestamp_field,omitempty" yaml:"timestamp_field,omitempty"`
+	TimestampFormat string `json:"timestamp_format,omitempty" yaml:"timestamp_format,omitempty"`
+	LevelField      string `json:"level_field,omitempty" yaml:"level_field,omitempty"`
+	MessageField    string `json:"message_field,omitempty" yaml:"message_field,omitempty"`
+}
+
+type LoggingProfileEnrichment struct {
+	Static  map[string]string `json:"static,omitempty" yaml:"static,omitempty"`
+	Context map[string]string `json:"context,omitempty" yaml:"context,omitempty"`
+}
+
+type LoggingProfileErrorCapture struct {
+	IncludeErrorType   bool   `json:"include_error_type" yaml:"include_error_type"`
+	IncludeErrorCode   bool   `json:"include_error_code" yaml:"include_error_code"`
+	IncludeStackTrace  bool   `json:"include_stack_trace" yaml:"include_stack_trace"`
+	StackTraceField    string `json:"stack_trace_field,omitempty" yaml:"stack_trace_field,omitempty"`
+	StackHashField     string `json:"stack_hash_field,omitempty" yaml:"stack_hash_field,omitempty"`
+	StackHashAlgorithm string `json:"stack_hash_algorithm,omitempty" yaml:"stack_hash_algorithm,omitempty"`
+}
+
+type LoggingProfileSanitization struct {
+	ExistingSanitizedLogging bool   `json:"existing_sanitized_logging" yaml:"existing_sanitized_logging"`
+	Notes                    string `json:"notes,omitempty" yaml:"notes,omitempty"`
+}
+
+type LoggingProfileAlertingHints struct {
+	FingerprintFields  []string `json:"fingerprint_fields,omitempty" yaml:"fingerprint_fields,omitempty"`
+	KeeperLookupFields []string `json:"keeper_lookup_fields,omitempty" yaml:"keeper_lookup_fields,omitempty"`
+}
+
+type LoggingProfileValidationError struct {
+	Errors []string
+}
+
+func (e *LoggingProfileValidationError) Error() string {
+	if e == nil || len(e.Errors) == 0 {
+		return "logging profile validation failed"
+	}
+	return "logging profile validation failed: " + strings.Join(e.Errors, "; ")
+}
+
+func BuiltInLoggingProfileNames() []string {
+	out := []string{
+		LoggingProfileCloudWatchJSON,
+		LoggingProfileLegacy,
+		LoggingProfileLocalDev,
+		LoggingProfilePayTheoryAlertV1,
+	}
+	sort.Strings(out)
+	return out
+}
+
+func LoggingProfileCatalog() map[string]any {
+	return map[string]any{
+		"schema_version": LoggingProfileSchemaVersion,
+		"profiles":       BuiltInLoggingProfileNames(),
+	}
+}
+
+func DefaultLoggingProfile(profile string) (LoggingProfileConfig, error) {
+	key := normalizeProfileToken(profile)
+	switch key {
+	case LoggingProfilePayTheoryAlertV1:
+		return payTheoryAlertProfile(), nil
+	case LoggingProfileCloudWatchJSON:
+		cfg := baseJSONProfile(LoggingProfileCloudWatchJSON)
+		cfg.RequiredFields = []string{"timestamp", "level", "message"}
+		return cfg, nil
+	case LoggingProfileLegacy:
+		cfg := baseJSONProfile(LoggingProfileLegacy)
+		cfg.Encoding.TimestampField = "timestamp"
+		cfg.Encoding.LevelField = "level"
+		cfg.Encoding.MessageField = "message"
+		return cfg, nil
+	case LoggingProfileLocalDev:
+		cfg := baseJSONProfile(LoggingProfileLocalDev)
+		cfg.Levels = map[string]string{"debug": "DEBUG", "info": "INFO", "warn": "WARN", "error": "ERROR"}
+		return cfg, nil
+	default:
+		return LoggingProfileConfig{}, fmt.Errorf("profile: unsupported value %s", strings.TrimSpace(profile))
+	}
+}
+
+func ValidateLoggingProfile(config LoggingProfileConfig) error {
+	errs := LoggingProfileValidationErrors(config)
+	if len(errs) == 0 {
+		return nil
+	}
+	return &LoggingProfileValidationError{Errors: errs}
+}
+
+func LoggingProfileValidationErrors(config LoggingProfileConfig) []string {
+	var errs []string
+
+	schema := strings.TrimSpace(config.SchemaVersion)
+	if schema == "" {
+		errs = append(errs, "schema_version: required")
+	} else if schema != LoggingProfileSchemaVersion {
+		errs = append(errs, "schema_version: unsupported value "+schema)
+	}
+
+	profile := normalizeProfileToken(config.Profile)
+	if profile == "" {
+		errs = append(errs, "profile: required")
+	} else if !isSupportedProfile(profile) {
+		errs = append(errs, "profile: unsupported value "+strings.TrimSpace(config.Profile))
+	}
+
+	format := strings.ToLower(strings.TrimSpace(config.Encoding.Format))
+	if format == "" {
+		errs = append(errs, "encoding.format: required")
+	} else if format != "json" {
+		errs = append(errs, "encoding.format: unsupported value "+strings.TrimSpace(config.Encoding.Format))
+	}
+
+	timestampFormat := strings.ToLower(strings.TrimSpace(config.Encoding.TimestampFormat))
+	if timestampFormat != "" && timestampFormat != "rfc3339nano" && timestampFormat != "rfc3339" {
+		errs = append(errs, "encoding.timestamp_format: unsupported value "+strings.TrimSpace(config.Encoding.TimestampFormat))
+	}
+
+	errs = append(errs, validateLevelMap(config.Levels)...)
+	errs = append(errs, validateProfileFieldList("required_fields", config.RequiredFields)...)
+	errs = append(errs, validateProfileFieldList("recommended_fields", config.RecommendedFields)...)
+	errs = append(errs, validateFieldMap(config.FieldMap)...)
+	errs = append(errs, validateStaticEnrichment(config.Enrichment.Static)...)
+	errs = append(errs, validateContextEnrichment(config.Enrichment.Context)...)
+	errs = append(errs, validateErrorCapture(config.ErrorCapture)...)
+	errs = append(errs, validateAlertingHints(config.AlertingHints)...)
+
+	return errs
+}
+
+func baseJSONProfile(profile string) LoggingProfileConfig {
+	return LoggingProfileConfig{
+		SchemaVersion: LoggingProfileSchemaVersion,
+		Profile:       profile,
+		Encoding: LoggingProfileEncoding{
+			Format:          "json",
+			TimestampField:  "timestamp",
+			TimestampFormat: "rfc3339nano",
+			LevelField:      "level",
+			MessageField:    "message",
+		},
+		Levels: map[string]string{"debug": "DEBUG", "info": "INFO", "warn": "WARN", "error": "ERROR"},
+		FieldMap: map[string]string{
+			"timestamp": "timestamp",
+			"severity":  "level",
+			"message":   "message",
+		},
+	}
+}
+
+func payTheoryAlertProfile() LoggingProfileConfig {
+	cfg := baseJSONProfile(LoggingProfilePayTheoryAlertV1)
+	cfg.Encoding = LoggingProfileEncoding{
+		Format:          "json",
+		TimestampField:  "ts",
+		TimestampFormat: "rfc3339nano",
+		LevelField:      "level",
+		MessageField:    "message",
+	}
+	cfg.RequiredFields = []string{"ts", "level", "message", "service", "stage", "partner", "function", "aws_region"}
+	cfg.RecommendedFields = []string{
+		"source_account_id", "account_family", "request_id", "trace_id", "correlation_id",
+		"error_type", "error_code", "normalized_message", "stack_hash", "route", "job_name",
+	}
+	cfg.FieldMap = map[string]string{
+		"timestamp":          "ts",
+		"severity":           "level",
+		"message":            "message",
+		"normalized_message": "normalized_message",
+		"error_type":         "error_type",
+		"error_code":         "error_code",
+		"request_id":         "request_id",
+		"trace_id":           "trace_id",
+		"correlation_id":     "correlation_id",
+		"stack_trace":        "stack_trace",
+		"stack_hash":         "stack_hash",
+		"service":            "service",
+		"stage":              "stage",
+		"partner":            "partner",
+		"function":           "function",
+		"account_family":     "account_family",
+		"source_account_id":  "source_account_id",
+		"aws_region":         "aws_region",
+		"route":              "route",
+		"job_name":           "job_name",
+	}
+	cfg.Enrichment = LoggingProfileEnrichment{
+		Static: map[string]string{
+			"service":           "${SERVICE_NAME}",
+			"stage":             "${STAGE}",
+			"partner":           "${PARTNER}",
+			"function":          "${AWS_LAMBDA_FUNCTION_NAME}",
+			"aws_region":        "${AWS_REGION}",
+			"source_account_id": "${SOURCE_ACCOUNT_ID}",
+			"account_family":    "${ACCOUNT_FAMILY}",
+		},
+		Context: map[string]string{
+			"request_id":     "request.request_id",
+			"trace_id":       "request.trace_id",
+			"correlation_id": "request.correlation_id",
+			"route":          "request.route",
+			"job_name":       "job.name",
+		},
+	}
+	cfg.ErrorCapture = LoggingProfileErrorCapture{
+		IncludeErrorType:   true,
+		IncludeErrorCode:   true,
+		IncludeStackTrace:  true,
+		StackTraceField:    "stack_trace",
+		StackHashField:     "stack_hash",
+		StackHashAlgorithm: "sha256",
+	}
+	cfg.Sanitization = LoggingProfileSanitization{ExistingSanitizedLogging: true}
+	cfg.AlertingHints = LoggingProfileAlertingHints{
+		FingerprintFields:  []string{"service", "normalized_message", "error_type", "stack_hash"},
+		KeeperLookupFields: []string{"partner", "stage", "account_family", "aws_region", "service", "function", "request_id", "trace_id"},
+	}
+	return cfg
+}
+
+func validateLevelMap(levels map[string]string) []string {
+	var errs []string
+	keys := sortedMapKeys(levels)
+	for _, key := range keys {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if !stringInSet(normalized, map[string]struct{}{"debug": {}, "info": {}, "warn": {}, "error": {}}) {
+			errs = append(errs, "levels."+key+": unsupported level "+key)
+			continue
+		}
+		if strings.TrimSpace(levels[key]) == "" {
+			errs = append(errs, "levels."+key+": required")
+		}
+	}
+	return errs
+}
+
+func validateProfileFieldList(path string, fields []string) []string {
+	var errs []string
+	for i, field := range fields {
+		trimmed := strings.TrimSpace(field)
+		if trimmed == "" {
+			errs = append(errs, fmt.Sprintf("%s[%d]: required", path, i))
+			continue
+		}
+		if !isSupportedProfileOutputField(trimmed) {
+			errs = append(errs, fmt.Sprintf("%s[%d]: unsupported field %s", path, i, trimmed))
+		}
+	}
+	return errs
+}
+
+func validateFieldMap(fieldMap map[string]string) []string {
+	var errs []string
+	for _, key := range sortedMapKeys(fieldMap) {
+		canonical := strings.TrimSpace(key)
+		if !isSupportedCanonicalField(canonical) {
+			errs = append(errs, "field_map."+key+": unsupported source "+canonical)
+		}
+		out := strings.TrimSpace(fieldMap[key])
+		if out == "" {
+			errs = append(errs, "field_map."+key+": required")
+		} else if !isSupportedProfileOutputField(out) {
+			errs = append(errs, "field_map."+key+": unsupported field "+out)
+		}
+	}
+	return errs
+}
+
+func validateStaticEnrichment(static map[string]string) []string {
+	var errs []string
+	for _, key := range sortedMapKeys(static) {
+		if !isSupportedProfileOutputField(strings.TrimSpace(key)) {
+			errs = append(errs, "enrichment.static."+key+": unsupported field "+strings.TrimSpace(key))
+		}
+	}
+	return errs
+}
+
+func validateContextEnrichment(context map[string]string) []string {
+	var errs []string
+	for _, key := range sortedMapKeys(context) {
+		if !isSupportedProfileOutputField(strings.TrimSpace(key)) {
+			errs = append(errs, "enrichment.context."+key+": unsupported field "+strings.TrimSpace(key))
+		}
+		source := strings.TrimSpace(context[key])
+		if source == "" {
+			errs = append(errs, "enrichment.context."+key+": required")
+		} else if !isSupportedContextSource(source) {
+			errs = append(errs, "enrichment.context."+key+": unsupported source "+source)
+		}
+	}
+	return errs
+}
+
+func validateErrorCapture(capture LoggingProfileErrorCapture) []string {
+	var errs []string
+	if strings.TrimSpace(capture.StackTraceField) != "" && !isSupportedProfileOutputField(strings.TrimSpace(capture.StackTraceField)) {
+		errs = append(errs, "error_capture.stack_trace_field: unsupported field "+strings.TrimSpace(capture.StackTraceField))
+	}
+	if strings.TrimSpace(capture.StackHashField) != "" && !isSupportedProfileOutputField(strings.TrimSpace(capture.StackHashField)) {
+		errs = append(errs, "error_capture.stack_hash_field: unsupported field "+strings.TrimSpace(capture.StackHashField))
+	}
+	algorithm := strings.ToLower(strings.TrimSpace(capture.StackHashAlgorithm))
+	if algorithm != "" && algorithm != "sha256" {
+		errs = append(errs, "error_capture.stack_hash_algorithm: unsupported value "+strings.TrimSpace(capture.StackHashAlgorithm))
+	}
+	return errs
+}
+
+func validateAlertingHints(hints LoggingProfileAlertingHints) []string {
+	var errs []string
+	errs = append(errs, validateProfileFieldList("alerting_hints.fingerprint_fields", hints.FingerprintFields)...)
+	errs = append(errs, validateProfileFieldList("alerting_hints.keeper_lookup_fields", hints.KeeperLookupFields)...)
+	return errs
+}
+
+func isSupportedProfile(profile string) bool {
+	return stringInSet(normalizeProfileToken(profile), map[string]struct{}{
+		LoggingProfilePayTheoryAlertV1: {},
+		LoggingProfileCloudWatchJSON:   {},
+		LoggingProfileLegacy:           {},
+		LoggingProfileLocalDev:         {},
+	})
+}
+
+func isSupportedCanonicalField(field string) bool {
+	return stringInSet(field, map[string]struct{}{
+		"timestamp": {}, "severity": {}, "message": {}, "event": {},
+		"normalized_message": {}, "error_type": {}, "error_code": {},
+		"request_id": {}, "tenant_id": {}, "user_id": {}, "trace_id": {}, "span_id": {}, "correlation_id": {},
+		"stack_trace": {}, "stack_hash": {}, "service": {}, "stage": {}, "partner": {}, "function": {},
+		"account_family": {}, "source_account_id": {}, "aws_region": {}, "route": {}, "job_name": {},
+		"method": {}, "path": {}, "status": {},
+	})
+}
+
+func isSupportedProfileOutputField(field string) bool {
+	return stringInSet(field, map[string]struct{}{
+		"ts": {}, "timestamp": {}, "level": {}, "severity": {}, "message": {}, "event": {},
+		"service": {}, "stage": {}, "partner": {}, "function": {}, "aws_region": {},
+		"source_account_id": {}, "account_family": {}, "request_id": {}, "tenant_id": {}, "user_id": {},
+		"trace_id": {}, "span_id": {}, "correlation_id": {}, "error_type": {}, "error_code": {},
+		"normalized_message": {}, "stack_trace": {}, "stack_hash": {}, "route": {}, "job_name": {},
+		"method": {}, "path": {}, "status": {},
+	})
+}
+
+func isSupportedContextSource(source string) bool {
+	return stringInSet(source, map[string]struct{}{
+		"request.request_id": {}, "request.tenant_id": {}, "request.user_id": {}, "request.trace_id": {},
+		"request.span_id": {}, "request.correlation_id": {}, "request.route": {}, "request.method": {},
+		"request.path": {}, "request.status": {}, "job.name": {},
+	})
+}
+
+func normalizeProfileToken(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func stringInSet(value string, set map[string]struct{}) bool {
+	_, ok := set[value]
+	return ok
+}

--- a/pkg/observability/profile_config.go
+++ b/pkg/observability/profile_config.go
@@ -150,6 +150,9 @@ func LoggingProfileValidationErrors(config LoggingProfileConfig) []string {
 	if timestampFormat != "" && timestampFormat != "rfc3339nano" && timestampFormat != "rfc3339" {
 		errs = append(errs, "encoding.timestamp_format: unsupported value "+strings.TrimSpace(config.Encoding.TimestampFormat))
 	}
+	errs = append(errs, validateEncodingOutputField("encoding.timestamp_field", config.Encoding.TimestampField)...)
+	errs = append(errs, validateEncodingOutputField("encoding.level_field", config.Encoding.LevelField)...)
+	errs = append(errs, validateEncodingOutputField("encoding.message_field", config.Encoding.MessageField)...)
 
 	errs = append(errs, validateLevelMap(config.Levels)...)
 	errs = append(errs, validateProfileFieldList("required_fields", config.RequiredFields)...)
@@ -282,6 +285,17 @@ func validateProfileFieldList(path string, fields []string) []string {
 		}
 	}
 	return errs
+}
+
+func validateEncodingOutputField(path string, field string) []string {
+	trimmed := strings.TrimSpace(field)
+	if trimmed == "" {
+		return nil
+	}
+	if !isSupportedProfileOutputField(trimmed) {
+		return []string{path + ": unsupported field " + trimmed}
+	}
+	return nil
 }
 
 func validateFieldMap(fieldMap map[string]string) []string {

--- a/pkg/observability/profile_config_test.go
+++ b/pkg/observability/profile_config_test.go
@@ -1,0 +1,89 @@
+package observability
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLoggingProfile_BuiltInCatalog(t *testing.T) {
+	got := BuiltInLoggingProfileNames()
+	want := []string{"cloudwatch-json", "legacy", "local-dev", "paytheory-alert-v1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuiltInLoggingProfileNames: expected %#v, got %#v", want, got)
+	}
+
+	catalog := LoggingProfileCatalog()
+	if catalog["schema_version"] != LoggingProfileSchemaVersion {
+		t.Fatalf("catalog schema: expected %q, got %#v", LoggingProfileSchemaVersion, catalog["schema_version"])
+	}
+	if !reflect.DeepEqual(catalog["profiles"], want) {
+		t.Fatalf("catalog profiles: expected %#v, got %#v", want, catalog["profiles"])
+	}
+}
+
+func TestLoggingProfile_DefaultPayTheoryAlertValidates(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	if err := ValidateLoggingProfile(cfg); err != nil {
+		t.Fatalf("ValidateLoggingProfile: %v", err)
+	}
+	if cfg.Encoding.Format != "json" || cfg.Encoding.TimestampField != "ts" {
+		t.Fatalf("unexpected encoding defaults: %#v", cfg.Encoding)
+	}
+	if cfg.FieldMap["stack_hash"] != "stack_hash" {
+		t.Fatalf("expected stack_hash field map, got %#v", cfg.FieldMap)
+	}
+	if !cfg.ErrorCapture.IncludeStackTrace || cfg.ErrorCapture.StackHashAlgorithm != "sha256" {
+		t.Fatalf("unexpected error capture defaults: %#v", cfg.ErrorCapture)
+	}
+}
+
+func TestLoggingProfile_ValidationErrorsAreDeterministic(t *testing.T) {
+	cfg := LoggingProfileConfig{
+		SchemaVersion: "apptheory.logging/v2",
+		Profile:       "custom-alert",
+		Encoding: LoggingProfileEncoding{
+			Format:          "xml",
+			TimestampFormat: "epoch_ms",
+		},
+		RequiredFields: []string{"raw_payload"},
+		Enrichment: LoggingProfileEnrichment{Context: map[string]string{
+			"request_id": "lambda.raw_event.requestContext.requestId",
+		}},
+		ErrorCapture: LoggingProfileErrorCapture{
+			IncludeStackTrace:  true,
+			StackHashAlgorithm: "md5",
+		},
+	}
+	got := LoggingProfileValidationErrors(cfg)
+	want := []string{
+		"schema_version: unsupported value apptheory.logging/v2",
+		"profile: unsupported value custom-alert",
+		"encoding.format: unsupported value xml",
+		"encoding.timestamp_format: unsupported value epoch_ms",
+		"required_fields[0]: unsupported field raw_payload",
+		"enrichment.context.request_id: unsupported source lambda.raw_event.requestContext.requestId",
+		"error_capture.stack_hash_algorithm: unsupported value md5",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validation errors:\nexpected %#v\ngot      %#v", want, got)
+	}
+
+	err := ValidateLoggingProfile(cfg)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var profileErr *LoggingProfileValidationError
+	if !reflect.TypeOf(err).AssignableTo(reflect.TypeOf(profileErr)) {
+		t.Fatalf("expected *LoggingProfileValidationError, got %T", err)
+	}
+}
+
+func TestLoggingProfile_DefaultUnknownProfileFails(t *testing.T) {
+	_, err := DefaultLoggingProfile("custom-alert")
+	if err == nil {
+		t.Fatal("expected unsupported profile error")
+	}
+}

--- a/pkg/observability/profile_config_test.go
+++ b/pkg/observability/profile_config_test.go
@@ -81,6 +81,26 @@ func TestLoggingProfile_ValidationErrorsAreDeterministic(t *testing.T) {
 	}
 }
 
+func TestLoggingProfile_EncodingFieldNamesFailClosed(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	cfg.Encoding.TimestampField = "raw_payload"
+	cfg.Encoding.LevelField = "raw_payload"
+	cfg.Encoding.MessageField = "raw_payload"
+
+	got := LoggingProfileValidationErrors(cfg)
+	want := []string{
+		"encoding.timestamp_field: unsupported field raw_payload",
+		"encoding.level_field: unsupported field raw_payload",
+		"encoding.message_field: unsupported field raw_payload",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validation errors:\nexpected %#v\ngot      %#v", want, got)
+	}
+}
+
 func TestLoggingProfile_DefaultUnknownProfileFails(t *testing.T) {
 	_, err := DefaultLoggingProfile("custom-alert")
 	if err == nil {

--- a/pkg/observability/profile_config_test.go
+++ b/pkg/observability/profile_config_test.go
@@ -1,7 +1,9 @@
 package observability
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +100,60 @@ func TestLoggingProfile_EncodingFieldNamesFailClosed(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("validation errors:\nexpected %#v\ngot      %#v", want, got)
+	}
+}
+
+func TestDecodeLoggingProfileJSON_UnknownOptionsFailClosed(t *testing.T) {
+	raw := []byte(`{
+		"schema_version":"apptheory.logging/v1",
+		"profile":"paytheory-alert-v1",
+		"encoding":{
+			"format":"json",
+			"timestamp_field":"ts",
+			"timestamp_format":"rfc3339nano",
+			"level_field":"level",
+			"message_field":"message",
+			"unknown_encoding_option":true
+		},
+		"unknown_top_level":true
+	}`)
+
+	_, err := DecodeLoggingProfileJSON(raw)
+	if err == nil {
+		t.Fatal("expected strict decode error")
+	}
+	var profileErr *LoggingProfileValidationError
+	if !errors.As(err, &profileErr) {
+		t.Fatalf("expected *LoggingProfileValidationError, got %T: %v", err, err)
+	}
+	want := []string{
+		"encoding.unknown_encoding_option: unsupported option",
+		"unknown_top_level: unsupported option",
+	}
+	if !reflect.DeepEqual(profileErr.Errors, want) {
+		t.Fatalf("validation errors:\nexpected %#v\ngot      %#v", want, profileErr.Errors)
+	}
+}
+
+func TestDecodeLoggingProfileYAML_UnknownOptionsFailClosed(t *testing.T) {
+	raw := []byte(`
+schema_version: apptheory.logging/v1
+profile: paytheory-alert-v1
+encoding:
+  format: json
+  timestamp_field: ts
+  timestamp_format: rfc3339nano
+  level_field: level
+  message_field: message
+unknown_top_level: true
+`)
+
+	_, err := DecodeLoggingProfileYAML(raw)
+	if err == nil {
+		t.Fatal("expected strict YAML decode error")
+	}
+	if !strings.Contains(err.Error(), "unknown_top_level") {
+		t.Fatalf("expected unknown option in YAML error, got %v", err)
 	}
 }
 

--- a/pkg/observability/profile_logger.go
+++ b/pkg/observability/profile_logger.go
@@ -559,6 +559,9 @@ func applySafeEventFields(out map[string]any, fields map[string]any, sanitizerFn
 		if !isAllowedProfileEventField(trimmed) {
 			continue
 		}
+		if _, exists := out[trimmed]; exists {
+			continue
+		}
 		putProfileField(out, trimmed, fields[key], sanitizerFn)
 	}
 }

--- a/pkg/observability/profile_logger.go
+++ b/pkg/observability/profile_logger.go
@@ -1,0 +1,699 @@
+package observability
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/theory-cloud/apptheory/pkg/sanitization"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+type LoggingProfileEvent struct {
+	Timestamp         time.Time                    `json:"timestamp"`
+	Level             string                       `json:"level"`
+	Event             string                       `json:"event,omitempty"`
+	Message           string                       `json:"message"`
+	NormalizedMessage string                       `json:"normalized_message,omitempty"`
+	Request           LoggingProfileRequestContext `json:"request,omitempty"`
+	Job               LoggingProfileJobContext     `json:"job,omitempty"`
+	Error             LoggingProfileError          `json:"error,omitempty"`
+	Fields            map[string]any               `json:"fields,omitempty"`
+}
+
+type LoggingProfileRequestContext struct {
+	RequestID     string `json:"request_id,omitempty"`
+	TenantID      string `json:"tenant_id,omitempty"`
+	UserID        string `json:"user_id,omitempty"`
+	TraceID       string `json:"trace_id,omitempty"`
+	SpanID        string `json:"span_id,omitempty"`
+	CorrelationID string `json:"correlation_id,omitempty"`
+	Route         string `json:"route,omitempty"`
+	Method        string `json:"method,omitempty"`
+	Path          string `json:"path,omitempty"`
+	Status        int    `json:"status,omitempty"`
+}
+
+type LoggingProfileJobContext struct {
+	Name string `json:"name,omitempty"`
+}
+
+type LoggingProfileError struct {
+	Type       string `json:"type,omitempty"`
+	Code       string `json:"code,omitempty"`
+	Message    string `json:"message,omitempty"`
+	StackTrace string `json:"stack_trace,omitempty"`
+}
+
+type ProfileLoggerOption func(*profileLoggerOptions)
+
+type profileLoggerOptions struct {
+	environment map[string]string
+	writer      io.Writer
+	sanitizer   SanitizerFunc
+	clock       func() time.Time
+}
+
+type ProfileLogger struct {
+	root *ProfileLogger
+
+	config      LoggingProfileConfig
+	environment map[string]string
+	writer      io.Writer
+	sanitizer   SanitizerFunc
+	clock       func() time.Time
+
+	mu      sync.Mutex
+	entries []map[string]any
+	fields  map[string]any
+
+	requestID string
+	tenantID  string
+	userID    string
+	traceID   string
+	spanID    string
+
+	closed        atomic.Bool
+	entriesLogged atomic.Int64
+	lastError     atomic.Value
+}
+
+var _ StructuredLogger = (*ProfileLogger)(nil)
+
+func WithProfileEnvironment(environment map[string]string) ProfileLoggerOption {
+	return func(opts *profileLoggerOptions) {
+		opts.environment = copyStringMap(environment)
+	}
+}
+
+func WithProfileWriter(writer io.Writer) ProfileLoggerOption {
+	return func(opts *profileLoggerOptions) {
+		opts.writer = writer
+	}
+}
+
+func WithProfileSanitizer(fn SanitizerFunc) ProfileLoggerOption {
+	return func(opts *profileLoggerOptions) {
+		opts.sanitizer = fn
+	}
+}
+
+func WithProfileClock(clock func() time.Time) ProfileLoggerOption {
+	return func(opts *profileLoggerOptions) {
+		opts.clock = clock
+	}
+}
+
+func NewProfileLogger(config LoggingProfileConfig, options ...ProfileLoggerOption) (*ProfileLogger, error) {
+	if err := ValidateLoggingProfile(config); err != nil {
+		return nil, err
+	}
+
+	opts := &profileLoggerOptions{
+		environment: map[string]string{},
+		writer:      os.Stdout,
+		sanitizer:   sanitization.SanitizeFieldValue,
+		clock:       time.Now,
+	}
+	for _, opt := range options {
+		if opt != nil {
+			opt(opts)
+		}
+	}
+	if opts.writer == nil {
+		opts.writer = io.Discard
+	}
+	if opts.sanitizer == nil {
+		opts.sanitizer = sanitization.SanitizeFieldValue
+	}
+	if opts.clock == nil {
+		opts.clock = time.Now
+	}
+
+	logger := &ProfileLogger{
+		config:      config,
+		environment: copyStringMap(opts.environment),
+		writer:      opts.writer,
+		sanitizer:   opts.sanitizer,
+		clock:       opts.clock,
+		fields:      map[string]any{},
+	}
+	logger.lastError.Store("")
+	return logger, nil
+}
+
+func EncodeLoggingProfileEvent(config LoggingProfileConfig, environment map[string]string, event LoggingProfileEvent) (map[string]any, error) {
+	return EncodeLoggingProfileEventWithSanitizer(config, environment, event, sanitization.SanitizeFieldValue)
+}
+
+func EncodeLoggingProfileEventWithSanitizer(config LoggingProfileConfig, environment map[string]string, event LoggingProfileEvent, sanitizerFn SanitizerFunc) (map[string]any, error) {
+	if err := ValidateLoggingProfile(config); err != nil {
+		return nil, err
+	}
+	if sanitizerFn == nil {
+		sanitizerFn = sanitization.SanitizeFieldValue
+	}
+
+	out := map[string]any{}
+	putProfileField(out, timestampField(config), formatProfileTimestamp(event.Timestamp, config.Encoding.TimestampFormat), sanitizerFn)
+	putProfileField(out, levelField(config), profileLevel(config, event.Level), sanitizerFn)
+	putProfileField(out, messageField(config), sanitization.SanitizeLogString(event.Message), sanitizerFn)
+
+	if event.Event != "" {
+		putCanonicalMappedField(out, config, "event", event.Event, sanitizerFn)
+	}
+	if event.NormalizedMessage != "" {
+		putCanonicalMappedField(out, config, "normalized_message", event.NormalizedMessage, sanitizerFn)
+	}
+
+	applyStaticEnrichment(out, config, environment, sanitizerFn)
+	applyContextEnrichment(out, config, event, sanitizerFn)
+	applyErrorCapture(out, config, event, sanitizerFn)
+	applySafeEventFields(out, event.Fields, sanitizerFn)
+
+	if missing := missingRequiredProfileFields(out, config.RequiredFields); len(missing) > 0 {
+		return nil, fmt.Errorf("logging profile required fields missing: %s", strings.Join(missing, ", "))
+	}
+	return out, nil
+}
+
+func HooksFromProfileLogger(config LoggingProfileConfig, options ...ProfileLoggerOption) (apptheory.ObservabilityHooks, *ProfileLogger, error) {
+	logger, err := NewProfileLogger(config, options...)
+	if err != nil {
+		return apptheory.ObservabilityHooks{}, nil, err
+	}
+	return HooksFromLogger(logger), logger, nil
+}
+
+func (l *ProfileLogger) Debug(message string, fields ...map[string]any) {
+	l.log("debug", message, fields...)
+}
+
+func (l *ProfileLogger) Info(message string, fields ...map[string]any) {
+	l.log("info", message, fields...)
+}
+
+func (l *ProfileLogger) Warn(message string, fields ...map[string]any) {
+	l.log("warn", message, fields...)
+}
+
+func (l *ProfileLogger) Error(message string, fields ...map[string]any) {
+	l.log("error", message, fields...)
+}
+
+func (l *ProfileLogger) WithField(key string, value any) StructuredLogger {
+	return l.WithFields(map[string]any{key: value})
+}
+
+func (l *ProfileLogger) WithFields(fields map[string]any) StructuredLogger {
+	next := l.clone()
+	if next.fields == nil {
+		next.fields = map[string]any{}
+	}
+	for k, v := range fields {
+		next.fields[k] = v
+	}
+	return next
+}
+
+func (l *ProfileLogger) WithRequestID(requestID string) StructuredLogger {
+	next := l.clone()
+	next.requestID = requestID
+	return next
+}
+
+func (l *ProfileLogger) WithTenantID(tenantID string) StructuredLogger {
+	next := l.clone()
+	next.tenantID = tenantID
+	return next
+}
+
+func (l *ProfileLogger) WithUserID(userID string) StructuredLogger {
+	next := l.clone()
+	next.userID = userID
+	return next
+}
+
+func (l *ProfileLogger) WithTraceID(traceID string) StructuredLogger {
+	next := l.clone()
+	next.traceID = traceID
+	return next
+}
+
+func (l *ProfileLogger) WithSpanID(spanID string) StructuredLogger {
+	next := l.clone()
+	next.spanID = spanID
+	return next
+}
+
+func (l *ProfileLogger) Flush(_ context.Context) error {
+	return nil
+}
+
+func (l *ProfileLogger) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.rootLogger().closed.Store(true)
+	return nil
+}
+
+func (l *ProfileLogger) IsHealthy() bool {
+	if l == nil || l.rootLogger().closed.Load() {
+		return false
+	}
+	return l.lastErrorString() == ""
+}
+
+func (l *ProfileLogger) GetStats() LoggerStats {
+	if l == nil {
+		return LoggerStats{}
+	}
+	root := l.rootLogger()
+	return LoggerStats{EntriesLogged: root.entriesLogged.Load(), LastError: l.lastErrorString()}
+}
+
+func (l *ProfileLogger) Entries() []map[string]any {
+	if l == nil {
+		return nil
+	}
+	root := l.rootLogger()
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	out := make([]map[string]any, len(root.entries))
+	for i, entry := range root.entries {
+		out[i] = copyAnyMap(entry)
+	}
+	return out
+}
+
+func (l *ProfileLogger) clone() *ProfileLogger {
+	if l == nil {
+		return &ProfileLogger{fields: map[string]any{}}
+	}
+	return &ProfileLogger{
+		root:        l.rootLogger(),
+		config:      l.config,
+		environment: copyStringMap(l.environment),
+		writer:      l.writer,
+		sanitizer:   l.sanitizer,
+		clock:       l.clock,
+		fields:      copyAnyMap(l.fields),
+		requestID:   l.requestID,
+		tenantID:    l.tenantID,
+		userID:      l.userID,
+		traceID:     l.traceID,
+		spanID:      l.spanID,
+	}
+}
+
+func (l *ProfileLogger) log(level string, message string, fields ...map[string]any) {
+	if l == nil || l.rootLogger().closed.Load() {
+		return
+	}
+	merged := copyAnyMap(l.fields)
+	for _, set := range fields {
+		for k, v := range set {
+			merged[k] = v
+		}
+	}
+
+	event := LoggingProfileEvent{
+		Timestamp: l.clock(),
+		Level:     level,
+		Message:   message,
+		Request: LoggingProfileRequestContext{
+			RequestID: l.requestID,
+			TenantID:  l.tenantID,
+			UserID:    l.userID,
+			TraceID:   l.traceID,
+			SpanID:    l.spanID,
+		},
+		Fields: merged,
+	}
+	applyKnownProfileFieldsToEvent(&event, merged)
+
+	encoded, err := EncodeLoggingProfileEventWithSanitizer(l.config, l.environment, event, l.sanitizer)
+	if err != nil {
+		l.rootLogger().lastError.Store(err.Error())
+		return
+	}
+
+	root := l.rootLogger()
+	root.mu.Lock()
+	root.entries = append(root.entries, copyAnyMap(encoded))
+	root.mu.Unlock()
+
+	if l.writer != nil {
+		line, err := json.Marshal(encoded)
+		if err != nil {
+			root.lastError.Store(err.Error())
+			return
+		}
+		if _, err := l.writer.Write(append(line, '\n')); err != nil {
+			root.lastError.Store(err.Error())
+			return
+		}
+	}
+	root.entriesLogged.Add(1)
+}
+
+func (l *ProfileLogger) rootLogger() *ProfileLogger {
+	if l == nil {
+		return nil
+	}
+	if l.root != nil {
+		return l.root
+	}
+	return l
+}
+
+func (l *ProfileLogger) lastErrorString() string {
+	if l == nil {
+		return ""
+	}
+	value := l.rootLogger().lastError.Load()
+	if value == nil {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
+}
+
+func timestampField(config LoggingProfileConfig) string {
+	if field := strings.TrimSpace(config.Encoding.TimestampField); field != "" {
+		return field
+	}
+	return mappedFieldOrDefault(config, "timestamp", "timestamp")
+}
+
+func levelField(config LoggingProfileConfig) string {
+	if field := strings.TrimSpace(config.Encoding.LevelField); field != "" {
+		return field
+	}
+	return mappedFieldOrDefault(config, "severity", "level")
+}
+
+func messageField(config LoggingProfileConfig) string {
+	if field := strings.TrimSpace(config.Encoding.MessageField); field != "" {
+		return field
+	}
+	return mappedFieldOrDefault(config, "message", "message")
+}
+
+func mappedFieldOrDefault(config LoggingProfileConfig, canonical string, fallback string) string {
+	if config.FieldMap != nil {
+		if mapped := strings.TrimSpace(config.FieldMap[canonical]); mapped != "" {
+			return mapped
+		}
+	}
+	return fallback
+}
+
+func putCanonicalMappedField(out map[string]any, config LoggingProfileConfig, canonical string, value any, sanitizerFn SanitizerFunc) {
+	field := mappedFieldOrDefault(config, canonical, canonical)
+	putProfileField(out, field, value, sanitizerFn)
+}
+
+func putProfileField(out map[string]any, field string, value any, sanitizerFn SanitizerFunc) {
+	key := strings.TrimSpace(field)
+	if key == "" || isZeroProfileValue(value) {
+		return
+	}
+	if sanitizerFn != nil {
+		value = sanitizerFn(key, value)
+	} else {
+		value = sanitization.SanitizeFieldValue(key, value)
+	}
+	out[key] = value
+}
+
+func putProfileRawString(out map[string]any, field string, value string) {
+	key := strings.TrimSpace(field)
+	if key == "" || strings.TrimSpace(value) == "" {
+		return
+	}
+	out[key] = value
+}
+
+func profileLevel(config LoggingProfileConfig, level string) string {
+	key := strings.ToLower(strings.TrimSpace(level))
+	if key == "" {
+		key = "info"
+	}
+	if config.Levels != nil {
+		if mapped := strings.TrimSpace(config.Levels[key]); mapped != "" {
+			return mapped
+		}
+	}
+	return strings.ToUpper(key)
+}
+
+func formatProfileTimestamp(value time.Time, format string) string {
+	if value.IsZero() {
+		value = time.Unix(0, 0).UTC()
+	}
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "rfc3339":
+		return value.UTC().Format(time.RFC3339)
+	default:
+		return value.UTC().Format(time.RFC3339Nano)
+	}
+}
+
+func applyStaticEnrichment(out map[string]any, config LoggingProfileConfig, environment map[string]string, sanitizerFn SanitizerFunc) {
+	for _, field := range sortedMapKeys(config.Enrichment.Static) {
+		value := resolveStaticEnrichmentValue(config.Enrichment.Static[field], environment)
+		putProfileField(out, field, value, sanitizerFn)
+	}
+}
+
+func resolveStaticEnrichmentValue(value string, environment map[string]string) string {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "${") && strings.HasSuffix(trimmed, "}") && len(trimmed) > 3 {
+		name := strings.TrimSpace(trimmed[2 : len(trimmed)-1])
+		if environment != nil {
+			if v, ok := environment[name]; ok {
+				return v
+			}
+		}
+		return os.Getenv(name)
+	}
+	return value
+}
+
+func applyContextEnrichment(out map[string]any, config LoggingProfileConfig, event LoggingProfileEvent, sanitizerFn SanitizerFunc) {
+	for _, field := range sortedMapKeys(config.Enrichment.Context) {
+		value := contextSourceValue(config.Enrichment.Context[field], event)
+		putProfileField(out, field, value, sanitizerFn)
+	}
+}
+
+func contextSourceValue(source string, event LoggingProfileEvent) any {
+	switch strings.TrimSpace(source) {
+	case "request.request_id":
+		return event.Request.RequestID
+	case "request.tenant_id":
+		return event.Request.TenantID
+	case "request.user_id":
+		return event.Request.UserID
+	case "request.trace_id":
+		return event.Request.TraceID
+	case "request.span_id":
+		return event.Request.SpanID
+	case "request.correlation_id":
+		return event.Request.CorrelationID
+	case "request.route":
+		return event.Request.Route
+	case "request.method":
+		return event.Request.Method
+	case "request.path":
+		return event.Request.Path
+	case "request.status":
+		return event.Request.Status
+	case "job.name":
+		return event.Job.Name
+	default:
+		return nil
+	}
+}
+
+func applyErrorCapture(out map[string]any, config LoggingProfileConfig, event LoggingProfileEvent, sanitizerFn SanitizerFunc) {
+	if config.ErrorCapture.IncludeErrorType {
+		putCanonicalMappedField(out, config, "error_type", event.Error.Type, sanitizerFn)
+	}
+	if config.ErrorCapture.IncludeErrorCode {
+		putCanonicalMappedField(out, config, "error_code", event.Error.Code, sanitizerFn)
+	}
+	if config.ErrorCapture.IncludeStackTrace {
+		field := strings.TrimSpace(config.ErrorCapture.StackTraceField)
+		if field == "" {
+			field = mappedFieldOrDefault(config, "stack_trace", "stack_trace")
+		}
+		putProfileRawString(out, field, event.Error.StackTrace)
+	}
+	if strings.TrimSpace(config.ErrorCapture.StackHashField) != "" && event.Error.StackTrace != "" {
+		putProfileField(out, config.ErrorCapture.StackHashField, profileStackHash(event.Error.StackTrace), sanitizerFn)
+	}
+}
+
+func profileStackHash(stackTrace string) string {
+	sum := sha256.Sum256([]byte(stackTrace))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func applySafeEventFields(out map[string]any, fields map[string]any, sanitizerFn SanitizerFunc) {
+	for _, key := range sortedMapKeys(fields) {
+		trimmed := strings.TrimSpace(key)
+		if !isAllowedProfileEventField(trimmed) {
+			continue
+		}
+		putProfileField(out, trimmed, fields[key], sanitizerFn)
+	}
+}
+
+func isAllowedProfileEventField(field string) bool {
+	if strings.HasPrefix(field, "safe_") {
+		return true
+	}
+	return isSupportedProfileOutputField(field)
+}
+
+func missingRequiredProfileFields(out map[string]any, required []string) []string {
+	var missing []string
+	for _, field := range required {
+		key := strings.TrimSpace(field)
+		if key == "" {
+			continue
+		}
+		value, ok := out[key]
+		if !ok || isZeroProfileValue(value) {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+func isZeroProfileValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v) == ""
+	case int:
+		return v == 0
+	case int64:
+		return v == 0
+	case float64:
+		return v == 0
+	default:
+		return false
+	}
+}
+
+func applyKnownProfileFieldsToEvent(event *LoggingProfileEvent, fields map[string]any) {
+	if event == nil {
+		return
+	}
+	if event.NormalizedMessage == "" {
+		event.NormalizedMessage = stringField(fields, "normalized_message")
+	}
+	if event.Event == "" {
+		event.Event = stringField(fields, "event")
+	}
+	if event.Request.CorrelationID == "" {
+		event.Request.CorrelationID = stringField(fields, "correlation_id")
+	}
+	if event.Request.Route == "" {
+		event.Request.Route = stringField(fields, "route")
+	}
+	if event.Request.Method == "" {
+		event.Request.Method = stringField(fields, "method")
+	}
+	if event.Request.Path == "" {
+		event.Request.Path = stringField(fields, "path")
+	}
+	if event.Request.Status == 0 {
+		event.Request.Status = intField(fields, "status")
+	}
+	if event.Job.Name == "" {
+		event.Job.Name = stringField(fields, "job_name")
+	}
+	if event.Error.Type == "" {
+		event.Error.Type = firstStringField(fields, "error_type", "error.type")
+	}
+	if event.Error.Code == "" {
+		event.Error.Code = firstStringField(fields, "error_code", "error.code")
+	}
+	if event.Error.StackTrace == "" {
+		event.Error.StackTrace = stringField(fields, "stack_trace")
+	}
+}
+
+func firstStringField(fields map[string]any, names ...string) string {
+	for _, name := range names {
+		if value := stringField(fields, name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringField(fields map[string]any, name string) string {
+	value, ok := fields[name]
+	if !ok || value == nil {
+		return ""
+	}
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return fmt.Sprint(value)
+}
+
+func intField(fields map[string]any, name string) int {
+	value, ok := fields[name]
+	if !ok || value == nil {
+		return 0
+	}
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		if n, err := v.Int64(); err == nil {
+			return int(n)
+		}
+	}
+	return 0
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyAnyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/observability/profile_logger_test.go
+++ b/pkg/observability/profile_logger_test.go
@@ -85,6 +85,49 @@ func TestEncodeLoggingProfileEvent_PayTheoryAlert(t *testing.T) {
 	}
 }
 
+func TestEncodeLoggingProfileEvent_ProfileFieldsOwnCollisions(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	event := LoggingProfileEvent{
+		Timestamp: time.Unix(0, 0).UTC(),
+		Level:     "error",
+		Message:   "profile-owned message",
+		Fields: map[string]any{
+			"ts":             "2099-01-01T00:00:00Z",
+			"level":          "INFO",
+			"message":        "override-msg",
+			"service":        "override-service",
+			"safe_processor": "tesouro",
+		},
+	}
+	env := map[string]string{
+		"SERVICE_NAME":             "payments-api",
+		"STAGE":                    "live",
+		"PARTNER":                  "paytheory",
+		"AWS_LAMBDA_FUNCTION_NAME": "payments-live-authorize",
+		"AWS_REGION":               "us-east-1",
+	}
+
+	got, err := EncodeLoggingProfileEvent(cfg, env, event)
+	if err != nil {
+		t.Fatalf("EncodeLoggingProfileEvent: %v", err)
+	}
+	checks := map[string]any{
+		"ts":             "1970-01-01T00:00:00Z",
+		"level":          "ERROR",
+		"message":        "profile-owned message",
+		"service":        "payments-api",
+		"safe_processor": "tesouro",
+	}
+	for field, want := range checks {
+		if got[field] != want {
+			t.Fatalf("field %s: expected %#v, got %#v in %#v", field, want, got[field], got)
+		}
+	}
+}
+
 func TestProfileLogger_WritesJSONAndHooks(t *testing.T) {
 	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
 	if err != nil {

--- a/pkg/observability/profile_logger_test.go
+++ b/pkg/observability/profile_logger_test.go
@@ -1,0 +1,148 @@
+package observability
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+func TestEncodeLoggingProfileEvent_PayTheoryAlert(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	stack := "processor.go:42\nhandler.go:7"
+	event := LoggingProfileEvent{
+		Timestamp:         time.Unix(0, 0).UTC(),
+		Level:             "error",
+		Message:           "charge authorization failed",
+		NormalizedMessage: "charge authorization failed",
+		Request: LoggingProfileRequestContext{
+			RequestID:     "req_test_123",
+			TraceID:       "trace-profile-123",
+			CorrelationID: "corr-profile-123",
+			Route:         "POST /payments/{payment_id}/authorize",
+		},
+		Job: LoggingProfileJobContext{Name: "authorize-payment"},
+		Error: LoggingProfileError{
+			Type:       "ProcessorError",
+			Code:       "processor.declined",
+			Message:    "processor declined",
+			StackTrace: stack,
+		},
+		Fields: map[string]any{
+			"safe_processor": "tesouro",
+			"raw_payload":    "must-not-appear",
+		},
+	}
+	env := map[string]string{
+		"SERVICE_NAME":             "payments-api",
+		"STAGE":                    "live",
+		"PARTNER":                  "paytheory",
+		"AWS_LAMBDA_FUNCTION_NAME": "payments-live-authorize",
+		"AWS_REGION":               "us-east-1",
+		"SOURCE_ACCOUNT_ID":        "111122223333",
+		"ACCOUNT_FAMILY":           "paytheory-live",
+	}
+
+	got, err := EncodeLoggingProfileEvent(cfg, env, event)
+	if err != nil {
+		t.Fatalf("EncodeLoggingProfileEvent: %v", err)
+	}
+	want := map[string]any{
+		"ts":                 "1970-01-01T00:00:00Z",
+		"level":              "ERROR",
+		"message":            "charge authorization failed",
+		"service":            "payments-api",
+		"stage":              "live",
+		"partner":            "paytheory",
+		"function":           "payments-live-authorize",
+		"aws_region":         "us-east-1",
+		"source_account_id":  "111122223333",
+		"account_family":     "paytheory-live",
+		"request_id":         "req_test_123",
+		"trace_id":           "trace-profile-123",
+		"correlation_id":     "corr-profile-123",
+		"error_type":         "ProcessorError",
+		"error_code":         "processor.declined",
+		"normalized_message": "charge authorization failed",
+		"stack_trace":        stack,
+		"stack_hash":         "sha256:d3d3dd723c56522d25492427bf8ca94b80feed197d55aa42e9bab0c1b5031bdc",
+		"route":              "POST /payments/{payment_id}/authorize",
+		"job_name":           "authorize-payment",
+		"safe_processor":     "tesouro",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("profile log mismatch:\nexpected %#v\ngot      %#v", want, got)
+	}
+	if _, ok := got["raw_payload"]; ok {
+		t.Fatalf("raw_payload must not be emitted: %#v", got)
+	}
+}
+
+func TestProfileLogger_WritesJSONAndHooks(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	var buf bytes.Buffer
+	hooks, logger, err := HooksFromProfileLogger(
+		cfg,
+		WithProfileWriter(&buf),
+		WithProfileClock(func() time.Time { return time.Unix(0, 0).UTC() }),
+		WithProfileEnvironment(map[string]string{
+			"SERVICE_NAME":             "svc",
+			"STAGE":                    "live",
+			"PARTNER":                  "paytheory",
+			"AWS_LAMBDA_FUNCTION_NAME": "fn",
+			"AWS_REGION":               "us-east-1",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("HooksFromProfileLogger: %v", err)
+	}
+	if hooks.Log == nil || logger == nil {
+		t.Fatal("expected hook and logger")
+	}
+
+	hooks.Log(apptheoryLogRecordForProfileTest())
+
+	var got map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &got); err != nil {
+		t.Fatalf("parse log json %q: %v", buf.String(), err)
+	}
+	if got["level"] != "ERROR" || got["request_id"] != "req_1" || got["error_code"] != "app.internal" {
+		t.Fatalf("unexpected hook output: %#v", got)
+	}
+	if logger.GetStats().LastError != "" {
+		t.Fatalf("unexpected logger error: %s", logger.GetStats().LastError)
+	}
+}
+
+func TestEncodeLoggingProfileEvent_MissingRequiredFails(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfilePayTheoryAlertV1)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	_, err = EncodeLoggingProfileEvent(cfg, nil, LoggingProfileEvent{Level: "error", Message: "boom"})
+	if err == nil || !strings.Contains(err.Error(), "service") {
+		t.Fatalf("expected missing required fields error, got %v", err)
+	}
+}
+
+func apptheoryLogRecordForProfileTest() apptheory.LogRecord {
+	return apptheory.LogRecord{
+		Level:     "error",
+		Event:     "request.completed",
+		RequestID: "req_1",
+		Method:    "GET",
+		Path:      "/boom",
+		Status:    500,
+		ErrorCode: "app.internal",
+	}
+}


### PR DESCRIPTION
## Milestone
go-profile-runtime — add the Go logging profile schema, validator, profile logger, encoder, and observability-hook integration for the fixture-first AppTheory #570 logging-profile contract.

## Linear
Project: https://linear.app/theorycloud/project/apptheory-configurable-logging-profiles-d8dc550453aa
Milestone: go-profile-runtime

## Tasks
- [x] THE-1496 Add Go logging profile schema and validator
- [x] THE-1497 Add Go profile logger and observability hooks

## Contract impact
Fixture-first continuation of PR #573. This PR adds Go runtime support for the new P2 logging-profile fixtures and updates the Go API snapshot for the exported profile schema/logger surface. It is intentionally draft/non-mergeable until the TypeScript and Python parity milestone lands so the full cross-language contract gate is green.

## Validation
Commands run on the final commit:
- `go test ./pkg/observability ./runtime` — PASS
- `go run ./contract-tests/runners/go` — PASS (`contract-tests(go): PASS (124 fixtures)`)
- `./scripts/update-api-snapshots.sh` — PASS
- `make lint` — PASS
- `make test` — PASS
- `./scripts/verify-contract-tests.sh` — expected FAIL after Go PASS because TS/Py logging-profile runtime parity is not implemented yet

## Cross-repo notes
None. This remains AppTheory contract growth; no raw logging or AWS SDK escape hatch is introduced.