### PR TITLE
fix(security): harden release and MCP gates

### DIFF
--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -1893,6 +1893,95 @@ scan_go_supply_chain_for_mod() {
   return 0
 }
 
+strip_python_dependency_comment() {
+  local raw="$1"
+  local out=""
+  local in_single=false
+  local in_double=false
+  local escaped=false
+  local i ch out_lower
+
+  for ((i = 0; i < ${#raw}; i++)); do
+    ch="${raw:i:1}"
+
+    if [[ "${in_double}" == "true" ]]; then
+      out+="${ch}"
+      if [[ "${escaped}" == "true" ]]; then
+        escaped=false
+      elif [[ "${ch}" == "\\" ]]; then
+        escaped=true
+      elif [[ "${ch}" == '"' ]]; then
+        in_double=false
+      fi
+      continue
+    fi
+
+    if [[ "${in_single}" == "true" ]]; then
+      out+="${ch}"
+      if [[ "${ch}" == "'" ]]; then
+        in_single=false
+      fi
+      continue
+    fi
+
+    case "${ch}" in
+      '"')
+        in_double=true
+        out+="${ch}"
+        ;;
+      "'")
+        in_single=true
+        out+="${ch}"
+        ;;
+      "#")
+        out_lower="${out,,}"
+        if [[ "${out_lower}" =~ (git\+)?(https?|ssh|file)://[^[:space:],\"]+$ ]]; then
+          out+="${ch}"
+        else
+          break
+        fi
+        ;;
+      *)
+        out+="${ch}"
+        ;;
+    esac
+  done
+
+  printf '%s' "${out}"
+}
+
+python_line_has_sha256_fragment() {
+  local effective lower
+  effective="$(strip_python_dependency_comment "$1")"
+  lower="$(printf '%s' "${effective}" | tr '[:upper:]' '[:lower:]')"
+  [[ "${lower}" =~ (git\+)?(https?|ssh|file)://[^[:space:],\"]*\#sha256=[0-9a-f]{64} ]]
+}
+
+verify_python_dependency_comment_parser() {
+  local hash="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  if ! python_line_has_sha256_fragment "\"safe @ https://example.com/safe.whl#sha256=${hash}\","; then
+    echo "Python supply-chain scan: internal parser failed to preserve TOML URL hash fragments" >&2
+    return 1
+  fi
+  if python_line_has_sha256_fragment "\"evil @ https://example.com/evil.whl\", #sha256=${hash}"; then
+    echo "Python supply-chain scan: internal parser treated TOML comment text as a URL hash fragment" >&2
+    return 1
+  fi
+  if python_line_has_sha256_fragment "\"evil @ https://example.com/evil.whl\", \"#sha256=${hash}\""; then
+    echo "Python supply-chain scan: internal parser treated a separate TOML string as a URL hash fragment" >&2
+    return 1
+  fi
+  if ! python_line_has_sha256_fragment "safe @ https://example.com/safe.whl#sha256=${hash}"; then
+    echo "Python supply-chain scan: internal parser failed to preserve requirements URL hash fragments" >&2
+    return 1
+  fi
+  if python_line_has_sha256_fragment "evil @ https://example.com/evil.whl #sha256=${hash}"; then
+    echo "Python supply-chain scan: internal parser treated requirements comment text as a URL hash fragment" >&2
+    return 1
+  fi
+}
+
 scan_python_supply_chain() {
   local allowlist_path="$1"
 
@@ -1941,6 +2030,8 @@ scan_python_supply_chain() {
   local allowlisted=0
   local file_count=0
 
+  verify_python_dependency_comment_parser || return $?
+
   local f
   for f in "${files[@]}"; do
     file_count=$((file_count + 1))
@@ -1949,8 +2040,10 @@ scan_python_supply_chain() {
     local line
     while IFS= read -r line || [[ -n "${line}" ]]; do
       local raw="${line//$'\r'/}"
+      local effective
+      effective="$(strip_python_dependency_comment "${raw}")"
       local trimmed
-      trimmed="$(printf '%s' "${raw}" | sed -E 's/[[:space:]]+/ /g; s/^ +//; s/ +$//')"
+      trimmed="$(printf '%s' "${effective}" | sed -E 's/[[:space:]]+/ /g; s/^ +//; s/ +$//')"
       [[ -z "${trimmed}" ]] && continue
 
       local lower
@@ -1967,7 +2060,7 @@ scan_python_supply_chain() {
       done
 
       local has_hash_fragment=false
-      if [[ "${lower}" =~ \#sha256=[0-9a-f]{64} ]]; then
+      if python_line_has_sha256_fragment "${raw}"; then
         has_hash_fragment=true
       fi
 

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -1950,33 +1950,59 @@ strip_python_dependency_comment() {
   printf '%s' "${out}"
 }
 
-python_line_has_sha256_fragment() {
-  local effective lower
+python_line_has_unhashed_direct_url() {
+  local effective lower rest match url
   effective="$(strip_python_dependency_comment "$1")"
   lower="$(printf '%s' "${effective}" | tr '[:upper:]' '[:lower:]')"
-  [[ "${lower}" =~ (git\+)?(https?|ssh|file)://[^[:space:],\"]*\#sha256=[0-9a-f]{64} ]]
+  rest="${lower}"
+
+  while [[ "${rest}" =~ [[:space:]]@[[:space:]]*((https?|file|ssh)://[^[:space:],\"\']+) ]]; do
+    match="${BASH_REMATCH[0]}"
+    url="${BASH_REMATCH[1]}"
+    if ! [[ "${url}" =~ \#sha256=[0-9a-f]{64} ]]; then
+      return 0
+    fi
+
+    # Continue scanning after this URL so same-line TOML arrays cannot let
+    # one hashed direct dependency cover another unhashed direct dependency.
+    rest="${rest#*"${match}"}"
+    if [[ "${rest}" == "${lower}" ]]; then
+      break
+    fi
+    lower="${rest}"
+  done
+
+  return 1
 }
 
 verify_python_dependency_comment_parser() {
   local hash="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-  if ! python_line_has_sha256_fragment "\"safe @ https://example.com/safe.whl#sha256=${hash}\","; then
+  if python_line_has_unhashed_direct_url "\"safe @ https://example.com/safe.whl#sha256=${hash}\","; then
     echo "Python supply-chain scan: internal parser failed to preserve TOML URL hash fragments" >&2
     return 1
   fi
-  if python_line_has_sha256_fragment "\"evil @ https://example.com/evil.whl\", #sha256=${hash}"; then
+  if ! python_line_has_unhashed_direct_url "\"evil @ https://example.com/evil.whl\", #sha256=${hash}"; then
     echo "Python supply-chain scan: internal parser treated TOML comment text as a URL hash fragment" >&2
     return 1
   fi
-  if python_line_has_sha256_fragment "\"evil @ https://example.com/evil.whl\", \"#sha256=${hash}\""; then
+  if ! python_line_has_unhashed_direct_url "\"evil @ https://example.com/evil.whl\", \"#sha256=${hash}\""; then
     echo "Python supply-chain scan: internal parser treated a separate TOML string as a URL hash fragment" >&2
     return 1
   fi
-  if ! python_line_has_sha256_fragment "safe @ https://example.com/safe.whl#sha256=${hash}"; then
+  if ! python_line_has_unhashed_direct_url "dependencies = [\"safe @ https://example.com/safe.whl#sha256=${hash}\", \"evil @ https://example.com/evil.whl\"]"; then
+    echo "Python supply-chain scan: internal parser let one hashed TOML dependency cover an unhashed direct URL" >&2
+    return 1
+  fi
+  if python_line_has_unhashed_direct_url "dependencies = [\"safe @ https://example.com/safe.whl#sha256=${hash}\", \"also-safe @ https://example.com/also-safe.whl#sha256=${hash}\"]"; then
+    echo "Python supply-chain scan: internal parser rejected a TOML line where every direct URL has its own hash" >&2
+    return 1
+  fi
+  if python_line_has_unhashed_direct_url "safe @ https://example.com/safe.whl#sha256=${hash}"; then
     echo "Python supply-chain scan: internal parser failed to preserve requirements URL hash fragments" >&2
     return 1
   fi
-  if python_line_has_sha256_fragment "evil @ https://example.com/evil.whl #sha256=${hash}"; then
+  if ! python_line_has_unhashed_direct_url "evil @ https://example.com/evil.whl #sha256=${hash}"; then
     echo "Python supply-chain scan: internal parser treated requirements comment text as a URL hash fragment" >&2
     return 1
   fi
@@ -2059,16 +2085,16 @@ scan_python_supply_chain() {
         fi
       done
 
-      local has_hash_fragment=false
-      if python_line_has_sha256_fragment "${raw}"; then
-        has_hash_fragment=true
+      local has_unhashed_direct_url=false
+      if python_line_has_unhashed_direct_url "${raw}"; then
+        has_unhashed_direct_url=true
       fi
 
       if [[ -z "${rule}" ]]; then
         if [[ "${lower}" == *"git+https://"* || "${lower}" == *"git+http://"* || "${lower}" == *"git+ssh://"* || "${lower}" == *"hg+http"* || "${lower}" == *"svn+http"* || "${lower}" == *"bzr+http"* ]]; then
           rule="VCS_OR_URL_DEP"
         elif [[ "${lower}" == *" @ https://"* || "${lower}" == *" @ http://"* || "${lower}" == *" @ file://"* || "${lower}" == *" @ ssh://"* ]]; then
-          if [[ "${has_hash_fragment}" != "true" ]]; then
+          if [[ "${has_unhashed_direct_url}" == "true" ]]; then
             rule="VCS_OR_URL_DEP"
           fi
         elif [[ "${lower}" == *"git = \""* && ( "${lower}" == *"http://"* || "${lower}" == *"https://"* || "${lower}" == *"ssh://"* ) ]]; then

--- a/runtime/mcp/capability_test.go
+++ b/runtime/mcp/capability_test.go
@@ -104,6 +104,90 @@ func TestInitializeCapabilities_ExplicitConfigCanDisableSurface(t *testing.T) {
 	}
 }
 
+func TestCapabilityDisables_RejectToolMethods(t *testing.T) {
+	s := NewServer("test", "dev", WithCapabilityConfig(CapabilityConfig{
+		Tools:       false,
+		Resources:   true,
+		Prompts:     true,
+		Completions: true,
+		Tasks:       true,
+	}))
+
+	toolCalled := false
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "secret_tool",
+		Description: "Should not run when tools are disabled",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(context.Context, json.RawMessage) (*ToolResult, error) {
+		toolCalled = true
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "SECRET_TOOL_EXECUTED"}}}, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	streamCalled := false
+	if err := s.Registry().RegisterStreamingTool(ToolDef{
+		Name:        "secret_stream",
+		Description: "Should not stream when tools are disabled",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(context.Context, json.RawMessage, func(SSEEvent)) (*ToolResult, error) {
+		streamCalled = true
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "SECRET_STREAM_EXECUTED"}}}, nil
+	}); err != nil {
+		t.Fatalf("register streaming tool: %v", err)
+	}
+
+	caps := initializeCapabilityMap(t, s)
+	if _, ok := caps["tools"]; ok {
+		t.Fatalf("expected disabled tools capability to be omitted: %+v", caps)
+	}
+
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	tests := []struct {
+		name   string
+		method string
+		params any
+	}{
+		{name: "tools list", method: methodToolsList},
+		{name: "tools call", method: methodToolsCall, params: map[string]any{"name": "secret_tool", "arguments": map[string]any{}}},
+		{name: "tools call stream", method: methodToolsCall, params: map[string]any{"name": "secret_stream", "arguments": map[string]any{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var params json.RawMessage
+			if tt.params != nil {
+				params = mustMarshal(t, tt.params)
+			}
+			req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: tt.method, Params: params})
+			resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+			if err != nil {
+				t.Fatalf("invoke %s: %v", tt.method, err)
+			}
+			if resp.BodyReader != nil {
+				t.Fatalf("expected disabled %s to use JSON error path, got BodyReader", tt.method)
+			}
+			rpcResp, err := parseJSONRPCResponse(resp)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tt.method, err)
+			}
+			if rpcResp.Error == nil || rpcResp.Error.Code != CodeMethodNotFound {
+				t.Fatalf("expected method-not-found for disabled %s, got %+v", tt.method, rpcResp.Error)
+			}
+		})
+	}
+
+	if toolCalled {
+		t.Fatalf("disabled tools/call executed registered tool")
+	}
+	if streamCalled {
+		t.Fatalf("disabled streaming tools/call executed registered streaming tool")
+	}
+}
+
 func TestInitializeCapabilities_OmitsResourceSubscribeUntilOutboundNotificationsExist(t *testing.T) {
 	s := NewServer("test", "dev", WithResourceSubscriptionHooks(
 		func(context.Context, ResourceSubscription) error { return nil },

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -1343,6 +1343,9 @@ func (s *Server) shouldStreamToolsCall(req *Request) bool {
 	if s == nil || s.registry == nil || req == nil {
 		return false
 	}
+	if !s.methodCapabilityEnabled(methodToolsCall) {
+		return false
+	}
 
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -1361,6 +1364,10 @@ func (s *Server) shouldStreamToolsCall(req *Request) bool {
 }
 
 func (s *Server) handleToolsCallStream(ctx context.Context, sessionID string, req *Request) (*apptheory.Response, error) {
+	if !s.methodCapabilityEnabled(methodToolsCall) {
+		resp := NewErrorResponse(req.ID, CodeMethodNotFound, "Method not found: "+methodToolsCall)
+		return s.marshalSingleResponse(resp, sessionID, false)
+	}
 	if s.streamStore == nil {
 		resp := NewErrorResponse(req.ID, CodeInternalError, "streaming not supported")
 		return s.marshalSingleResponse(resp, sessionID, false)

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -92,8 +92,6 @@ make build
 scripts/generate-checksums.sh
 scripts/render-release-notes.sh "${tag}"
 
-mapfile -t existing_assets < <(gh release view "${tag}" --json assets --jq '.assets[].name' 2>/dev/null || true)
-
 assets=(
   'dist/theory-cloud-apptheory*.tgz'
   'dist/apptheory*.whl'
@@ -111,12 +109,10 @@ for asset_glob in "${assets[@]}"; do
   fi
 
   for asset_path in "${matches[@]}"; do
-    asset_name="$(basename "${asset_path}")"
-    if printf '%s\n' "${existing_assets[@]}" | grep -Fxq "${asset_name}"; then
-      echo "release-assets: skip existing ${asset_name}"
-      continue
-    fi
-    gh release upload "${tag}" "${asset_path}"
+    # Draft recovery must never trust pre-existing asset bytes by filename.
+    # Always replace the draft asset with the artifact built and checksummed
+    # from source_commit in this run before publishing the immutable release.
+    gh release upload "${tag}" "${asset_path}" --clobber
   done
 done
 

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -122,6 +122,16 @@ require_order(
     'gh release upload "${tag}"',
     "release asset publisher must checksum artifacts before upload",
 )
+require_contains(
+    "scripts/publish-release-assets.sh",
+    '--clobber',
+    "release asset publisher must replace any existing draft assets during recovery",
+)
+require_not_contains(
+    "scripts/publish-release-assets.sh",
+    "release-assets: skip existing",
+    "release asset publisher must not trust existing draft assets by filename",
+)
 require_order(
     "scripts/publish-release-assets.sh",
     'gh release upload "${tag}"',


### PR DESCRIPTION
## Milestone
AppTheory — harden AppTheory security findings from Codex Security 2026-05-21

## Linear
https://linear.app/theorycloud/project/codex-security-2026-05-21-1fd4c90347f7 / AppTheory

## Tasks
- [x] THE-1461 Draft release recovery can publish stale assets
- [x] THE-1462 Python supply-chain hash check can be bypassed with comments
- [x] THE-1463 MCP capability disables are not enforced

## Contract impact
Security hardening. THE-1463 is MCP runtime-visible; regression coverage pins disabled `tools/*` JSON and streaming calls to method-not-found. THE-1461/THE-1462 harden release/supply-chain verifier behavior, including same-line multi-dependency Python URL hash checks.

## Validation
Commands run on the current tip (`e2baeb7`):
- `bash -n gov-infra/verifiers/gov-verify-rubric.sh` PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` PASS
- `make test-unit` PASS
- `make rubric` PASS

Previously run on this PR:
- `git merge-base --is-ancestor origin/main HEAD` PASS
- `go test ./runtime/mcp -run 'TestCapabilityDisables|TestToolsCallStreaming_RequiredTaskToolUsesJSONErrorPath'` PASS
- `./scripts/verify-contract-tests.sh` PASS
- `./scripts/verify-version-alignment.sh` PASS
- THE-1461: `./scripts/verify-release-workflows.sh` PASS
- THE-1461: `./scripts/verify-branch-release-supply-chain.sh` PASS

## Cross-repo notes
None for AppTheory milestone; FaceTheory issues are in the sibling milestone and are not touched here.
