### PR TITLE
fix(release): harden release publisher reliability

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -88,7 +88,7 @@ jobs:
 
           scripts/publish-release-assets.sh "${TAG_NAME}"
 
-      - name: Report failed draft prerelease (immutable)
+      - name: Diagnose failed prerelease state (read-only)
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -98,8 +98,5 @@ jobs:
             TAG_NAME="v$(./scripts/read-version.sh)"
           fi
 
-          # Releases and tags are immutable. Do not delete or mutate anything on
-          # failure; leave the draft/tag state visible for process recovery.
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          echo "release-cleanup: PRESERVE ${TAG_NAME} (draft=${is_draft:-unknown})"
-          echo "release-cleanup: manual deletion is forbidden; recover through the branch release process"
+          export TAG_NAME
+          scripts/diagnose-release-state.sh --tag "${TAG_NAME}"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,6 +5,10 @@ on:
     branches: ["premain"]
   workflow_dispatch: {}
 
+concurrency:
+  group: release-publisher-${{ github.repository }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
         description: "Optional: upload assets to an existing tag's *draft* release (fails if already published/immutable) (e.g., v0.2.0)"
         required: false
 
+concurrency:
+  group: release-publisher-${{ github.repository }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,18 +131,19 @@ jobs:
 
           scripts/publish-release-assets.sh "${TAG_NAME}"
 
-      - name: Report failed draft release (immutable)
-        if: failure() && github.ref == 'refs/heads/main' && inputs.tag_name == ''
+      - name: Diagnose failed release state (read-only)
+        if: failure()
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          TAG_NAME: ${{ inputs.tag_name || steps.release.outputs.tag_name }}
         run: |
+          if [[ -z "${TAG_NAME}" && "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+
           if [[ -z "${TAG_NAME}" ]]; then
             TAG_NAME="v$(./scripts/read-version.sh)"
           fi
 
-          # Releases and tags are immutable. Do not delete or mutate anything on
-          # failure; leave the draft/tag state visible for process recovery.
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          echo "release-cleanup: PRESERVE ${TAG_NAME} (draft=${is_draft:-unknown})"
-          echo "release-cleanup: manual deletion is forbidden; recover through the branch release process"
+          export TAG_NAME
+          scripts/diagnose-release-state.sh --tag "${TAG_NAME}"

--- a/scripts/diagnose-release-state.sh
+++ b/scripts/diagnose-release-state.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+STABLE_MANIFEST = ".release-please-manifest.json"
+PREMAIN_MANIFEST = ".release-please-manifest.premain.json"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run(cmd: list[str]) -> CommandResult:
+    completed = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+    return CommandResult(completed.returncode, completed.stdout.strip(), completed.stderr.strip())
+
+
+def git(args: list[str]) -> str | None:
+    completed = run(["git", *args])
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def git_ref_exists(ref: str) -> bool:
+    return run(["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"]).returncode == 0
+
+
+def git_commit(ref: str) -> str | None:
+    return git(["rev-parse", f"{ref}^{{commit}}"])
+
+
+def short_sha(value: str | None) -> str:
+    if not value:
+        return "unknown"
+    return value[:12]
+
+
+def current_branch() -> str:
+    github_ref = os.environ.get("GITHUB_REF", "")
+    github_ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    if github_ref.startswith("refs/heads/"):
+        return github_ref_name or github_ref.removeprefix("refs/heads/")
+    if github_ref.startswith("refs/tags/"):
+        return f"tag:{github_ref_name or github_ref.removeprefix('refs/tags/')}"
+
+    branch = git(["branch", "--show-current"])
+    if branch:
+        return branch
+
+    head = git_commit("HEAD")
+    return f"detached@{short_sha(head)}"
+
+
+def infer_tag(explicit_tag: str | None) -> str | None:
+    for value in (
+        explicit_tag,
+        os.environ.get("TAG_NAME"),
+    ):
+        if value:
+            return value
+
+    github_ref = os.environ.get("GITHUB_REF", "")
+    github_ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    if github_ref.startswith("refs/tags/"):
+        return github_ref_name or github_ref.removeprefix("refs/tags/")
+
+    if Path("scripts/read-version.sh").is_file():
+        completed = run(["bash", "scripts/read-version.sh"])
+        if completed.returncode == 0 and completed.stdout:
+            return "v" + completed.stdout.removeprefix("v")
+    return None
+
+
+def manifest_version(ref: str, path: str) -> str:
+    text = git(["show", f"{ref}:{path}"])
+    if text is None:
+        return "missing"
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return "invalid-json"
+    value = data.get(".")
+    return value if isinstance(value, str) and value else "missing-version"
+
+
+def branch_refs() -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for branch in ("main", "staging", "premain"):
+        remote_ref = f"origin/{branch}"
+        refs[branch] = remote_ref if git_ref_exists(remote_ref) else branch
+    return refs
+
+
+def manifest_state() -> list[tuple[str, str, str, str, str]]:
+    rows: list[tuple[str, str, str, str, str]] = []
+    for branch, ref in branch_refs().items():
+        rows.append(
+            (
+                branch,
+                ref,
+                short_sha(git_commit(ref)),
+                manifest_version(ref, STABLE_MANIFEST),
+                manifest_version(ref, PREMAIN_MANIFEST),
+            )
+        )
+    return rows
+
+
+def gh_available() -> bool:
+    return run(["bash", "-lc", "command -v gh >/dev/null 2>&1"]).returncode == 0
+
+
+def release_state(tag: str | None) -> dict[str, Any]:
+    if not tag:
+        return {"state": "unknown", "reason": "no tag could be inferred"}
+    if not gh_available():
+        return {"state": "unknown", "reason": "gh not found"}
+
+    completed = run(
+        [
+            "gh",
+            "release",
+            "view",
+            tag,
+            "--json",
+            "assets,isDraft,isPrerelease,tagName,targetCommitish,url",
+        ]
+    )
+    if completed.returncode != 0:
+        return {"state": "absent", "reason": completed.stderr or completed.stdout}
+
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return {"state": "unknown", "reason": "gh returned invalid JSON"}
+
+    assets = data.get("assets")
+    asset_names = []
+    if isinstance(assets, list):
+        for asset in assets:
+            if isinstance(asset, dict) and isinstance(asset.get("name"), str):
+                asset_names.append(asset["name"])
+
+    return {
+        "state": "draft" if data.get("isDraft") is True else "published",
+        "target": data.get("targetCommitish") or "unknown",
+        "prerelease": data.get("isPrerelease"),
+        "url": data.get("url") or "",
+        "assets": sorted(asset_names),
+    }
+
+
+def tag_state(tag: str | None) -> tuple[str, str]:
+    if not tag:
+        return ("unknown", "no tag could be inferred")
+    target = git_commit(f"refs/tags/{tag}")
+    if target:
+        return ("present", target)
+    return ("absent", "not present in local refs")
+
+
+def verify_release_state() -> dict[str, Any]:
+    completed = run(["bash", "scripts/verify-release-state.sh", "--live", "--json"])
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        data = {
+            "valid": False,
+            "classification": "unavailable",
+            "active_tag": None,
+            "diagnostics": [
+                {
+                    "code": "release-state:unavailable",
+                    "message": completed.stderr or completed.stdout or "verify-release-state did not return JSON",
+                }
+            ],
+        }
+    if completed.returncode != 0:
+        data["valid"] = False
+    return data
+
+
+def safe_next_action(classification: str, release_status: str, tag_status: str, diagnostics: list[dict[str, str]]) -> str:
+    if diagnostics:
+        return (
+            "Fix the reported branch/manifest/tag/release invariant, then rerun the same publisher. "
+            "Do not delete tags/releases or overwrite published assets."
+        )
+    if release_status == "published":
+        return (
+            "The release is already immutable. Rerun the publisher only to verify matching assets; "
+            "if assets are wrong or missing, cut a new version instead of clobbering this release."
+        )
+    if release_status == "draft":
+        return (
+            "Rerun the same serialized publisher. Draft assets may be replaced only while the release "
+            "is still draft; once published, reruns must verify and skip."
+        )
+    if tag_status == "present" or classification.endswith("-tagged"):
+        return (
+            "Rerun the same serialized publisher to recover the existing immutable tag into a draft "
+            "release and publish it after verification."
+        )
+    if classification.endswith("-ready") or classification == "branch-manifest-ready":
+        return "Rerun the release workflow from the same branch after fixing the failed job; no release mutation is required first."
+    return "Stop and inspect the diagnostics before rerunning; do not mutate GitHub Releases manually."
+
+
+def print_diagnostics(tag: str | None) -> None:
+    head = git_commit("HEAD")
+    tag_status, tag_detail = tag_state(tag)
+    release = release_state(tag)
+    release_status = str(release.get("state", "unknown"))
+    verifier = verify_release_state()
+    diagnostics = verifier.get("diagnostics") if isinstance(verifier.get("diagnostics"), list) else []
+    classification = str(verifier.get("classification") or "unknown")
+
+    print("release-diagnostics: BEGIN")
+    print(f"release-diagnostics: branch={current_branch()} head={short_sha(head)}")
+    print(f"release-diagnostics: tag={tag or 'unknown'} state={tag_status} target={tag_detail}")
+    release_line = (
+        f"release-diagnostics: release={tag or 'unknown'} state={release_status} "
+        f"target={release.get('target', 'unknown')} prerelease={release.get('prerelease', 'unknown')}"
+    )
+    if release.get("url"):
+        release_line += f" url={release['url']}"
+    if release.get("reason"):
+        release_line += f" reason={release['reason']}"
+    print(release_line)
+    assets = release.get("assets")
+    if isinstance(assets, list):
+        print(f"release-diagnostics: release-assets={','.join(assets) if assets else 'none'}")
+
+    print("release-diagnostics: manifests:")
+    for branch, ref, head_sha, stable, premain in manifest_state():
+        print(
+            "release-diagnostics: "
+            f"  {branch} ref={ref} head={head_sha} stable={stable} premain={premain}"
+        )
+
+    valid = bool(verifier.get("valid"))
+    active_tag = verifier.get("active_tag") or "none"
+    print(f"release-diagnostics: verifier={'PASS' if valid else 'FAIL'} classification={classification} active={active_tag}")
+    for item in diagnostics:
+        if isinstance(item, dict):
+            print(
+                "release-diagnostics: "
+                f"  {item.get('code', 'diagnostic')}: {item.get('message', '')}"
+            )
+    print(
+        "release-diagnostics: safe-next-action="
+        + safe_next_action(classification, release_status, tag_status, [item for item in diagnostics if isinstance(item, dict)])
+    )
+    print("release-diagnostics: END")
+
+
+def self_test() -> int:
+    cases = [
+        (
+            "invalid state blocks manual mutation",
+            "invalid",
+            "draft",
+            "present",
+            [{"code": "manifest:staging-stable-mismatch", "message": "staging is stale"}],
+            "Fix the reported branch/manifest/tag/release invariant",
+        ),
+        (
+            "published release is immutable",
+            "stable-published",
+            "published",
+            "present",
+            [],
+            "already immutable",
+        ),
+        (
+            "draft release reruns are safe",
+            "prerelease-draft",
+            "draft",
+            "present",
+            [],
+            "Draft assets may be replaced only while the release is still draft",
+        ),
+        (
+            "tagged release recovers through publisher",
+            "prerelease-tagged",
+            "absent",
+            "present",
+            [],
+            "recover the existing immutable tag",
+        ),
+    ]
+    failures: list[str] = []
+    for name, classification, release_status, tag_status, diagnostics, expected in cases:
+        actual = safe_next_action(classification, release_status, tag_status, diagnostics)
+        if expected not in actual:
+            failures.append(f"{name}: expected {expected!r} in {actual!r}")
+    if failures:
+        print("release-diagnostics: self-test FAIL")
+        for failure in failures:
+            print(f"release-diagnostics: {failure}")
+        return 1
+    print(f"release-diagnostics: self-test PASS ({len(cases)} cases)")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Print read-only AppTheory release-state diagnostics.")
+    parser.add_argument("--tag", help="release tag to diagnose; defaults to TAG_NAME/GITHUB_REF/read-version")
+    parser.add_argument("--self-test", action="store_true", help="run deterministic diagnostics self-tests")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    print_diagnostics(infer_tag(args.tag))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+PY

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -18,6 +18,116 @@ remote="${GIT_REMOTE:-origin}"
 main_branch="${MAIN_BRANCH:-main}"
 premain_branch="${PREMAIN_BRANCH:-premain}"
 
+release_asset_globs=(
+  'dist/theory-cloud-apptheory*.tgz'
+  'dist/apptheory*.whl'
+  'dist/apptheory*.tar.gz'
+  'dist/SHA256SUMS.txt'
+)
+
+sha256_file() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{print $1}'
+  else
+    shasum -a 256 "${path}" | awk '{print $1}'
+  fi
+}
+
+release_is_draft() {
+  gh release view "${tag}" --json isDraft --jq '.isDraft'
+}
+
+release_target_commitish() {
+  gh release view "${tag}" --json targetCommitish --jq '.targetCommitish // ""'
+}
+
+resolve_commitish() {
+  local ref="$1"
+  git rev-parse --verify --quiet "${ref}^{commit}" 2>/dev/null
+}
+
+collect_release_assets() {
+  local -n out="$1"
+  out=()
+
+  for asset_glob in "${release_asset_globs[@]}"; do
+    shopt -s nullglob
+    matches=( ${asset_glob} )
+    shopt -u nullglob
+    if (( ${#matches[@]} == 0 )); then
+      echo "release-assets: FAIL (missing asset matching ${asset_glob})" >&2
+      exit 1
+    fi
+
+    out+=( "${matches[@]}" )
+  done
+}
+
+assert_release_target_matches_source() {
+  local current_target="$1"
+  local resolved_target=""
+
+  if [[ -z "${current_target}" ]]; then
+    echo "release-assets: FAIL (${tag} published release has no targetCommitish; refusing to trust immutable assets)" >&2
+    exit 1
+  fi
+
+  resolved_target="$(resolve_commitish "${current_target}" || true)"
+  if [[ -z "${resolved_target}" ]]; then
+    echo "release-assets: FAIL (${tag} release target ${current_target} is not available after fetching refs)" >&2
+    exit 1
+  fi
+
+  if [[ "${resolved_target}" != "${source_commit}" ]]; then
+    echo "release-assets: FAIL (${tag} release target ${resolved_target} does not match source ${source_commit})" >&2
+    exit 1
+  fi
+}
+
+verify_published_release_assets() {
+  local current_target=""
+  local download_dir=""
+  local published_names=""
+
+  current_target="$(release_target_commitish)"
+  assert_release_target_matches_source "${current_target}"
+
+  published_names="$(gh release view "${tag}" --json assets --jq '.assets[].name')"
+
+  download_dir="$(mktemp -d)"
+  cleanup_download_dir() {
+    rm -rf "${download_dir}"
+  }
+  trap cleanup_download_dir RETURN
+
+  for asset_path in "${asset_paths[@]}"; do
+    asset_name="$(basename "${asset_path}")"
+    if ! grep -Fxq "${asset_name}" <<<"${published_names}"; then
+      echo "release-assets: FAIL (${tag} published release is missing immutable asset ${asset_name})" >&2
+      exit 1
+    fi
+
+    rm -f "${download_dir}/${asset_name}"
+    gh release download "${tag}" --pattern "${asset_name}" --dir "${download_dir}" >/dev/null
+    if [[ ! -f "${download_dir}/${asset_name}" ]]; then
+      echo "release-assets: FAIL (${tag} published asset ${asset_name} did not download)" >&2
+      exit 1
+    fi
+
+    expected_sha="$(sha256_file "${asset_path}")"
+    actual_sha="$(sha256_file "${download_dir}/${asset_name}")"
+    if [[ "${actual_sha}" != "${expected_sha}" ]]; then
+      echo "release-assets: FAIL (${tag} published asset ${asset_name} sha256 ${actual_sha} does not match source build ${expected_sha})" >&2
+      exit 1
+    fi
+  done
+
+  trap - RETURN
+  cleanup_download_dir
+  echo "release-assets: SKIP (${tag} already published with matching immutable assets)"
+}
+
 git fetch "${remote}" "${main_branch}" "${premain_branch}" --tags --force
 
 release_exists=false
@@ -35,13 +145,8 @@ if [[ "${release_exists}" != "true" ]]; then
   gh release create "${tag}" --verify-tag --generate-notes --draft
 fi
 
-is_draft="$(gh release view "${tag}" --json isDraft --jq '.isDraft')"
-if [[ "${is_draft}" != "true" ]]; then
-  echo "release-assets: FAIL (${tag} is already published; immutable releases prevent adding assets/notes)" >&2
-  exit 1
-fi
-
-target_commitish="$(gh release view "${tag}" --json targetCommitish --jq '.targetCommitish // ""')"
+is_draft="$(release_is_draft)"
+target_commitish="$(release_target_commitish)"
 tag_ref="refs/tags/${tag}"
 source_ref=""
 allow_untagged_draft=false
@@ -49,6 +154,10 @@ allow_untagged_draft=false
 if git show-ref --verify --quiet "${tag_ref}"; then
   source_ref="${tag}"
 else
+  if [[ "${is_draft}" != "true" ]]; then
+    echo "release-assets: FAIL (${tag} published release has no local tag ref; refusing to trust immutable assets)" >&2
+    exit 1
+  fi
   if [[ -z "${target_commitish}" ]]; then
     echo "release-assets: FAIL (${tag} draft release has no tag ref and no targetCommitish)" >&2
     exit 1
@@ -92,33 +201,49 @@ make build
 scripts/generate-checksums.sh
 scripts/render-release-notes.sh "${tag}"
 
-assets=(
-  'dist/theory-cloud-apptheory*.tgz'
-  'dist/apptheory*.whl'
-  'dist/apptheory*.tar.gz'
-  'dist/SHA256SUMS.txt'
-)
+asset_paths=()
+collect_release_assets asset_paths
 
-for asset_glob in "${assets[@]}"; do
-  shopt -s nullglob
-  matches=( ${asset_glob} )
-  shopt -u nullglob
-  if (( ${#matches[@]} == 0 )); then
-    echo "release-assets: FAIL (missing asset matching ${asset_glob})" >&2
+is_draft="$(release_is_draft)"
+if [[ "${is_draft}" != "true" ]]; then
+  verify_published_release_assets
+  git fetch "${remote}" tag "${tag}" --force
+  scripts/verify-release-branch.sh "${tag}"
+  echo "release-assets: PASS (${tag} source=${source_commit})"
+  exit 0
+fi
+
+for asset_path in "${asset_paths[@]}"; do
+  # Draft recovery must never trust pre-existing asset bytes by filename.
+  # Always replace the draft asset with the artifact built and checksummed
+  # from source_commit in this run before publishing the immutable release.
+  if ! gh release upload "${tag}" "${asset_path}" --clobber; then
+    is_draft="$(release_is_draft)"
+    if [[ "${is_draft}" != "true" ]]; then
+      verify_published_release_assets
+      git fetch "${remote}" tag "${tag}" --force
+      scripts/verify-release-branch.sh "${tag}"
+      echo "release-assets: PASS (${tag} source=${source_commit})"
+      exit 0
+    fi
+
+    echo "release-assets: FAIL (${tag} failed to upload draft asset $(basename "${asset_path}"))" >&2
     exit 1
   fi
-
-  for asset_path in "${matches[@]}"; do
-    # Draft recovery must never trust pre-existing asset bytes by filename.
-    # Always replace the draft asset with the artifact built and checksummed
-    # from source_commit in this run before publishing the immutable release.
-    gh release upload "${tag}" "${asset_path}" --clobber
-  done
 done
 
 prerelease_flag=()
 if [[ "${tag}" =~ -rc(\.|$) ]]; then
   prerelease_flag=(--prerelease)
+fi
+
+is_draft="$(release_is_draft)"
+if [[ "${is_draft}" != "true" ]]; then
+  verify_published_release_assets
+  git fetch "${remote}" tag "${tag}" --force
+  scripts/verify-release-branch.sh "${tag}"
+  echo "release-assets: PASS (${tag} source=${source_commit})"
+  exit 0
 fi
 
 gh release edit "${tag}" --target "${source_commit}" --draft=false "${prerelease_flag[@]}" --notes-file dist/RELEASE_NOTES.md

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -129,8 +129,53 @@ require_contains(
 )
 require_not_contains(
     "scripts/publish-release-assets.sh",
+    "is already published; immutable releases prevent adding assets/notes",
+    "release asset publisher reruns must verify published immutable assets instead of failing before integrity checks",
+)
+require_contains(
+    "scripts/publish-release-assets.sh",
+    "verify_published_release_assets",
+    "release asset publisher must verify immutable assets when a rerun finds the release already published",
+)
+require_contains(
+    "scripts/publish-release-assets.sh",
+    "published release is missing immutable asset",
+    "release asset publisher must fail closed when a published release is missing an expected asset",
+)
+require_contains(
+    "scripts/publish-release-assets.sh",
+    "does not match source build",
+    "release asset publisher must fail closed when a published release asset checksum differs from the source build",
+)
+require_contains(
+    "scripts/publish-release-assets.sh",
+    "already published with matching immutable assets",
+    "release asset publisher must skip safely when rerun after successful publication",
+)
+require_not_contains(
+    "scripts/publish-release-assets.sh",
     "release-assets: skip existing",
     "release asset publisher must not trust existing draft assets by filename",
+)
+require_order(
+    "scripts/publish-release-assets.sh",
+    "scripts/generate-checksums.sh",
+    "collect_release_assets asset_paths",
+    "release asset publisher must enumerate source-built assets after checksums are generated",
+)
+require_order_after(
+    "scripts/publish-release-assets.sh",
+    "collect_release_assets asset_paths",
+    "verify_published_release_assets",
+    'gh release upload "${tag}" "${asset_path}" --clobber',
+    "release asset publisher must verify-and-skip published releases before any clobbering draft upload",
+)
+require_order_after(
+    "scripts/publish-release-assets.sh",
+    'if ! gh release upload "${tag}" "${asset_path}" --clobber; then',
+    "verify_published_release_assets",
+    "failed to upload draft asset",
+    "release asset publisher must re-check immutable publication races before failing an upload rerun",
 )
 require_order(
     "scripts/publish-release-assets.sh",

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -62,6 +62,29 @@ require_order(
     "Release Please (Stable)",
     "stable release must pass rubric before release-please can create a draft release",
 )
+for workflow in (".github/workflows/prerelease.yml", ".github/workflows/release.yml"):
+    require_contains(
+        workflow,
+        "concurrency:\n  group: release-publisher-${{ github.repository }}\n  cancel-in-progress: false",
+        "release publisher workflows must share one non-cancelling concurrency group",
+    )
+    require_not_contains(
+        workflow,
+        "cancel-in-progress: true",
+        "release publisher workflows must queue reruns and workflow_dispatch events instead of cancelling an active publisher",
+    )
+    require_order(
+        workflow,
+        "workflow_dispatch",
+        "concurrency:",
+        "release publisher concurrency must apply at workflow scope, including workflow_dispatch reruns",
+    )
+    require_order(
+        workflow,
+        "concurrency:",
+        "permissions:",
+        "release publisher concurrency must be declared before jobs so the whole publisher workflow is serialized",
+    )
 require_not_contains(
     ".github/workflows/release.yml",
     "if: github.ref == 'refs/heads/main'\n",

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -116,6 +116,54 @@ require_contains(
     "Recover existing draft release assets",
     "stable reruns must recover draft releases left by a failed first attempt",
 )
+for workflow in (".github/workflows/prerelease.yml", ".github/workflows/release.yml"):
+    require_contains(
+        workflow,
+        "scripts/diagnose-release-state.sh --tag",
+        "failed release publisher jobs must print read-only release diagnostics",
+    )
+require_contains(
+    ".github/workflows/release.yml",
+    "- name: Diagnose failed release state (read-only)\n        if: failure()",
+    "stable diagnostics must run for main, tag, and workflow_dispatch publisher failures",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "release-diagnostics: branch=",
+    "release diagnostics must print the current branch and head",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "release-diagnostics: tag=",
+    "release diagnostics must print the active tag state",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "release-diagnostics: release=",
+    "release diagnostics must print GitHub Release state",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "release-diagnostics: manifests:",
+    "release diagnostics must print manifest state",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "release-diagnostics: safe-next-action=",
+    "release diagnostics must print the safe next action",
+)
+for forbidden in (
+    "gh release upload",
+    "gh release edit",
+    "gh release create",
+    "gh release delete",
+    "gh release delete-asset",
+):
+    require_not_contains(
+        "scripts/diagnose-release-state.sh",
+        forbidden,
+        "release diagnostics must not mutate GitHub Releases",
+    )
 require_contains(
     "scripts/publish-release-assets.sh",
     'git fetch "${remote}" "${main_branch}" "${premain_branch}" --tags --force',


### PR DESCRIPTION
## Milestone
release-publisher-hardening — harden AppTheory release publisher reruns, serialization, and diagnostics.

## Linear
- THE-1506: https://linear.app/theorycloud/issue/THE-1506/make-asset-publication-reentrant
- THE-1507: https://linear.app/theorycloud/issue/THE-1507/serialize-publisher-workflows
- THE-1508: https://linear.app/theorycloud/issue/THE-1508/add-release-diagnostics

## Tasks
- [x] THE-1506 — Make asset publication reentrant
- [x] THE-1507 — Serialize publisher workflows
- [x] THE-1508 — Add release diagnostics

## Contract impact
Internal release-process hardening only. No runtime API, contract fixture, or app behavior changes.

## Changed files
- `scripts/publish-release-assets.sh` — reentrant immutable-release verification and safe published-release skip path.
- `.github/workflows/prerelease.yml` / `.github/workflows/release.yml` — shared non-cancelling publisher concurrency and read-only diagnostics on failure.
- `scripts/diagnose-release-state.sh` — new read-only release diagnostic command with self-test.
- `scripts/verify-release-workflows.sh` — static workflow/publisher invariant checks for the new hardening.

## Validation
- `bash scripts/verify-release-workflows.sh` — PASS (`release-workflows: PASS`)
- `bash scripts/diagnose-release-state.sh --self-test` — PASS (`release-diagnostics: self-test PASS (4 cases)`)
- `bash scripts/verify-release-state.sh --self-test` — PASS (`release-state: self-test PASS (8 cases)`)
- `make test` — PASS (`version-alignment: PASS (1.7.0)`)
- `make rubric` — PASS (`Status: PASS`, `Pass: 28`, `Fail: 0`, `Blocked: 0`)

## Notes
- Branch was created from `origin/project/apptheory-release-process-reliability`, which contains PR #581 / THE-1505.
- Preflight verified `origin/main`, `origin/staging`, and `origin/project/apptheory-release-process-reliability` are ancestors of this branch.
- No release tags, GitHub Releases, registries, staging, premain, or main branches were mutated.