### PR TITLE
fix(release): harden release PR promotion flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ permissions:
   contents: read
 
 jobs:
+  release-train-promotion:
+    name: Release train promotion gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Verify release train promotion path
+        run: |
+          scripts/verify-release-train-promotion.sh \
+            --base "${{ github.event.pull_request.base.ref }}" \
+            --head "${{ github.event.pull_request.head.ref }}" \
+            --head-ref HEAD
+
   prerelease-readiness:
     name: Prerelease readiness (staging → premain)
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'premain' && github.event.pull_request.head.ref == 'staging'

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
           scripts/run-release-please-pr.sh \
             --target-branch premain \
             --config-file release-please-config.premain.json \

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -40,15 +40,10 @@ jobs:
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-
-          npx -y release-please@17.1.3 release-pr \
-            --token "${RELEASE_PLEASE_TOKEN}" \
-            --repo-url "${GITHUB_REPOSITORY}" \
+          scripts/run-release-please-pr.sh \
             --target-branch premain \
             --config-file release-please-config.premain.json \
-            --manifest-file .release-please-manifest.premain.json \
-            --draft-pull-request
+            --manifest-file .release-please-manifest.premain.json
 
       - name: Detect open release PR
         id: release_pr

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -123,6 +123,7 @@ jobs:
           # NOTE: release-please-action currently does not apply `release-as` when using
           # `config-file`+`manifest-file` (manifest mode). Use the CLI so the stable
           # release PR can be forced to the premain RC baseline.
+          # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
           scripts/run-release-please-pr.sh \
             --target-branch main \
             --config-file release-please-config.json \
@@ -135,6 +136,7 @@ jobs:
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
           scripts/run-release-please-pr.sh \
             --target-branch main \
             --config-file release-please-config.json \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -120,19 +120,14 @@ jobs:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           RELEASE_AS: ${{ steps.version.outputs.release_as }}
         run: |
-          set -euo pipefail
-
           # NOTE: release-please-action currently does not apply `release-as` when using
           # `config-file`+`manifest-file` (manifest mode). Use the CLI so the stable
           # release PR can be forced to the premain RC baseline.
-          npx -y release-please@17.1.3 release-pr \
-            --token "${RELEASE_PLEASE_TOKEN}" \
-            --repo-url "${GITHUB_REPOSITORY}" \
+          scripts/run-release-please-pr.sh \
             --target-branch main \
             --config-file release-please-config.json \
             --manifest-file .release-please-manifest.json \
-            --release-as "${RELEASE_AS}" \
-            --draft-pull-request
+            --release-as "${RELEASE_AS}"
 
       - name: Release Please (PR only)
         if: steps.stable_release.outputs.blocked != 'true' && steps.version.outputs.release_as == ''
@@ -140,15 +135,10 @@ jobs:
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-
-          npx -y release-please@17.1.3 release-pr \
-            --token "${RELEASE_PLEASE_TOKEN}" \
-            --repo-url "${GITHUB_REPOSITORY}" \
+          scripts/run-release-please-pr.sh \
             --target-branch main \
             --config-file release-please-config.json \
-            --manifest-file .release-please-manifest.json \
-            --draft-pull-request
+            --manifest-file .release-please-manifest.json
 
       - name: Detect open release PR
         if: steps.stable_release.outputs.blocked != 'true'

--- a/scripts/run-release-please-pr.sh
+++ b/scripts/run-release-please-pr.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+usage() {
+  cat >&2 <<'USAGE'
+run-release-please-pr: usage:
+  scripts/run-release-please-pr.sh \
+    --target-branch <branch> \
+    --config-file <path> \
+    --manifest-file <path> \
+    [--release-as <version>] \
+    [--release-branch <branch>]
+USAGE
+}
+
+target_branch=""
+config_file=""
+manifest_file=""
+release_as=""
+release_branch=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-branch)
+      target_branch="${2:-}"
+      shift 2
+      ;;
+    --config-file)
+      config_file="${2:-}"
+      shift 2
+      ;;
+    --manifest-file)
+      manifest_file="${2:-}"
+      shift 2
+      ;;
+    --release-as)
+      release_as="${2:-}"
+      shift 2
+      ;;
+    --release-branch)
+      release_branch="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "release-please-pr: FAIL (unknown argument $1)" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${target_branch}" || -z "${config_file}" || -z "${manifest_file}" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ -z "${release_branch}" ]]; then
+  release_branch="release-please--branches--${target_branch}"
+fi
+
+if [[ -z "${RELEASE_PLEASE_TOKEN:-}" ]]; then
+  echo "release-please-pr: FAIL (RELEASE_PLEASE_TOKEN is required)" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "release-please-pr: FAIL (gh not found)" >&2
+  exit 1
+fi
+
+detect_open_release_pr() {
+  gh pr list \
+    --state open \
+    --base "${target_branch}" \
+    --head "${release_branch}" \
+    --json number,isDraft,baseRefName,headRefName,state \
+    --jq '.[0] // empty' \
+    2>/dev/null || true
+}
+
+draft_lock_release_pr() {
+  local pr_number="$1"
+  local is_draft
+
+  is_draft="$(gh pr view "${pr_number}" --json isDraft --jq '.isDraft')"
+  if [[ "${is_draft}" != "true" ]]; then
+    echo "release-please-pr: draft-locking open release PR #${pr_number}"
+    gh pr ready "${pr_number}" --undo
+  fi
+
+  is_draft="$(gh pr view "${pr_number}" --json isDraft --jq '.isDraft')"
+  if [[ "${is_draft}" != "true" ]]; then
+    echo "release-please-pr: FAIL (PR #${pr_number} could not be draft-locked)" >&2
+    exit 1
+  fi
+}
+
+use_existing_open_release_pr() {
+  local context="$1"
+  local pr_json
+  pr_json="$(detect_open_release_pr)"
+  if [[ -z "${pr_json}" ]]; then
+    return 1
+  fi
+
+  local pr_number
+  pr_number="$(jq -r '.number' <<<"${pr_json}")"
+  if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+    return 1
+  fi
+
+  draft_lock_release_pr "${pr_number}"
+  echo "release-please-pr: PASS (${context}; using open draft ${target_branch} release PR #${pr_number})"
+  return 0
+}
+
+if use_existing_open_release_pr "valid release PR already exists"; then
+  exit 0
+fi
+
+args=(
+  -y
+  release-please@17.1.3
+  release-pr
+  --token "${RELEASE_PLEASE_TOKEN}"
+  --repo-url "${GITHUB_REPOSITORY}"
+  --target-branch "${target_branch}"
+  --config-file "${config_file}"
+  --manifest-file "${manifest_file}"
+  --draft-pull-request
+)
+
+if [[ -n "${release_as}" ]]; then
+  args+=(--release-as "${release_as}")
+fi
+
+set +e
+npx "${args[@]}"
+release_please_status=$?
+set -e
+
+if [[ "${release_please_status}" -ne 0 ]]; then
+  if use_existing_open_release_pr "release-please exited ${release_please_status} after creating or finding a release PR"; then
+    exit 0
+  fi
+
+  echo "release-please-pr: FAIL (release-please exited ${release_please_status} and no open draft ${target_branch} release PR exists)" >&2
+  exit "${release_please_status}"
+fi
+
+if use_existing_open_release_pr "release-please completed"; then
+  exit 0
+fi
+
+echo "release-please-pr: PASS (release-please completed; no release PR needed for ${target_branch})"

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -98,17 +98,6 @@ collect_check_records() {
     return 1
   fi
 
-  local pr_checks_file
-  pr_checks_file="$(mktemp)"
-  if ! gh pr checks "${pr_number}" --json name,bucket,startedAt,completedAt,workflow >"${pr_checks_file}" 2>/dev/null; then
-    # `gh pr checks` exits 8 while checks are pending, but still prints the
-    # JSON payload. It can also report no checks for workflow_dispatch runs that
-    # are attached to the commit but not surfaced through the PR checks view.
-    if [[ ! -s "${pr_checks_file}" ]]; then
-      printf '[]' >"${pr_checks_file}"
-    fi
-  fi
-
   local repo
   repo="$(repo_full_name)"
 
@@ -126,13 +115,13 @@ collect_check_records() {
       ),
       startedAt: (.started_at // ""),
       completedAt: (.completed_at // ""),
-      workflow: (.app.slug // "github-actions")
+      workflow: (.app.slug // "github-actions"),
+      headSha: "'${current_pr_head}'"
     }]' >"${commit_checks_file}" 2>/dev/null; then
     printf '[]' >"${commit_checks_file}"
   fi
 
-  PR_CHECKS_JSON="$(cat "${pr_checks_file}")" \
-    COMMIT_CHECKS_JSON="$(cat "${commit_checks_file}")" \
+  CURRENT_PR_HEAD="${current_pr_head}" COMMIT_CHECKS_JSON="$(cat "${commit_checks_file}")" \
     python3 - <<'PY'
 import json
 import os
@@ -148,10 +137,16 @@ def load(name: str) -> list[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
-print(json.dumps(load("PR_CHECKS_JSON") + load("COMMIT_CHECKS_JSON"), separators=(",", ":")))
+current_head = os.environ["CURRENT_PR_HEAD"]
+records = []
+for item in load("COMMIT_CHECKS_JSON"):
+    if item.get("headSha") == current_head:
+        records.append(item)
+
+print(json.dumps(records, separators=(",", ":")))
 PY
 
-  rm -f "${pr_checks_file}" "${commit_checks_file}"
+  rm -f "${commit_checks_file}"
 }
 
 wait_for_required_checks() {
@@ -182,8 +177,8 @@ for check in checks:
     name = check.get("name", "")
     if name not in required:
         continue
-    # `gh pr checks` can report multiple workflow runs for the same PR head.
-    # Keep the newest status per required check.
+    # Manual reruns and workflow_dispatch can attach multiple check runs to the
+    # same PR head. Keep the newest status per required check.
     timestamp = check.get("startedAt") or check.get("completedAt") or ""
     if name not in latest or timestamp >= latest[name][0]:
         latest[name] = (timestamp, check)
@@ -372,6 +367,32 @@ wait_for_pr_head() {
   done
 }
 
+require_pr_head() {
+  local expected_head="$1"
+  local context="$2"
+  local current_pr_line
+  current_pr_line="$(pr_state_line)"
+  if [[ -z "${current_pr_line}" ]]; then
+    echo "sync-release-pr-generated: FAIL (PR #${pr_number} disappeared ${context})"
+    exit 1
+  fi
+
+  local current_pr_state
+  local current_pr_head
+  current_pr_state="${current_pr_line%%$'\t'*}"
+  current_pr_head="${current_pr_line##*$'\t'}"
+
+  if [[ "${current_pr_state}" != "OPEN" ]]; then
+    echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} ${context})"
+    exit 1
+  fi
+
+  if [[ "${current_pr_head}" != "${expected_head}" ]]; then
+    echo "sync-release-pr-generated: FAIL (PR #${pr_number} head changed ${context}; expected ${expected_head}, found ${current_pr_head})"
+    exit 1
+  fi
+}
+
 sync_stable_release_premain_manifest() {
   if [[ "${release_branch}" != "release-please--branches--main" ]]; then
     return 0
@@ -426,18 +447,46 @@ if [[ "${changed}" == "true" ]]; then
   git push origin HEAD:"${release_branch}"
 fi
 
-wait_for_pr_head "$(git rev-parse HEAD)"
+synced_head="$(git rev-parse HEAD)"
+
+wait_for_pr_head "${synced_head}"
 # After the generated-artifact head is visible, rely only on independent PR
 # checks for protected required contexts. Bot-authored release PR updates can be
 # suppressed by GitHub's recursive workflow guard, so explicitly dispatch CI on
 # the release branch instead of self-attesting protected statuses from mutable
 # release-branch code.
 ensure_release_pr_is_draft "before waiting for independent required checks"
+require_pr_head "${synced_head}" "before dispatching independent required checks"
 dispatch_required_checks
 wait_for_required_checks_to_start
 wait_for_required_checks
 
+require_pr_head "${synced_head}" "after required checks passed"
 ensure_release_pr_is_draft "before marking generated-artifact-synced PR ready"
+require_pr_head "${synced_head}" "before marking generated-artifact-synced PR ready"
 gh pr ready "${pr_number}"
+
+current_pr_line="$(pr_state_line)"
+if [[ -z "${current_pr_line}" ]]; then
+  echo "sync-release-pr-generated: FAIL (PR #${pr_number} disappeared after marking ready)"
+  exit 1
+fi
+current_pr_state="${current_pr_line%%$'\t'*}"
+current_pr_is_draft="${current_pr_line#*$'\t'}"
+current_pr_is_draft="${current_pr_is_draft%%$'\t'*}"
+current_pr_head="${current_pr_line##*$'\t'}"
+if [[ "${current_pr_state}" != "OPEN" ]]; then
+  echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} after marking ready)"
+  exit 1
+fi
+if [[ "${current_pr_head}" != "${synced_head}" ]]; then
+  gh pr ready "${pr_number}" --undo || true
+  echo "sync-release-pr-generated: FAIL (PR #${pr_number} head changed while marking ready; expected ${synced_head}, found ${current_pr_head})"
+  exit 1
+fi
+if [[ "${current_pr_is_draft}" != "false" ]]; then
+  echo "sync-release-pr-generated: FAIL (PR #${pr_number} could not be marked ready after generated artifacts and required checks matched ${synced_head})"
+  exit 1
+fi
 
 echo "sync-release-pr-generated: PASS (${release_branch} updated)"

--- a/scripts/verify-release-train-promotion.sh
+++ b/scripts/verify-release-train-promotion.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+
+RELEASE_BRANCHES = {"staging", "premain", "main"}
+VALID_PROMOTIONS = {
+    ("staging", "premain"): "staging → premain prerelease promotion",
+    ("premain", "main"): "premain → main stable promotion",
+    ("main", "staging"): "main → staging stable back-merge",
+}
+
+
+@dataclass(frozen=True)
+class PromotionPlan:
+    valid: bool
+    message: str
+    ancestor_branch: str | None = None
+    descendant_branch: str | None = None
+    non_release_pr: bool = False
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=check, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def fail(message: str) -> None:
+    print(f"release-train-promotion: FAIL ({message})")
+    raise SystemExit(1)
+
+
+def ref_exists(ref: str) -> bool:
+    return run(["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"], check=False).returncode == 0
+
+
+def fetch_branch(remote: str, branch: str) -> None:
+    result = run(
+        ["git", "fetch", "--no-tags", remote, f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}"],
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        fail(f"could not fetch {remote}/{branch}; {detail or 'git fetch failed'}")
+
+
+def resolve_branch_ref(remote: str, branch: str, explicit_ref: str | None = None) -> str:
+    if explicit_ref:
+        if not ref_exists(explicit_ref):
+            fail(f"could not resolve explicit ref {explicit_ref!r} for {branch}")
+        return explicit_ref
+
+    remote_ref = f"refs/remotes/{remote}/{branch}"
+    if not ref_exists(remote_ref):
+        fetch_branch(remote, branch)
+    if ref_exists(remote_ref):
+        return remote_ref
+
+    if branch == os.environ.get("GITHUB_HEAD_REF") and ref_exists("HEAD"):
+        return "HEAD"
+
+    fail(f"could not resolve {remote}/{branch}; use fetch-depth: 0 and fetch release train branches")
+    raise AssertionError("unreachable")
+
+
+def is_ancestor(ancestor_ref: str, descendant_ref: str) -> bool:
+    return run(["git", "merge-base", "--is-ancestor", ancestor_ref, descendant_ref], check=False).returncode == 0
+
+
+def expected_base_for_release_head(head: str) -> str:
+    if head == "staging":
+        return "premain"
+    if head == "premain":
+        return "main"
+    if head == "main":
+        return "staging"
+    raise ValueError(f"{head!r} is not a release branch")
+
+
+def classify(base: str, head: str) -> PromotionPlan:
+    if base == "premain":
+        if head != "staging":
+            return PromotionPlan(
+                False,
+                "invalid release-train PR "
+                f"{head} → premain; premain only accepts staging → premain prerelease promotions",
+            )
+        return PromotionPlan(True, VALID_PROMOTIONS[(head, base)], ancestor_branch="premain", descendant_branch=head)
+
+    if base == "main":
+        if head != "premain":
+            return PromotionPlan(
+                False,
+                "invalid release-train PR "
+                f"{head} → main; main only accepts premain → main stable promotions",
+            )
+        return PromotionPlan(True, VALID_PROMOTIONS[(head, base)], ancestor_branch="main", descendant_branch=head)
+
+    if base == "staging":
+        if head in RELEASE_BRANCHES:
+            if head != "main":
+                return PromotionPlan(
+                    False,
+                    "invalid release-train PR "
+                    f"{head} → staging; staging only accepts main → staging release back-merges from release branches",
+                )
+            return PromotionPlan(True, VALID_PROMOTIONS[(head, base)], ancestor_branch="staging", descendant_branch=head)
+
+        return PromotionPlan(
+            True,
+            "ordinary staging PR with current main baseline",
+            ancestor_branch="main",
+            descendant_branch=head,
+        )
+
+    if head in RELEASE_BRANCHES:
+        expected_base = expected_base_for_release_head(head)
+        return PromotionPlan(
+            False,
+            "invalid release-train PR "
+            f"{head} → {base}; {head} may only promote to {expected_base}",
+        )
+
+    return PromotionPlan(True, "non-release-train PR", non_release_pr=True)
+
+
+def validate(base: str, head: str, remote: str, base_ref: str | None, head_ref: str | None) -> None:
+    plan = classify(base, head)
+    if not plan.valid:
+        fail(plan.message)
+
+    if plan.non_release_pr:
+        print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
+        return
+
+    assert plan.ancestor_branch is not None
+    assert plan.descendant_branch is not None
+
+    ancestor_ref = resolve_branch_ref(
+        remote,
+        plan.ancestor_branch,
+        base_ref if plan.ancestor_branch == base else None,
+    )
+    descendant_ref = resolve_branch_ref(
+        remote,
+        plan.descendant_branch,
+        head_ref if plan.descendant_branch == head else None,
+    )
+
+    if not is_ancestor(ancestor_ref, descendant_ref):
+        if base == "staging" and head not in RELEASE_BRANCHES:
+            fail(
+                "staging PR branch does not contain the current main baseline; "
+                "merge origin/main into the PR branch before targeting staging"
+            )
+        fail(
+            f"{plan.ancestor_branch} is not an ancestor of {plan.descendant_branch}; "
+            "recreate the release-train PR from the current branch heads and do not merge around "
+            "staging → premain → main → staging"
+        )
+
+    print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
+
+
+def assert_plan(base: str, head: str, valid: bool, ancestor: str | None, descendant: str | None) -> None:
+    plan = classify(base, head)
+    if plan.valid != valid:
+        raise AssertionError(f"{head} → {base}: expected valid={valid}, got {plan.valid} ({plan.message})")
+    if plan.ancestor_branch != ancestor or plan.descendant_branch != descendant:
+        raise AssertionError(
+            f"{head} → {base}: expected ancestry {ancestor}->{descendant}, "
+            f"got {plan.ancestor_branch}->{plan.descendant_branch}"
+        )
+
+
+def self_test() -> None:
+    assert_plan("premain", "staging", True, "premain", "staging")
+    assert_plan("main", "premain", True, "main", "premain")
+    assert_plan("staging", "main", True, "staging", "main")
+    assert_plan("staging", "feature/release-fix", True, "main", "feature/release-fix")
+    assert_plan("main", "staging", False, None, None)
+    assert_plan("premain", "main", False, None, None)
+    assert_plan("premain", "feature/release-fix", False, None, None)
+    assert_plan("project/apptheory-release-process-reliability", "main", False, None, None)
+    assert_plan("project/apptheory-release-process-reliability", "milestone/release-hardening", True, None, None)
+
+    print("release-train-promotion: self-test PASS")
+
+
+def event_value(name: str) -> str:
+    path = os.environ.get("GITHUB_EVENT_PATH")
+    if not path:
+        return ""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            event = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return ""
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        return ""
+    ref = pr.get(name, {}).get("ref") if isinstance(pr.get(name), dict) else ""
+    return ref if isinstance(ref, str) else ""
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Verify AppTheory release train promotion PRs")
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--base", default=os.environ.get("GITHUB_BASE_REF") or event_value("base"))
+    parser.add_argument("--head", default=os.environ.get("GITHUB_HEAD_REF") or event_value("head"))
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--base-ref", default=None)
+    parser.add_argument("--head-ref", default=None)
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        self_test()
+        return 0
+
+    if not args.base or not args.head:
+        fail("base and head branches are required; pass --base/--head or run on a pull_request event")
+
+    validate(args.base, args.head, args.remote, args.base_ref, args.head_ref)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+PY

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -284,6 +284,31 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
+    "Release train promotion gate",
+    "CI must gate release train promotion PRs before release state can advance",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "scripts/verify-release-train-promotion.sh",
+    "CI must run the release train promotion verifier",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "ref: ${{ github.event.pull_request.head.sha }}",
+    "release train promotion verifier must inspect the PR head commit, not the synthetic merge ref",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "fetch-depth: 0",
+    "release train promotion verifier must have enough git history for ancestry checks",
+)
+require_contains(
+    "scripts/verify-release-train-promotion.sh",
+    "staging → premain → main → staging",
+    "release train promotion verifier must preserve the single valid branch ordering",
+)
+require_contains(
+    ".github/workflows/ci.yml",
     "scripts/verify-branch-version-sync.sh",
     "CI must run the branch release-version sync verifier with git metadata",
 )

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -293,6 +293,29 @@ require_order(
     "Release Please (PR only)",
     "prerelease PR generation must fail closed before opening stale release-please PRs",
 )
+for workflow in (".github/workflows/prerelease-pr.yml", ".github/workflows/release-pr.yml"):
+    require_contains(
+        workflow,
+        "scripts/run-release-please-pr.sh",
+        "release PR workflows must create release-please PRs through the stale-state-tolerant wrapper",
+    )
+require_order(
+    "scripts/run-release-please-pr.sh",
+    'if use_existing_open_release_pr "valid release PR already exists"; then',
+    'npx "${args[@]}"',
+    "release-please PR generation must tolerate already-open draft release PRs before invoking release-please",
+)
+require_order(
+    "scripts/run-release-please-pr.sh",
+    'npx "${args[@]}"',
+    'if use_existing_open_release_pr "release-please exited ${release_please_status} after creating or finding a release PR"; then',
+    "release-please PR generation must recover when stale release-please state errors after a valid PR exists",
+)
+require_contains(
+    "scripts/run-release-please-pr.sh",
+    'gh pr ready "${pr_number}" --undo',
+    "release-please PR generation must draft-lock valid open release PRs before artifact setup",
+)
 require_order(
     ".github/workflows/prerelease.yml",
     "Verify branch version sync (release preflight)",

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -381,7 +381,13 @@ require_contains(
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",
-    'wait_for_pr_head "$(git rev-parse HEAD)"',
+    'synced_head="$(git rev-parse HEAD)"',
+    'wait_for_pr_head "${synced_head}"',
+    "release PR sync must capture the generated-artifact head before waiting for it",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    'wait_for_pr_head "${synced_head}"',
     "After the generated-artifact head is visible",
     "release PR sync must wait for the pushed artifact commit before checking independent CI",
 )
@@ -401,11 +407,28 @@ require_contains(
     "COMMIT_CHECKS_JSON",
     "release PR sync must merge commit-attached check-runs into the required check view",
 )
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "headSha",
+    "release PR sync must only pass required checks attached to the current PR head",
+)
+require_order_after(
+    "scripts/sync-release-pr-generated.sh",
+    "dispatch_required_checks\nwait_for_required_checks_to_start\nwait_for_required_checks",
+    "wait_for_required_checks",
+    'require_pr_head "${synced_head}" "after required checks passed"',
+    "release PR must re-check the generated-artifact head after required checks pass",
+)
 require_order(
     "scripts/sync-release-pr-generated.sh",
-    "wait_for_required_checks",
+    'require_pr_head "${synced_head}" "after required checks passed"',
     'gh pr ready "${pr_number}"\n\n',
     "release PR must wait for required checks before becoming ready",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'gh pr ready "${pr_number}" --undo || true',
+    "release PR sync must restore draft state if the PR head changes while becoming ready",
 )
 for forbidden in (
     "repos/${GITHUB_REPOSITORY}/statuses",


### PR DESCRIPTION
## Milestone
release-pr-promotion-hardening — harden Release Please PR generation, release PR artifact sync, and release-train promotion gates.

## Linear
- THE-1509 — Harden Release Please PR generation
- THE-1510 — Harden release PR artifact sync
- THE-1511 — Gate release train promotions

## Tasks
- [x] THE-1509: stale or merged Release Please PR state cannot fail the lane when a valid open draft release PR exists or can be safely created.
- [x] THE-1510: release PRs cannot become ready until generated artifacts and required checks match the current head.
- [x] THE-1511: invalid staging → premain, premain → main, and main → staging PRs fail with actionable messages.

## Contract impact
Internal-only release automation. No runtime API, contract fixture, or application behavior changes.

## Validation
Commands run on the final branch:
- `bash scripts/verify-release-workflows.sh` → `release-workflows: PASS`
- `bash scripts/verify-release-train-promotion.sh --self-test` → `release-train-promotion: self-test PASS`
- `bash -n scripts/run-release-please-pr.sh scripts/sync-release-pr-generated.sh scripts/verify-release-train-promotion.sh scripts/verify-release-workflows.sh` → PASS
- `make test` → Go tests passed; `version-alignment: PASS (1.7.0)`
- `make rubric` → `Status: PASS`, `Pass: 28`, `Fail: 0`, `Blocked: 0`, `rubric: PASS`

## Cross-repo notes
None.