### PR TITLE
test(contract): add kinesis log subscription fixtures

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -155,6 +155,9 @@ path while pinning the portable decoder contract that later runtime work must ex
 
 The runner handler is intentionally narrow: it should call the runtime decoder and compare the result to the fixture
 expectations. It must not grow a runner-local alternate decoder that bypasses the runtime contract.
+The runners also validate expectation hygiene before invoking the runtime path: every Kinesis input record must have
+exactly one `record_id` expectation, malformed records must be explicit `decode_error` expectations, and extra expected
+records fail the fixture instead of being ignored.
 
 
 ## M1 non-HTTP observability and safe error fixtures

--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -139,6 +139,24 @@ DynamoDB stream normalization fixtures keep the runtime contract on the partial-
 The partial-failure fixture intentionally fails only the `REMOVE` record after summary validation, proving the existing per-record retry behavior remains intact while the normalized summary contract grows.
 
 
+## M1 Kinesis CloudWatch Logs subscription fixtures
+
+Kinesis CloudWatch Logs subscription fixtures keep the runtime contract on the existing Kinesis partial-batch response
+path while pinning the portable decoder contract that later runtime work must expose. The runner-only handler
+`kinesis_require_cloudwatch_logs_subscription` represents the future runtime helper and records expectations under
+`expect.cloudwatch_logs_subscription.records`:
+
+- Valid records contain gzip-compressed CloudWatch Logs subscription JSON in `kinesis.data` and must decode to
+  `message_type`, `owner`, `log_group`, `log_stream`, `subscription_filters`, and ordered `log_events`.
+- Malformed records use `decode_error = true`; decoding them must fail closed for that record without broadening the
+  failure to neighboring valid records.
+- `safe_summary` pins the safe metadata a handler may log: record/log identity and counts only. Values listed in
+  `forbidden_safe_log_substrings` are raw log event messages and must not appear in the safe summary.
+
+The runner handler is intentionally narrow: it should call the runtime decoder and compare the result to the fixture
+expectations. It must not grow a runner-local alternate decoder that bypasses the runtime contract.
+
+
 ## M1 non-HTTP observability and safe error fixtures
 
 Non-HTTP observability fixtures use the existing `expect.logs`, `expect.metrics`, and `expect.spans` fixture fields for event workloads. Event log records keep the HTTP fields present but empty/zero and add event dimensions for the non-HTTP trigger:

--- a/contract-tests/fixtures/m1/kinesis-cloudwatch-logs-subscription-malformed-partial-batch.json
+++ b/contract-tests/fixtures/m1/kinesis-cloudwatch-logs-subscription-malformed-partial-batch.json
@@ -1,0 +1,147 @@
+{
+  "id": "m1.kinesis.cloudwatch_logs_subscription.malformed_partial_batch",
+  "tier": "m1",
+  "name": "Kinesis: CloudWatch Logs subscription malformed record fails only itself",
+  "setup": {
+    "kinesis": [
+      {
+        "stream": "contract-logs-stream",
+        "handler": "kinesis_require_cloudwatch_logs_subscription"
+      }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "kinesis",
+      "event": {
+        "Records": [
+          {
+            "eventID": "kin-cwl-valid-1",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/contract-logs-stream",
+            "eventVersion": "1.0",
+            "awsRegion": "us-east-1",
+            "kinesis": {
+              "partitionKey": "pk-cwl-valid-1",
+              "sequenceNumber": "1001",
+              "kinesisSchemaVersion": "1.0",
+              "data": "H4sIAAAAAAAC/4WQwWrDMBBEf8UsPVrIdtqk8c1QJ5f2ZN+CKWtnmwhkS0hKTQj5964CoYdQOgcdZp6GYS+gzaH+pil4KHcXUHsoYZi1oOgJzCGFkbzHA8XATMHhEBL+lGg1UYLaHpGZoJgKOFoo89Vq/Zotn7Ooa/rYWfzT2VP4qzKPlV0aR2+dOXEEEmcvNY79HiVaG45k3FncW+HGNsERjgwXWbGU2Yvkd/f0XrV103Z3VODvrvZs47a3qq0+P+qmqbY1h2aeyLGdswrWgsW2P/V+cMoGZaaN0oFcvCU8jhFftxS66w9T/9mvdwEAAA=="
+            }
+          },
+          {
+            "eventID": "kin-cwl-malformed-1",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/contract-logs-stream",
+            "eventVersion": "1.0",
+            "awsRegion": "us-east-1",
+            "kinesis": {
+              "partitionKey": "pk-cwl-malformed-1",
+              "sequenceNumber": "1002",
+              "kinesisSchemaVersion": "1.0",
+              "data": "eyJtZXNzYWdlVHlwZSI6IkRBVEFfTUVTU0FHRSIsIm5vdCI6Imd6aXAifQ=="
+            }
+          },
+          {
+            "eventID": "kin-cwl-valid-2",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/contract-logs-stream",
+            "eventVersion": "1.0",
+            "awsRegion": "us-east-1",
+            "kinesis": {
+              "partitionKey": "pk-cwl-valid-2",
+              "sequenceNumber": "1003",
+              "kinesisSchemaVersion": "1.0",
+              "data": "H4sIAAAAAAAC/2WPzWrDMBCEX8UsPUZIdtuk8c1QN5f2ZN+CKRtFdQX6Q1JqQsi7dxUIPXQOOsx8uzu6gPFz/6NcTtDuL6CP0IJcDFPFY7KGFViVEs6qBN7liDJXNFQZ7VQ1o7VITNZEZbQB2nqz2b6I9ZNohBDXaVUu7KI/UQQcl8QN2sMROYaQv5WPZ3ZfCzd2yFGhJbgRzZqLZ07v/uG9G/thnO4ok3/FxnMo5V67sfv86Ieh2/UU+sWpSHZNakiPJLLT6ZBk1CFr7960ySqWj8P/MuzrlsJ0/QWxCWzrJAEAAA=="
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expect": {
+    "cloudwatch_logs_subscription": {
+      "records": [
+        {
+          "record_id": "kin-cwl-valid-1",
+          "message_type": "DATA_MESSAGE",
+          "owner": "111122223333",
+          "log_group": "/aws/lambda/apptheory-contract",
+          "log_stream": "2026/05/26/[$LATEST]contract-a",
+          "subscription_filters": [
+            "apptheory-contract-filter"
+          ],
+          "log_events": [
+            {
+              "id": "cwl-event-a1",
+              "timestamp": 1779806400000,
+              "message": "contract log line alpha"
+            },
+            {
+              "id": "cwl-event-a2",
+              "timestamp": 1779806401000,
+              "message": "contract log line beta"
+            }
+          ],
+          "safe_summary": {
+            "record_id": "kin-cwl-valid-1",
+            "message_type": "DATA_MESSAGE",
+            "owner": "111122223333",
+            "log_group": "/aws/lambda/apptheory-contract",
+            "log_stream": "2026/05/26/[$LATEST]contract-a",
+            "subscription_filter_count": 1,
+            "log_event_count": 2,
+            "safe_log": "record_id=kin-cwl-valid-1 owner=111122223333 log_group=/aws/lambda/apptheory-contract log_stream=2026/05/26/[$LATEST]contract-a message_type=DATA_MESSAGE log_events=2 subscription_filters=1"
+          },
+          "forbidden_safe_log_substrings": [
+            "contract log line alpha",
+            "contract log line beta"
+          ]
+        },
+        {
+          "record_id": "kin-cwl-malformed-1",
+          "decode_error": true
+        },
+        {
+          "record_id": "kin-cwl-valid-2",
+          "message_type": "DATA_MESSAGE",
+          "owner": "111122223333",
+          "log_group": "/aws/lambda/apptheory-contract",
+          "log_stream": "2026/05/26/[$LATEST]contract-c",
+          "subscription_filters": [
+            "apptheory-contract-filter"
+          ],
+          "log_events": [
+            {
+              "id": "cwl-event-c1",
+              "timestamp": 1779806402000,
+              "message": "contract log line gamma"
+            }
+          ],
+          "safe_summary": {
+            "record_id": "kin-cwl-valid-2",
+            "message_type": "DATA_MESSAGE",
+            "owner": "111122223333",
+            "log_group": "/aws/lambda/apptheory-contract",
+            "log_stream": "2026/05/26/[$LATEST]contract-c",
+            "subscription_filter_count": 1,
+            "log_event_count": 1,
+            "safe_log": "record_id=kin-cwl-valid-2 owner=111122223333 log_group=/aws/lambda/apptheory-contract log_stream=2026/05/26/[$LATEST]contract-c message_type=DATA_MESSAGE log_events=1 subscription_filters=1"
+          },
+          "forbidden_safe_log_substrings": [
+            "contract log line gamma"
+          ]
+        }
+      ]
+    },
+    "output_json": {
+      "batchItemFailures": [
+        {
+          "itemIdentifier": "kin-cwl-malformed-1"
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/m1/kinesis-cloudwatch-logs-subscription-valid.json
+++ b/contract-tests/fixtures/m1/kinesis-cloudwatch-logs-subscription-valid.json
@@ -1,0 +1,81 @@
+{
+  "id": "m1.kinesis.cloudwatch_logs_subscription.valid_decode",
+  "tier": "m1",
+  "name": "Kinesis: CloudWatch Logs subscription valid decode",
+  "setup": {
+    "kinesis": [
+      {
+        "stream": "contract-logs-stream",
+        "handler": "kinesis_require_cloudwatch_logs_subscription"
+      }
+    ]
+  },
+  "input": {
+    "aws_event": {
+      "source": "kinesis",
+      "event": {
+        "Records": [
+          {
+            "eventID": "kin-cwl-valid-1",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/contract-logs-stream",
+            "eventVersion": "1.0",
+            "awsRegion": "us-east-1",
+            "kinesis": {
+              "partitionKey": "pk-cwl-valid-1",
+              "sequenceNumber": "1001",
+              "kinesisSchemaVersion": "1.0",
+              "data": "H4sIAAAAAAAC/4WQwWrDMBBEf8UsPVrIdtqk8c1QJ5f2ZN+CKWtnmwhkS0hKTQj5964CoYdQOgcdZp6GYS+gzaH+pil4KHcXUHsoYZi1oOgJzCGFkbzHA8XATMHhEBL+lGg1UYLaHpGZoJgKOFoo89Vq/Zotn7Ooa/rYWfzT2VP4qzKPlV0aR2+dOXEEEmcvNY79HiVaG45k3FncW+HGNsERjgwXWbGU2Yvkd/f0XrV103Z3VODvrvZs47a3qq0+P+qmqbY1h2aeyLGdswrWgsW2P/V+cMoGZaaN0oFcvCU8jhFftxS66w9T/9mvdwEAAA=="
+            }
+          }
+        ]
+      }
+    }
+  },
+  "expect": {
+    "cloudwatch_logs_subscription": {
+      "records": [
+        {
+          "record_id": "kin-cwl-valid-1",
+          "message_type": "DATA_MESSAGE",
+          "owner": "111122223333",
+          "log_group": "/aws/lambda/apptheory-contract",
+          "log_stream": "2026/05/26/[$LATEST]contract-a",
+          "subscription_filters": [
+            "apptheory-contract-filter"
+          ],
+          "log_events": [
+            {
+              "id": "cwl-event-a1",
+              "timestamp": 1779806400000,
+              "message": "contract log line alpha"
+            },
+            {
+              "id": "cwl-event-a2",
+              "timestamp": 1779806401000,
+              "message": "contract log line beta"
+            }
+          ],
+          "safe_summary": {
+            "record_id": "kin-cwl-valid-1",
+            "message_type": "DATA_MESSAGE",
+            "owner": "111122223333",
+            "log_group": "/aws/lambda/apptheory-contract",
+            "log_stream": "2026/05/26/[$LATEST]contract-a",
+            "subscription_filter_count": 1,
+            "log_event_count": 2,
+            "safe_log": "record_id=kin-cwl-valid-1 owner=111122223333 log_group=/aws/lambda/apptheory-contract log_stream=2026/05/26/[$LATEST]contract-a message_type=DATA_MESSAGE log_events=2 subscription_filters=1"
+          },
+          "forbidden_safe_log_substrings": [
+            "contract log line alpha",
+            "contract log line beta"
+          ]
+        }
+      ]
+    },
+    "output_json": {
+      "batchItemFailures": []
+    }
+  }
+}

--- a/contract-tests/runners/go/apptheory_m1.go
+++ b/contract-tests/runners/go/apptheory_m1.go
@@ -15,6 +15,8 @@ import (
 )
 
 const dynamoDBEventNameRemove = "REMOVE"
+const cloudWatchLogsSubscriptionHandlerName = "kinesis_require_cloudwatch_logs_subscription"
+const cloudWatchLogsSubscriptionMissingHelperMessage = "apptheory: cloudwatch logs subscription decoder helper missing"
 
 func runFixtureM1(f Fixture) error {
 	now := time.Unix(0, 0).UTC()
@@ -67,6 +69,15 @@ func runFixtureM1(f Fixture) error {
 		app.UseEvents(mw)
 	}
 
+	if f.Input.AWSEvent == nil {
+		return errors.New("fixture missing input.aws_event")
+	}
+
+	cloudWatchLogsExpectations, err := newCloudWatchLogsSubscriptionExpectations(f)
+	if err != nil {
+		return err
+	}
+
 	for _, r := range f.Setup.SQS {
 		queue := strings.TrimSpace(r.Queue)
 		handler := builtInSQSHandler(r.Handler)
@@ -78,7 +89,7 @@ func runFixtureM1(f Fixture) error {
 
 	for _, r := range f.Setup.Kinesis {
 		stream := strings.TrimSpace(r.Stream)
-		handler := builtInKinesisHandler(r.Handler)
+		handler := builtInKinesisHandler(r.Handler, cloudWatchLogsExpectations)
 		if handler == nil {
 			return fmt.Errorf("unknown kinesis handler %q", r.Handler)
 		}
@@ -114,10 +125,6 @@ func runFixtureM1(f Fixture) error {
 			DetailType: strings.TrimSpace(r.DetailType),
 		}
 		app.EventBridge(selector, handler)
-	}
-
-	if f.Input.AWSEvent == nil {
-		return errors.New("fixture missing input.aws_event")
 	}
 
 	ctx, cancel := fixtureM1LambdaContext(now, f.Input.Context)
@@ -291,16 +298,14 @@ func builtInSQSHandler(name string) apptheory.SQSHandler {
 	return apptheory.SQSHandler(handler)
 }
 
-func builtInKinesisHandler(name string) apptheory.KinesisHandler {
+func builtInKinesisHandler(name string, cloudWatchLogsExpectations *cloudWatchLogsSubscriptionExpectations) apptheory.KinesisHandler {
 	switch strings.TrimSpace(name) {
 	case "kinesis_requires_event_middleware":
 		return func(ctx *apptheory.EventContext, _ events.KinesisEventRecord) error {
 			return requireEventMiddleware(ctx)
 		}
-	case "kinesis_require_cloudwatch_logs_subscription":
-		return func(_ *apptheory.EventContext, _ events.KinesisEventRecord) error {
-			return errors.New("apptheory: cloudwatch logs subscription decoder helper missing")
-		}
+	case cloudWatchLogsSubscriptionHandlerName:
+		return newCloudWatchLogsSubscriptionHandler(cloudWatchLogsExpectations, missingCloudWatchLogsSubscriptionDecoder)
 	}
 
 	handler := builtInRecordHandler[events.KinesisEventRecord](
@@ -316,6 +321,265 @@ func builtInKinesisHandler(name string) apptheory.KinesisHandler {
 		return nil
 	}
 	return apptheory.KinesisHandler(handler)
+}
+
+type cloudWatchLogsSubscriptionExpectations struct {
+	byRecordID map[string]FixtureCloudWatchLogsSubscriptionRecord
+}
+
+type cloudWatchLogsSubscriptionDecoder func(events.KinesisEventRecord) (FixtureCloudWatchLogsSubscriptionRecord, error)
+
+func newCloudWatchLogsSubscriptionExpectations(f Fixture) (*cloudWatchLogsSubscriptionExpectations, error) {
+	usesHandler := false
+	for _, route := range f.Setup.Kinesis {
+		if strings.TrimSpace(route.Handler) == cloudWatchLogsSubscriptionHandlerName {
+			usesHandler = true
+			break
+		}
+	}
+
+	if f.Expect.CloudWatchLogsSubscription == nil {
+		if usesHandler {
+			return nil, errors.New("fixture missing expect.cloudwatch_logs_subscription")
+		}
+		return nil, nil
+	}
+	if !usesHandler {
+		return nil, errors.New("expect.cloudwatch_logs_subscription requires kinesis_require_cloudwatch_logs_subscription handler")
+	}
+	if len(f.Expect.CloudWatchLogsSubscription.Records) == 0 {
+		return nil, errors.New("fixture missing expect.cloudwatch_logs_subscription.records")
+	}
+	if f.Input.AWSEvent == nil {
+		return nil, errors.New("fixture missing input.aws_event")
+	}
+
+	inputRecordIDs, err := kinesisInputRecordIDs(f.Input.AWSEvent.Event)
+	if err != nil {
+		return nil, err
+	}
+
+	expectedByID := make(map[string]FixtureCloudWatchLogsSubscriptionRecord, len(f.Expect.CloudWatchLogsSubscription.Records))
+	for i, expected := range f.Expect.CloudWatchLogsSubscription.Records {
+		recordID := strings.TrimSpace(expected.RecordID)
+		if recordID == "" {
+			return nil, fmt.Errorf("expect.cloudwatch_logs_subscription.records[%d] missing record_id", i)
+		}
+		if _, exists := expectedByID[recordID]; exists {
+			return nil, fmt.Errorf("duplicate cloudwatch logs subscription expectation for record_id %q", recordID)
+		}
+		expected.RecordID = recordID
+		if err := validateCloudWatchLogsSubscriptionExpectationRecord(expected); err != nil {
+			return nil, err
+		}
+		expectedByID[recordID] = expected
+	}
+
+	seenInputRecordIDs := make(map[string]bool, len(inputRecordIDs))
+	for _, recordID := range inputRecordIDs {
+		if seenInputRecordIDs[recordID] {
+			return nil, fmt.Errorf("duplicate kinesis input record_id %q", recordID)
+		}
+		seenInputRecordIDs[recordID] = true
+		if _, ok := expectedByID[recordID]; !ok {
+			return nil, fmt.Errorf("missing cloudwatch logs subscription expectation for kinesis record_id %q", recordID)
+		}
+	}
+	for recordID := range expectedByID {
+		if !seenInputRecordIDs[recordID] {
+			return nil, fmt.Errorf("extra cloudwatch logs subscription expectation for record_id %q", recordID)
+		}
+	}
+
+	return &cloudWatchLogsSubscriptionExpectations{byRecordID: expectedByID}, nil
+}
+
+func kinesisInputRecordIDs(raw json.RawMessage) ([]string, error) {
+	var event struct {
+		Records []struct {
+			EventID string `json:"eventID"`
+		} `json:"Records"`
+	}
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return nil, fmt.Errorf("parse kinesis input event for cloudwatch logs subscription expectations: %w", err)
+	}
+	if len(event.Records) == 0 {
+		return nil, errors.New("cloudwatch logs subscription fixture missing kinesis input records")
+	}
+	ids := make([]string, 0, len(event.Records))
+	for i, record := range event.Records {
+		recordID := strings.TrimSpace(record.EventID)
+		if recordID == "" {
+			return nil, fmt.Errorf("kinesis input Records[%d] missing eventID for cloudwatch logs subscription expectation", i)
+		}
+		ids = append(ids, recordID)
+	}
+	return ids, nil
+}
+
+func validateCloudWatchLogsSubscriptionExpectationRecord(expected FixtureCloudWatchLogsSubscriptionRecord) error {
+	if expected.DecodeError {
+		if strings.TrimSpace(expected.MessageType) != "" ||
+			strings.TrimSpace(expected.Owner) != "" ||
+			strings.TrimSpace(expected.LogGroup) != "" ||
+			strings.TrimSpace(expected.LogStream) != "" ||
+			len(expected.SubscriptionFilters) > 0 ||
+			len(expected.LogEvents) > 0 ||
+			len(expected.SafeSummary) > 0 ||
+			len(expected.ForbiddenSafeLogSubstrings) > 0 {
+			return fmt.Errorf("cloudwatch logs subscription record_id %q has decode_error=true and decoded fields", expected.RecordID)
+		}
+		return nil
+	}
+
+	var missing []string
+	if strings.TrimSpace(expected.MessageType) == "" {
+		missing = append(missing, "message_type")
+	}
+	if strings.TrimSpace(expected.Owner) == "" {
+		missing = append(missing, "owner")
+	}
+	if strings.TrimSpace(expected.LogGroup) == "" {
+		missing = append(missing, "log_group")
+	}
+	if strings.TrimSpace(expected.LogStream) == "" {
+		missing = append(missing, "log_stream")
+	}
+	if len(expected.SubscriptionFilters) == 0 {
+		missing = append(missing, "subscription_filters")
+	}
+	if len(expected.LogEvents) == 0 {
+		missing = append(missing, "log_events")
+	}
+	if len(expected.SafeSummary) == 0 {
+		missing = append(missing, "safe_summary")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q expectation missing %s; malformed records must set decode_error=true", expected.RecordID, strings.Join(missing, ", "))
+	}
+
+	for i, filter := range expected.SubscriptionFilters {
+		if strings.TrimSpace(filter) == "" {
+			return fmt.Errorf("cloudwatch logs subscription record_id %q subscription_filters[%d] is empty", expected.RecordID, i)
+		}
+	}
+	for i, event := range expected.LogEvents {
+		if strings.TrimSpace(event.ID) == "" {
+			return fmt.Errorf("cloudwatch logs subscription record_id %q log_events[%d] missing id", expected.RecordID, i)
+		}
+		if strings.TrimSpace(event.Message) == "" {
+			return fmt.Errorf("cloudwatch logs subscription record_id %q log_events[%d] missing message", expected.RecordID, i)
+		}
+	}
+	if cloudWatchLogsSafeSummaryContainsForbidden(expected.SafeSummary, expected.ForbiddenSafeLogSubstrings) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q safe_summary contains forbidden raw log substring", expected.RecordID)
+	}
+
+	return nil
+}
+
+func newCloudWatchLogsSubscriptionHandler(
+	expectations *cloudWatchLogsSubscriptionExpectations,
+	decoder cloudWatchLogsSubscriptionDecoder,
+) apptheory.KinesisHandler {
+	if decoder == nil {
+		decoder = missingCloudWatchLogsSubscriptionDecoder
+	}
+	return func(_ *apptheory.EventContext, record events.KinesisEventRecord) error {
+		if expectations == nil {
+			return errors.New("fixture missing validated cloudwatch logs subscription expectations")
+		}
+		recordID := strings.TrimSpace(record.EventID)
+		expected, ok := expectations.byRecordID[recordID]
+		if !ok {
+			return fmt.Errorf("missing cloudwatch logs subscription expectation for kinesis record_id %q", recordID)
+		}
+
+		actual, err := decoder(record)
+		if err != nil {
+			return err
+		}
+		if expected.DecodeError {
+			return fmt.Errorf("cloudwatch logs subscription record_id %q expected decode_error=true, got decoded record", recordID)
+		}
+		return compareCloudWatchLogsSubscriptionDecodedRecord(expected, actual)
+	}
+}
+
+func missingCloudWatchLogsSubscriptionDecoder(events.KinesisEventRecord) (FixtureCloudWatchLogsSubscriptionRecord, error) {
+	return FixtureCloudWatchLogsSubscriptionRecord{}, errors.New(cloudWatchLogsSubscriptionMissingHelperMessage)
+}
+
+func compareCloudWatchLogsSubscriptionDecodedRecord(
+	expected FixtureCloudWatchLogsSubscriptionRecord,
+	actual FixtureCloudWatchLogsSubscriptionRecord,
+) error {
+	if actualRecordID := strings.TrimSpace(actual.RecordID); actualRecordID != "" && actualRecordID != expected.RecordID {
+		return fmt.Errorf("cloudwatch logs subscription record_id mismatch: expected %q, got %q", expected.RecordID, actualRecordID)
+	}
+	if strings.TrimSpace(actual.MessageType) != strings.TrimSpace(expected.MessageType) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q message_type mismatch", expected.RecordID)
+	}
+	if strings.TrimSpace(actual.Owner) != strings.TrimSpace(expected.Owner) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q owner mismatch", expected.RecordID)
+	}
+	if strings.TrimSpace(actual.LogGroup) != strings.TrimSpace(expected.LogGroup) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q log_group mismatch", expected.RecordID)
+	}
+	if strings.TrimSpace(actual.LogStream) != strings.TrimSpace(expected.LogStream) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q log_stream mismatch", expected.RecordID)
+	}
+	if !stringSlicesEqual(expected.SubscriptionFilters, actual.SubscriptionFilters) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q subscription_filters mismatch", expected.RecordID)
+	}
+	if !cloudWatchLogsSubscriptionLogEventsEqual(expected.LogEvents, actual.LogEvents) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q log_events mismatch", expected.RecordID)
+	}
+	if !jsonEqual(expected.SafeSummary, actual.SafeSummary) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q safe_summary mismatch", expected.RecordID)
+	}
+	if cloudWatchLogsSafeSummaryContainsForbidden(actual.SafeSummary, expected.ForbiddenSafeLogSubstrings) {
+		return fmt.Errorf("cloudwatch logs subscription record_id %q safe_summary contains forbidden raw log substring", expected.RecordID)
+	}
+	return nil
+}
+
+func stringSlicesEqual(expected []string, actual []string) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cloudWatchLogsSubscriptionLogEventsEqual(
+	expected []FixtureCloudWatchLogsSubscriptionLogEvent,
+	actual []FixtureCloudWatchLogsSubscriptionLogEvent,
+) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cloudWatchLogsSafeSummaryContainsForbidden(safeSummary map[string]any, forbidden []string) bool {
+	if len(safeSummary) == 0 || len(forbidden) == 0 {
+		return false
+	}
+	raw, err := json.Marshal(safeSummary)
+	if err != nil {
+		return true
+	}
+	return containsAny(string(raw), forbidden)
 }
 
 func builtInSNSHandler(name string) apptheory.SNSHandler {

--- a/contract-tests/runners/go/apptheory_m1.go
+++ b/contract-tests/runners/go/apptheory_m1.go
@@ -292,9 +292,14 @@ func builtInSQSHandler(name string) apptheory.SQSHandler {
 }
 
 func builtInKinesisHandler(name string) apptheory.KinesisHandler {
-	if strings.TrimSpace(name) == "kinesis_requires_event_middleware" {
+	switch strings.TrimSpace(name) {
+	case "kinesis_requires_event_middleware":
 		return func(ctx *apptheory.EventContext, _ events.KinesisEventRecord) error {
 			return requireEventMiddleware(ctx)
+		}
+	case "kinesis_require_cloudwatch_logs_subscription":
+		return func(_ *apptheory.EventContext, _ events.KinesisEventRecord) error {
+			return errors.New("apptheory: cloudwatch logs subscription decoder helper missing")
 		}
 	}
 

--- a/contract-tests/runners/go/apptheory_m1_more_test.go
+++ b/contract-tests/runners/go/apptheory_m1_more_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -151,7 +152,7 @@ func TestBuiltInOutputHandler_UnknownIsNil(t *testing.T) {
 		t.Fatal("expected unknown dynamodb handler to be nil")
 	}
 
-	if builtInKinesisHandler("nope") != nil {
+	if builtInKinesisHandler("nope", nil) != nil {
 		t.Fatal("expected unknown kinesis handler to be nil")
 	}
 
@@ -178,5 +179,149 @@ func TestRunFixtureM1_MissingAWSEvent(t *testing.T) {
 	err := runFixtureM1(Fixture{})
 	if err == nil || !strings.Contains(err.Error(), "fixture missing input.aws_event") {
 		t.Fatalf("expected missing input.aws_event error, got %v", err)
+	}
+}
+
+func TestCloudWatchLogsSubscriptionExpectations_Hygiene(t *testing.T) {
+	t.Parallel()
+
+	fixture := cloudWatchLogsSubscriptionFixtureForTest()
+	expectations, err := newCloudWatchLogsSubscriptionExpectations(fixture)
+	if err != nil {
+		t.Fatalf("expected valid cloudwatch logs subscription expectations, got %v", err)
+	}
+	if expectations == nil || len(expectations.byRecordID) != 2 {
+		t.Fatalf("expected two expectations, got %#v", expectations)
+	}
+
+	missing := cloudWatchLogsSubscriptionFixtureForTest()
+	missing.Expect.CloudWatchLogsSubscription.Records = missing.Expect.CloudWatchLogsSubscription.Records[:1]
+	if _, err := newCloudWatchLogsSubscriptionExpectations(missing); err == nil || !strings.Contains(err.Error(), "missing cloudwatch logs subscription expectation") {
+		t.Fatalf("expected missing input record expectation error, got %v", err)
+	}
+
+	extra := cloudWatchLogsSubscriptionFixtureForTest()
+	extra.Expect.CloudWatchLogsSubscription.Records = append(
+		append([]FixtureCloudWatchLogsSubscriptionRecord(nil), extra.Expect.CloudWatchLogsSubscription.Records...),
+		FixtureCloudWatchLogsSubscriptionRecord{RecordID: "unexpected", DecodeError: true},
+	)
+	if _, err := newCloudWatchLogsSubscriptionExpectations(extra); err == nil || !strings.Contains(err.Error(), "extra cloudwatch logs subscription expectation") {
+		t.Fatalf("expected extra expectation error, got %v", err)
+	}
+
+	duplicate := cloudWatchLogsSubscriptionFixtureForTest()
+	duplicate.Expect.CloudWatchLogsSubscription.Records = append(
+		append([]FixtureCloudWatchLogsSubscriptionRecord(nil), duplicate.Expect.CloudWatchLogsSubscription.Records...),
+		duplicate.Expect.CloudWatchLogsSubscription.Records[0],
+	)
+	if _, err := newCloudWatchLogsSubscriptionExpectations(duplicate); err == nil || !strings.Contains(err.Error(), "duplicate cloudwatch logs subscription expectation") {
+		t.Fatalf("expected duplicate expectation error, got %v", err)
+	}
+
+	malformedNotMarked := cloudWatchLogsSubscriptionFixtureForTest()
+	malformedNotMarked.Expect.CloudWatchLogsSubscription.Records[1] = FixtureCloudWatchLogsSubscriptionRecord{RecordID: "r2"}
+	if _, err := newCloudWatchLogsSubscriptionExpectations(malformedNotMarked); err == nil || !strings.Contains(err.Error(), "malformed records must set decode_error=true") {
+		t.Fatalf("expected malformed expectation hygiene error, got %v", err)
+	}
+
+	decodeErrorWithFields := cloudWatchLogsSubscriptionFixtureForTest()
+	decodeErrorWithFields.Expect.CloudWatchLogsSubscription.Records[1] = FixtureCloudWatchLogsSubscriptionRecord{
+		RecordID:    "r2",
+		DecodeError: true,
+		MessageType: "DATA_MESSAGE",
+	}
+	if _, err := newCloudWatchLogsSubscriptionExpectations(decodeErrorWithFields); err == nil || !strings.Contains(err.Error(), "decode_error=true and decoded fields") {
+		t.Fatalf("expected decode_error decoded field hygiene error, got %v", err)
+	}
+}
+
+func TestCloudWatchLogsSubscriptionHandler_CompareScaffold(t *testing.T) {
+	t.Parallel()
+
+	fixture := cloudWatchLogsSubscriptionFixtureForTest()
+	expectations, err := newCloudWatchLogsSubscriptionExpectations(fixture)
+	if err != nil {
+		t.Fatalf("expected valid expectations, got %v", err)
+	}
+
+	validExpected := expectations.byRecordID["r1"]
+	handler := newCloudWatchLogsSubscriptionHandler(expectations, func(record events.KinesisEventRecord) (FixtureCloudWatchLogsSubscriptionRecord, error) {
+		if record.EventID == "r2" {
+			return FixtureCloudWatchLogsSubscriptionRecord{}, errors.New("decode failed")
+		}
+		return validExpected, nil
+	})
+
+	if err := handler(&apptheory.EventContext{}, events.KinesisEventRecord{EventID: "r1"}); err != nil {
+		t.Fatalf("expected valid decoded record to pass, got %v", err)
+	}
+	if err := handler(&apptheory.EventContext{}, events.KinesisEventRecord{EventID: "r2"}); err == nil || !strings.Contains(err.Error(), "decode failed") {
+		t.Fatalf("expected decode_error record to return decoder error, got %v", err)
+	}
+
+	mismatched := newCloudWatchLogsSubscriptionHandler(expectations, func(events.KinesisEventRecord) (FixtureCloudWatchLogsSubscriptionRecord, error) {
+		actual := validExpected
+		actual.MessageType = "CONTROL_MESSAGE"
+		return actual, nil
+	})
+	if err := mismatched(&apptheory.EventContext{}, events.KinesisEventRecord{EventID: "r1"}); err == nil || !strings.Contains(err.Error(), "message_type mismatch") {
+		t.Fatalf("expected message_type comparison error, got %v", err)
+	}
+
+	unsafe := newCloudWatchLogsSubscriptionHandler(expectations, func(events.KinesisEventRecord) (FixtureCloudWatchLogsSubscriptionRecord, error) {
+		actual := validExpected
+		actual.SafeSummary = map[string]any{"safe_log": "contract log line alpha"}
+		return actual, nil
+	})
+	if err := unsafe(&apptheory.EventContext{}, events.KinesisEventRecord{EventID: "r1"}); err == nil || !strings.Contains(err.Error(), "safe_summary mismatch") {
+		t.Fatalf("expected safe_summary comparison error, got %v", err)
+	}
+
+	missingHelper := newCloudWatchLogsSubscriptionHandler(expectations, nil)
+	if err := missingHelper(&apptheory.EventContext{}, events.KinesisEventRecord{EventID: "r1"}); err == nil || !strings.Contains(err.Error(), cloudWatchLogsSubscriptionMissingHelperMessage) {
+		t.Fatalf("expected missing helper error, got %v", err)
+	}
+}
+
+func cloudWatchLogsSubscriptionFixtureForTest() Fixture {
+	return Fixture{
+		Setup: FixtureSetup{
+			Kinesis: []FixtureKinesisRoute{{Stream: "stream", Handler: cloudWatchLogsSubscriptionHandlerName}},
+		},
+		Input: FixtureInput{
+			AWSEvent: &FixtureAWSEvent{
+				Source: "kinesis",
+				Event:  json.RawMessage(`{"Records":[{"eventID":"r1"},{"eventID":"r2"}]}`),
+			},
+		},
+		Expect: FixtureExpect{
+			CloudWatchLogsSubscription: &FixtureCloudWatchLogsSubscription{
+				Records: []FixtureCloudWatchLogsSubscriptionRecord{
+					{
+						RecordID:            "r1",
+						MessageType:         "DATA_MESSAGE",
+						Owner:               "111122223333",
+						LogGroup:            "/aws/lambda/example",
+						LogStream:           "2026/05/26/[$LATEST]example",
+						SubscriptionFilters: []string{"filter"},
+						LogEvents: []FixtureCloudWatchLogsSubscriptionLogEvent{
+							{ID: "event-1", Timestamp: 1779806400000, Message: "contract log line alpha"},
+						},
+						SafeSummary: map[string]any{
+							"record_id":                 "r1",
+							"message_type":              "DATA_MESSAGE",
+							"owner":                     "111122223333",
+							"log_group":                 "/aws/lambda/example",
+							"log_stream":                "2026/05/26/[$LATEST]example",
+							"subscription_filter_count": 1,
+							"log_event_count":           1,
+							"safe_log":                  "record_id=r1 owner=111122223333 log_events=1 subscription_filters=1",
+						},
+						ForbiddenSafeLogSubstrings: []string{"contract log line alpha"},
+					},
+					{RecordID: "r2", DecodeError: true},
+				},
+			},
+		},
 	}
 }

--- a/contract-tests/runners/go/fixture.go
+++ b/contract-tests/runners/go/fixture.go
@@ -108,16 +108,17 @@ type FixtureRequest struct {
 }
 
 type FixtureExpect struct {
-	Response                *FixtureResponse       `json:"response,omitempty"`
-	Output                  json.RawMessage        `json:"output_json,omitempty"`
-	Error                   *FixtureError          `json:"error,omitempty"`
-	WebSocketCalls          []FixtureWebSocketCall `json:"ws_calls,omitempty"`
-	Logs                    []FixtureLogRecord     `json:"logs,omitempty"`
-	Metrics                 []FixtureMetricRecord  `json:"metrics,omitempty"`
-	Spans                   []FixtureSpanRecord    `json:"spans,omitempty"`
-	ProfileLogs             []map[string]any       `json:"profile_logs,omitempty"`
-	ProfileValidationErrors []string               `json:"profile_validation_errors,omitempty"`
-	LoggingProfileCatalog   map[string]any         `json:"logging_profile_catalog,omitempty"`
+	Response                   *FixtureResponse                   `json:"response,omitempty"`
+	Output                     json.RawMessage                    `json:"output_json,omitempty"`
+	Error                      *FixtureError                      `json:"error,omitempty"`
+	WebSocketCalls             []FixtureWebSocketCall             `json:"ws_calls,omitempty"`
+	CloudWatchLogsSubscription *FixtureCloudWatchLogsSubscription `json:"cloudwatch_logs_subscription,omitempty"`
+	Logs                       []FixtureLogRecord                 `json:"logs,omitempty"`
+	Metrics                    []FixtureMetricRecord              `json:"metrics,omitempty"`
+	Spans                      []FixtureSpanRecord                `json:"spans,omitempty"`
+	ProfileLogs                []map[string]any                   `json:"profile_logs,omitempty"`
+	ProfileValidationErrors    []string                           `json:"profile_validation_errors,omitempty"`
+	LoggingProfileCatalog      map[string]any                     `json:"logging_profile_catalog,omitempty"`
 }
 
 type FixtureError struct {
@@ -141,6 +142,29 @@ type FixtureWebSocketCall struct {
 	Endpoint     string       `json:"endpoint,omitempty"`
 	ConnectionID string       `json:"connection_id"`
 	Data         *FixtureBody `json:"data,omitempty"`
+}
+
+type FixtureCloudWatchLogsSubscription struct {
+	Records []FixtureCloudWatchLogsSubscriptionRecord `json:"records,omitempty"`
+}
+
+type FixtureCloudWatchLogsSubscriptionRecord struct {
+	RecordID                   string                                      `json:"record_id"`
+	DecodeError                bool                                        `json:"decode_error,omitempty"`
+	MessageType                string                                      `json:"message_type,omitempty"`
+	Owner                      string                                      `json:"owner,omitempty"`
+	LogGroup                   string                                      `json:"log_group,omitempty"`
+	LogStream                  string                                      `json:"log_stream,omitempty"`
+	SubscriptionFilters        []string                                    `json:"subscription_filters,omitempty"`
+	LogEvents                  []FixtureCloudWatchLogsSubscriptionLogEvent `json:"log_events,omitempty"`
+	SafeSummary                map[string]any                              `json:"safe_summary,omitempty"`
+	ForbiddenSafeLogSubstrings []string                                    `json:"forbidden_safe_log_substrings,omitempty"`
+}
+
+type FixtureCloudWatchLogsSubscriptionLogEvent struct {
+	ID        string `json:"id"`
+	Timestamp int64  `json:"timestamp"`
+	Message   string `json:"message"`
 }
 
 type FixtureBody struct {

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any
 
 _APPTHEORY_RUNTIME: Any | None = None
+CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER = "kinesis_require_cloudwatch_logs_subscription"
+CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER = "apptheory: cloudwatch logs subscription decoder helper missing"
 
 
 @dataclass
@@ -1341,7 +1343,7 @@ def _built_in_sqs_handler(name: str):
     return None
 
 
-def _built_in_kinesis_handler(name: str):
+def _built_in_kinesis_handler(runtime: Any, name: str, fixture: dict[str, Any]):
     if name == "kinesis_noop":
         return lambda _ctx, _record: None
 
@@ -1370,11 +1372,11 @@ def _built_in_kinesis_handler(name: str):
 
         return handler
 
-    if name == "kinesis_require_cloudwatch_logs_subscription":
-        def handler(_ctx, _record):
-            raise RuntimeError("apptheory: cloudwatch logs subscription decoder helper missing")
-
-        return handler
+    if name == CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER:
+        return make_cloudwatch_logs_subscription_kinesis_handler(
+            fixture,
+            _runtime_cloudwatch_logs_subscription_decoder(runtime),
+        )
 
     return None
 
@@ -1628,7 +1630,7 @@ def run_fixture_m1(fixture: dict[str, Any]) -> tuple[bool, str, Any, Any, _Dummy
         app.sqs(str(route.get("queue") or ""), handler)
 
     for route in setup.get("kinesis", []) or []:
-        handler = _built_in_kinesis_handler(str(route.get("handler") or ""))
+        handler = _built_in_kinesis_handler(runtime, str(route.get("handler") or ""), fixture)
         if handler is None:
             raise RuntimeError(f"unknown kinesis handler {route.get('handler')!r}")
         app.kinesis(str(route.get("stream") or ""), handler)
@@ -1716,6 +1718,222 @@ def _compare_m1_side_effects_if_expected(
     if (expect_obj.get("spans") or []) != effects.spans:
         return False, "spans mismatch", actual, expected, effects
     return True, "", actual, expected, effects
+
+
+def uses_cloudwatch_logs_subscription_handler(fixture: dict[str, Any]) -> bool:
+    setup = fixture.get("setup", {}) or {}
+    return any(
+        str((route or {}).get("handler") or "").strip() == CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER
+        for route in setup.get("kinesis", []) or []
+    )
+
+
+def build_cloudwatch_logs_subscription_expectations(
+    fixture: dict[str, Any],
+) -> dict[str, dict[str, Any]] | None:
+    uses_handler = uses_cloudwatch_logs_subscription_handler(fixture)
+    expectation_root = (fixture.get("expect", {}) or {}).get("cloudwatch_logs_subscription")
+    if not expectation_root:
+        if uses_handler:
+            raise RuntimeError("fixture missing expect.cloudwatch_logs_subscription")
+        return None
+    if not uses_handler:
+        raise RuntimeError(
+            "expect.cloudwatch_logs_subscription requires kinesis_require_cloudwatch_logs_subscription handler"
+        )
+
+    expected_records = expectation_root.get("records") or []
+    if not isinstance(expected_records, list) or not expected_records:
+        raise RuntimeError("fixture missing expect.cloudwatch_logs_subscription.records")
+
+    input_records = (
+        (((fixture.get("input", {}) or {}).get("aws_event") or {}).get("event") or {}).get("Records")
+    )
+    if not isinstance(input_records, list) or not input_records:
+        raise RuntimeError("cloudwatch logs subscription fixture missing kinesis input records")
+
+    by_record_id: dict[str, dict[str, Any]] = {}
+    for index, expected in enumerate(expected_records):
+        record_id = str((expected or {}).get("record_id") or "").strip()
+        if not record_id:
+            raise RuntimeError(f"expect.cloudwatch_logs_subscription.records[{index}] missing record_id")
+        if record_id in by_record_id:
+            raise RuntimeError(f"duplicate cloudwatch logs subscription expectation for record_id {record_id!r}")
+        normalized = dict(expected or {})
+        normalized["record_id"] = record_id
+        validate_cloudwatch_logs_subscription_expectation_record(normalized)
+        by_record_id[record_id] = normalized
+
+    seen_input_record_ids: set[str] = set()
+    for index, record in enumerate(input_records):
+        record_id = str((record or {}).get("eventID") or "").strip()
+        if not record_id:
+            raise RuntimeError(
+                f"kinesis input Records[{index}] missing eventID for cloudwatch logs subscription expectation"
+            )
+        if record_id in seen_input_record_ids:
+            raise RuntimeError(f"duplicate kinesis input record_id {record_id!r}")
+        seen_input_record_ids.add(record_id)
+        if record_id not in by_record_id:
+            raise RuntimeError(
+                f"missing cloudwatch logs subscription expectation for kinesis record_id {record_id!r}"
+            )
+
+    for record_id in by_record_id:
+        if record_id not in seen_input_record_ids:
+            raise RuntimeError(f"extra cloudwatch logs subscription expectation for record_id {record_id!r}")
+
+    return by_record_id
+
+
+def validate_cloudwatch_logs_subscription_expectation_record(expected: dict[str, Any]) -> None:
+    record_id = str((expected or {}).get("record_id") or "").strip()
+    if expected.get("decode_error") is True:
+        has_decoded_fields = (
+            str(expected.get("message_type") or "").strip()
+            or str(expected.get("owner") or "").strip()
+            or str(expected.get("log_group") or "").strip()
+            or str(expected.get("log_stream") or "").strip()
+            or bool(expected.get("subscription_filters") or [])
+            or bool(expected.get("log_events") or [])
+            or bool(expected.get("safe_summary") or {})
+            or bool(expected.get("forbidden_safe_log_substrings") or [])
+        )
+        if has_decoded_fields:
+            raise RuntimeError(
+                f"cloudwatch logs subscription record_id {record_id!r} has decode_error=true and decoded fields"
+            )
+        return
+
+    missing: list[str] = []
+    if not str(expected.get("message_type") or "").strip():
+        missing.append("message_type")
+    if not str(expected.get("owner") or "").strip():
+        missing.append("owner")
+    if not str(expected.get("log_group") or "").strip():
+        missing.append("log_group")
+    if not str(expected.get("log_stream") or "").strip():
+        missing.append("log_stream")
+    if not isinstance(expected.get("subscription_filters"), list) or not expected.get("subscription_filters"):
+        missing.append("subscription_filters")
+    if not isinstance(expected.get("log_events"), list) or not expected.get("log_events"):
+        missing.append("log_events")
+    safe_summary = expected.get("safe_summary")
+    if not isinstance(safe_summary, dict) or not safe_summary:
+        missing.append("safe_summary")
+    if missing:
+        raise RuntimeError(
+            f"cloudwatch logs subscription record_id {record_id!r} expectation missing {', '.join(missing)}; "
+            "malformed records must set decode_error=true"
+        )
+
+    for index, value in enumerate(expected.get("subscription_filters") or []):
+        if not str(value or "").strip():
+            raise RuntimeError(
+                f"cloudwatch logs subscription record_id {record_id!r} subscription_filters[{index}] is empty"
+            )
+    for index, event in enumerate(expected.get("log_events") or []):
+        if not str((event or {}).get("id") or "").strip():
+            raise RuntimeError(f"cloudwatch logs subscription record_id {record_id!r} log_events[{index}] missing id")
+        if not str((event or {}).get("message") or "").strip():
+            raise RuntimeError(
+                f"cloudwatch logs subscription record_id {record_id!r} log_events[{index}] missing message"
+            )
+    if cloudwatch_logs_safe_summary_contains_forbidden(
+        safe_summary,
+        expected.get("forbidden_safe_log_substrings") or [],
+    ):
+        raise RuntimeError(
+            f"cloudwatch logs subscription record_id {record_id!r} safe_summary contains forbidden raw log substring"
+        )
+
+
+def _runtime_cloudwatch_logs_subscription_decoder(runtime: Any):
+    helper = getattr(runtime, "decode_cloudwatch_logs_subscription_record", None)
+    if not callable(helper):
+        helper = getattr(runtime, "decode_cloudwatch_logs_subscription", None)
+    if not callable(helper):
+        return missing_cloudwatch_logs_subscription_decoder
+    return lambda record: helper(record)
+
+
+def missing_cloudwatch_logs_subscription_decoder(_record: Any) -> dict[str, Any]:
+    raise RuntimeError(CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER)
+
+
+def make_cloudwatch_logs_subscription_kinesis_handler(
+    fixture: dict[str, Any],
+    decoder: Any | None = None,
+):
+    expectations = build_cloudwatch_logs_subscription_expectations(fixture)
+    if decoder is None:
+        decoder = missing_cloudwatch_logs_subscription_decoder
+
+    def handler(_ctx: Any, record: dict[str, Any]) -> None:
+        if expectations is None:
+            raise RuntimeError("fixture missing validated cloudwatch logs subscription expectations")
+        record_id = str((record or {}).get("eventID") or "").strip()
+        expected = expectations.get(record_id)
+        if expected is None:
+            raise RuntimeError(f"missing cloudwatch logs subscription expectation for kinesis record_id {record_id!r}")
+
+        actual = decoder(record)
+        if expected.get("decode_error") is True:
+            raise RuntimeError(
+                f"cloudwatch logs subscription record_id {record_id!r} expected decode_error=true, got decoded record"
+            )
+
+        ok, reason = compare_cloudwatch_logs_subscription_decoded_record(expected, actual)
+        if not ok:
+            raise RuntimeError(reason)
+
+    return handler
+
+
+def compare_cloudwatch_logs_subscription_decoded_record(
+    expected: dict[str, Any],
+    actual: dict[str, Any],
+) -> tuple[bool, str]:
+    record_id = str((expected or {}).get("record_id") or "").strip()
+    actual_record_id = str((actual or {}).get("record_id") or "").strip()
+    if actual_record_id and actual_record_id != record_id:
+        return (
+            False,
+            "cloudwatch logs subscription record_id mismatch: "
+            f"expected {record_id!r}, got {actual_record_id!r}",
+        )
+    for key in ("message_type", "owner", "log_group", "log_stream"):
+        if str((actual or {}).get(key) or "").strip() != str((expected or {}).get(key) or "").strip():
+            return False, f"cloudwatch logs subscription record_id {record_id!r} {key} mismatch"
+    expected_filters = (expected or {}).get("subscription_filters") or []
+    actual_filters = (actual or {}).get("subscription_filters") or []
+    if expected_filters != actual_filters:
+        return False, f"cloudwatch logs subscription record_id {record_id!r} subscription_filters mismatch"
+    expected_events = (expected or {}).get("log_events") or []
+    actual_events = (actual or {}).get("log_events") or []
+    if expected_events != actual_events:
+        return False, f"cloudwatch logs subscription record_id {record_id!r} log_events mismatch"
+    expected_summary = (expected or {}).get("safe_summary") or {}
+    actual_summary = (actual or {}).get("safe_summary") or {}
+    if expected_summary != actual_summary:
+        return False, f"cloudwatch logs subscription record_id {record_id!r} safe_summary mismatch"
+    if cloudwatch_logs_safe_summary_contains_forbidden(
+        actual_summary,
+        (expected or {}).get("forbidden_safe_log_substrings") or [],
+    ):
+        return (
+            False,
+            f"cloudwatch logs subscription record_id {record_id!r} "
+            "safe_summary contains forbidden raw log substring",
+        )
+    return True, ""
+
+
+def cloudwatch_logs_safe_summary_contains_forbidden(safe_summary: Any, forbidden_substrings: Any) -> bool:
+    if not isinstance(safe_summary, dict) or not isinstance(forbidden_substrings, list):
+        return False
+    serialized = json.dumps(safe_summary, sort_keys=True, separators=(",", ":"))
+    return any(str(substring or "") and str(substring) in serialized for substring in forbidden_substrings)
 
 
 def _m1_log_record(record: Any) -> dict[str, Any]:

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -1370,6 +1370,12 @@ def _built_in_kinesis_handler(name: str):
 
         return handler
 
+    if name == "kinesis_require_cloudwatch_logs_subscription":
+        def handler(_ctx, _record):
+            raise RuntimeError("apptheory: cloudwatch logs subscription decoder helper missing")
+
+        return handler
+
     return None
 
 

--- a/contract-tests/runners/py/run_self_test.py
+++ b/contract-tests/runners/py/run_self_test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+def load_runner() -> Any:
+    runner_path = Path(__file__).with_name("run.py")
+    spec = importlib.util.spec_from_file_location("apptheory_contract_py_runner", runner_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load runner from {runner_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = load_runner()
+
+
+def cloudwatch_logs_subscription_fixture() -> dict[str, Any]:
+    return {
+        "setup": {
+            "kinesis": [
+                {"stream": "stream", "handler": runner.CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER},
+            ],
+        },
+        "input": {
+            "aws_event": {
+                "source": "kinesis",
+                "event": {"Records": [{"eventID": "r1"}, {"eventID": "r2"}]},
+            },
+        },
+        "expect": {
+            "cloudwatch_logs_subscription": {
+                "records": [
+                    {
+                        "record_id": "r1",
+                        "message_type": "DATA_MESSAGE",
+                        "owner": "111122223333",
+                        "log_group": "/aws/lambda/example",
+                        "log_stream": "2026/05/26/[$LATEST]example",
+                        "subscription_filters": ["filter"],
+                        "log_events": [
+                            {
+                                "id": "event-1",
+                                "timestamp": 1779806400000,
+                                "message": "contract log line alpha",
+                            },
+                        ],
+                        "safe_summary": {
+                            "record_id": "r1",
+                            "message_type": "DATA_MESSAGE",
+                            "owner": "111122223333",
+                            "log_group": "/aws/lambda/example",
+                            "log_stream": "2026/05/26/[$LATEST]example",
+                            "subscription_filter_count": 1,
+                            "log_event_count": 1,
+                            "safe_log": "record_id=r1 owner=111122223333 log_events=1 subscription_filters=1",
+                        },
+                        "forbidden_safe_log_substrings": ["contract log line alpha"],
+                    },
+                    {"record_id": "r2", "decode_error": True},
+                ],
+            },
+        },
+    }
+
+
+class CloudWatchLogsSubscriptionScaffoldTests(unittest.TestCase):
+    def test_expectation_hygiene_maps_each_input_record_once(self) -> None:
+        fixture = cloudwatch_logs_subscription_fixture()
+        expectations = runner.build_cloudwatch_logs_subscription_expectations(fixture)
+        self.assertEqual({"r1", "r2"}, set(expectations or {}))
+
+        missing = cloudwatch_logs_subscription_fixture()
+        missing["expect"]["cloudwatch_logs_subscription"]["records"] = missing["expect"][
+            "cloudwatch_logs_subscription"
+        ]["records"][:1]
+        with self.assertRaisesRegex(RuntimeError, "missing cloudwatch logs subscription expectation"):
+            runner.build_cloudwatch_logs_subscription_expectations(missing)
+
+        extra = cloudwatch_logs_subscription_fixture()
+        extra["expect"]["cloudwatch_logs_subscription"]["records"].append(
+            {"record_id": "unexpected", "decode_error": True}
+        )
+        with self.assertRaisesRegex(RuntimeError, "extra cloudwatch logs subscription expectation"):
+            runner.build_cloudwatch_logs_subscription_expectations(extra)
+
+        duplicate = cloudwatch_logs_subscription_fixture()
+        duplicate["expect"]["cloudwatch_logs_subscription"]["records"].append(
+            duplicate["expect"]["cloudwatch_logs_subscription"]["records"][0]
+        )
+        with self.assertRaisesRegex(RuntimeError, "duplicate cloudwatch logs subscription expectation"):
+            runner.build_cloudwatch_logs_subscription_expectations(duplicate)
+
+        malformed_not_marked = cloudwatch_logs_subscription_fixture()
+        malformed_not_marked["expect"]["cloudwatch_logs_subscription"]["records"][1] = {"record_id": "r2"}
+        with self.assertRaisesRegex(RuntimeError, "malformed records must set decode_error=true"):
+            runner.build_cloudwatch_logs_subscription_expectations(malformed_not_marked)
+
+        decode_error_with_fields = cloudwatch_logs_subscription_fixture()
+        decode_error_with_fields["expect"]["cloudwatch_logs_subscription"]["records"][1] = {
+            "record_id": "r2",
+            "decode_error": True,
+            "message_type": "DATA_MESSAGE",
+        }
+        with self.assertRaisesRegex(RuntimeError, "decode_error=true and decoded fields"):
+            runner.build_cloudwatch_logs_subscription_expectations(decode_error_with_fields)
+
+    def test_handler_compares_decoder_result(self) -> None:
+        fixture = cloudwatch_logs_subscription_fixture()
+        expected = fixture["expect"]["cloudwatch_logs_subscription"]["records"][0]
+
+        def decoder(record: dict[str, Any]) -> dict[str, Any]:
+            if record["eventID"] == "r2":
+                raise RuntimeError("decode failed")
+            return expected
+
+        handler = runner.make_cloudwatch_logs_subscription_kinesis_handler(fixture, decoder)
+        handler(None, {"eventID": "r1"})
+        with self.assertRaisesRegex(RuntimeError, "decode failed"):
+            handler(None, {"eventID": "r2"})
+
+        mismatched = dict(expected)
+        mismatched["message_type"] = "CONTROL_MESSAGE"
+        mismatch_handler = runner.make_cloudwatch_logs_subscription_kinesis_handler(
+            fixture,
+            lambda _record: mismatched,
+        )
+        with self.assertRaisesRegex(RuntimeError, "message_type mismatch"):
+            mismatch_handler(None, {"eventID": "r1"})
+
+        unsafe = dict(expected)
+        unsafe["safe_summary"] = dict(expected["safe_summary"], safe_log="contract log line alpha")
+        ok, reason = runner.compare_cloudwatch_logs_subscription_decoded_record(expected, unsafe)
+        self.assertFalse(ok)
+        self.assertIn("safe_summary mismatch", reason)
+
+        missing_helper_handler = runner.make_cloudwatch_logs_subscription_kinesis_handler(fixture)
+        with self.assertRaisesRegex(RuntimeError, runner.CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER):
+            missing_helper_handler(None, {"eventID": "r1"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contract-tests/runners/ts/fixtures.test.cjs
+++ b/contract-tests/runners/ts/fixtures.test.cjs
@@ -3,7 +3,13 @@ const path = require("node:path");
 const test = require("node:test");
 const { pathToFileURL } = require("node:url");
 
-const { runAllFixtures } = require("./run.cjs");
+const {
+  CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER,
+  buildCloudWatchLogsSubscriptionExpectations,
+  compareCloudWatchLogsSubscriptionDecodedRecord,
+  makeCloudWatchLogsSubscriptionKinesisHandler,
+  runAllFixtures,
+} = require("./run.cjs");
 
 async function importDist(relPath) {
   const abs = path.join(process.cwd(), "ts", "dist", relPath);
@@ -277,6 +283,131 @@ test("contract fixtures (ts runtime)", { timeout: 60_000 }, async () => {
     `expected 0 failing fixtures, got ${failures.length}/${fixtures.length}: ${ids.join(", ")}`,
   );
 });
+
+test("cloudwatch logs subscription expectations enforce fixture hygiene", () => {
+  const fixture = cloudWatchLogsSubscriptionFixtureForTest();
+  const expectations = buildCloudWatchLogsSubscriptionExpectations(fixture);
+  assert.equal(expectations.size, 2);
+  assert.ok(expectations.has("r1"));
+  assert.ok(expectations.has("r2"));
+
+  const missing = cloudWatchLogsSubscriptionFixtureForTest();
+  missing.expect.cloudwatch_logs_subscription.records = missing.expect.cloudwatch_logs_subscription.records.slice(0, 1);
+  assert.throws(
+    () => buildCloudWatchLogsSubscriptionExpectations(missing),
+    /missing cloudwatch logs subscription expectation/,
+  );
+
+  const extra = cloudWatchLogsSubscriptionFixtureForTest();
+  extra.expect.cloudwatch_logs_subscription.records.push({ record_id: "unexpected", decode_error: true });
+  assert.throws(
+    () => buildCloudWatchLogsSubscriptionExpectations(extra),
+    /extra cloudwatch logs subscription expectation/,
+  );
+
+  const duplicate = cloudWatchLogsSubscriptionFixtureForTest();
+  duplicate.expect.cloudwatch_logs_subscription.records.push(
+    duplicate.expect.cloudwatch_logs_subscription.records[0],
+  );
+  assert.throws(
+    () => buildCloudWatchLogsSubscriptionExpectations(duplicate),
+    /duplicate cloudwatch logs subscription expectation/,
+  );
+
+  const malformedNotMarked = cloudWatchLogsSubscriptionFixtureForTest();
+  malformedNotMarked.expect.cloudwatch_logs_subscription.records[1] = { record_id: "r2" };
+  assert.throws(
+    () => buildCloudWatchLogsSubscriptionExpectations(malformedNotMarked),
+    /malformed records must set decode_error=true/,
+  );
+
+  const decodeErrorWithFields = cloudWatchLogsSubscriptionFixtureForTest();
+  decodeErrorWithFields.expect.cloudwatch_logs_subscription.records[1] = {
+    record_id: "r2",
+    decode_error: true,
+    message_type: "DATA_MESSAGE",
+  };
+  assert.throws(
+    () => buildCloudWatchLogsSubscriptionExpectations(decodeErrorWithFields),
+    /decode_error=true and decoded fields/,
+  );
+});
+
+test("cloudwatch logs subscription handler compares decoder results", async () => {
+  const fixture = cloudWatchLogsSubscriptionFixtureForTest();
+  const validExpected = fixture.expect.cloudwatch_logs_subscription.records[0];
+  const handler = makeCloudWatchLogsSubscriptionKinesisHandler(fixture, async (record) => {
+    if (record.eventID === "r2") {
+      throw new Error("decode failed");
+    }
+    return validExpected;
+  });
+
+  await handler({}, { eventID: "r1" });
+  await assert.rejects(() => handler({}, { eventID: "r2" }), /decode failed/);
+
+  const mismatched = makeCloudWatchLogsSubscriptionKinesisHandler(fixture, async () => ({
+    ...validExpected,
+    message_type: "CONTROL_MESSAGE",
+  }));
+  await assert.rejects(() => mismatched({}, { eventID: "r1" }), /message_type mismatch/);
+
+  const unsafe = compareCloudWatchLogsSubscriptionDecodedRecord(validExpected, {
+    ...validExpected,
+    safe_summary: { ...validExpected.safe_summary, safe_log: "contract log line alpha" },
+  });
+  assert.equal(unsafe.ok, false);
+  assert.match(unsafe.reason, /safe_summary mismatch/);
+
+  const missingHelper = makeCloudWatchLogsSubscriptionKinesisHandler(fixture);
+  await assert.rejects(
+    () => missingHelper({}, { eventID: "r1" }),
+    new RegExp(CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER),
+  );
+});
+
+function cloudWatchLogsSubscriptionFixtureForTest() {
+  return {
+    setup: {
+      kinesis: [{ stream: "stream", handler: "kinesis_require_cloudwatch_logs_subscription" }],
+    },
+    input: {
+      aws_event: {
+        source: "kinesis",
+        event: { Records: [{ eventID: "r1" }, { eventID: "r2" }] },
+      },
+    },
+    expect: {
+      cloudwatch_logs_subscription: {
+        records: [
+          {
+            record_id: "r1",
+            message_type: "DATA_MESSAGE",
+            owner: "111122223333",
+            log_group: "/aws/lambda/example",
+            log_stream: "2026/05/26/[$LATEST]example",
+            subscription_filters: ["filter"],
+            log_events: [
+              { id: "event-1", timestamp: 1779806400000, message: "contract log line alpha" },
+            ],
+            safe_summary: {
+              record_id: "r1",
+              message_type: "DATA_MESSAGE",
+              owner: "111122223333",
+              log_group: "/aws/lambda/example",
+              log_stream: "2026/05/26/[$LATEST]example",
+              subscription_filter_count: 1,
+              log_event_count: 1,
+              safe_log: "record_id=r1 owner=111122223333 log_events=1 subscription_filters=1",
+            },
+            forbidden_safe_log_substrings: ["contract log line alpha"],
+          },
+          { record_id: "r2", decode_error: true },
+        ],
+      },
+    },
+  };
+}
 
 test("routing: handleStrict rejects invalid patterns", async () => {
   const { createApp } = await importDist("index.js");

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -10,6 +10,10 @@ const util = require("node:util");
 
 let cachedRuntime = null;
 
+const CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER = "kinesis_require_cloudwatch_logs_subscription";
+const CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER =
+  "apptheory: cloudwatch logs subscription decoder helper missing";
+
 async function loadAppTheoryRuntime() {
   if (cachedRuntime) return cachedRuntime;
   const runtimePath = path.join(process.cwd(), "ts", "dist", "index.js");
@@ -1053,6 +1057,210 @@ function compareM1SideEffectsIfExpected(fixture, effects) {
   return { ok: true };
 }
 
+function usesCloudWatchLogsSubscriptionHandler(fixture) {
+  return (fixture.setup?.kinesis ?? []).some(
+    (route) => String(route?.handler ?? "").trim() === CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER,
+  );
+}
+
+function buildCloudWatchLogsSubscriptionExpectations(fixture) {
+  const usesHandler = usesCloudWatchLogsSubscriptionHandler(fixture);
+  const expectationRoot = fixture.expect?.cloudwatch_logs_subscription ?? null;
+  if (!expectationRoot) {
+    if (usesHandler) {
+      throw new Error("fixture missing expect.cloudwatch_logs_subscription");
+    }
+    return null;
+  }
+  if (!usesHandler) {
+    throw new Error("expect.cloudwatch_logs_subscription requires kinesis_require_cloudwatch_logs_subscription handler");
+  }
+
+  const expectedRecords = expectationRoot.records ?? [];
+  if (!Array.isArray(expectedRecords) || expectedRecords.length === 0) {
+    throw new Error("fixture missing expect.cloudwatch_logs_subscription.records");
+  }
+
+  const inputRecords = fixture.input?.aws_event?.event?.Records ?? null;
+  if (!Array.isArray(inputRecords) || inputRecords.length === 0) {
+    throw new Error("cloudwatch logs subscription fixture missing kinesis input records");
+  }
+
+  const byRecordId = new Map();
+  expectedRecords.forEach((expected, index) => {
+    const recordId = String(expected?.record_id ?? "").trim();
+    if (!recordId) {
+      throw new Error(`expect.cloudwatch_logs_subscription.records[${index}] missing record_id`);
+    }
+    if (byRecordId.has(recordId)) {
+      throw new Error(`duplicate cloudwatch logs subscription expectation for record_id ${JSON.stringify(recordId)}`);
+    }
+    validateCloudWatchLogsSubscriptionExpectationRecord({ ...expected, record_id: recordId });
+    byRecordId.set(recordId, { ...expected, record_id: recordId });
+  });
+
+  const seenInputRecordIds = new Set();
+  inputRecords.forEach((record, index) => {
+    const recordId = String(record?.eventID ?? "").trim();
+    if (!recordId) {
+      throw new Error(`kinesis input Records[${index}] missing eventID for cloudwatch logs subscription expectation`);
+    }
+    if (seenInputRecordIds.has(recordId)) {
+      throw new Error(`duplicate kinesis input record_id ${JSON.stringify(recordId)}`);
+    }
+    seenInputRecordIds.add(recordId);
+    if (!byRecordId.has(recordId)) {
+      throw new Error(`missing cloudwatch logs subscription expectation for kinesis record_id ${JSON.stringify(recordId)}`);
+    }
+  });
+
+  for (const recordId of byRecordId.keys()) {
+    if (!seenInputRecordIds.has(recordId)) {
+      throw new Error(`extra cloudwatch logs subscription expectation for record_id ${JSON.stringify(recordId)}`);
+    }
+  }
+
+  return byRecordId;
+}
+
+function validateCloudWatchLogsSubscriptionExpectationRecord(expected) {
+  const recordId = String(expected?.record_id ?? "").trim();
+  if (expected?.decode_error === true) {
+    const hasDecodedFields =
+      String(expected.message_type ?? "").trim() ||
+      String(expected.owner ?? "").trim() ||
+      String(expected.log_group ?? "").trim() ||
+      String(expected.log_stream ?? "").trim() ||
+      (Array.isArray(expected.subscription_filters) && expected.subscription_filters.length > 0) ||
+      (Array.isArray(expected.log_events) && expected.log_events.length > 0) ||
+      (expected.safe_summary && Object.keys(expected.safe_summary).length > 0) ||
+      (Array.isArray(expected.forbidden_safe_log_substrings) &&
+        expected.forbidden_safe_log_substrings.length > 0);
+    if (hasDecodedFields) {
+      throw new Error(`cloudwatch logs subscription record_id ${JSON.stringify(recordId)} has decode_error=true and decoded fields`);
+    }
+    return;
+  }
+
+  const missing = [];
+  if (!String(expected?.message_type ?? "").trim()) missing.push("message_type");
+  if (!String(expected?.owner ?? "").trim()) missing.push("owner");
+  if (!String(expected?.log_group ?? "").trim()) missing.push("log_group");
+  if (!String(expected?.log_stream ?? "").trim()) missing.push("log_stream");
+  if (!Array.isArray(expected?.subscription_filters) || expected.subscription_filters.length === 0) {
+    missing.push("subscription_filters");
+  }
+  if (!Array.isArray(expected?.log_events) || expected.log_events.length === 0) {
+    missing.push("log_events");
+  }
+  if (!expected?.safe_summary || typeof expected.safe_summary !== "object" || Array.isArray(expected.safe_summary) || Object.keys(expected.safe_summary).length === 0) {
+    missing.push("safe_summary");
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `cloudwatch logs subscription record_id ${JSON.stringify(recordId)} expectation missing ${missing.join(", ")}; malformed records must set decode_error=true`,
+    );
+  }
+
+  expected.subscription_filters.forEach((filter, index) => {
+    if (!String(filter ?? "").trim()) {
+      throw new Error(`cloudwatch logs subscription record_id ${JSON.stringify(recordId)} subscription_filters[${index}] is empty`);
+    }
+  });
+  expected.log_events.forEach((event, index) => {
+    if (!String(event?.id ?? "").trim()) {
+      throw new Error(`cloudwatch logs subscription record_id ${JSON.stringify(recordId)} log_events[${index}] missing id`);
+    }
+    if (!String(event?.message ?? "").trim()) {
+      throw new Error(`cloudwatch logs subscription record_id ${JSON.stringify(recordId)} log_events[${index}] missing message`);
+    }
+  });
+  if (cloudWatchLogsSafeSummaryContainsForbidden(
+    expected.safe_summary,
+    expected.forbidden_safe_log_substrings ?? [],
+  )) {
+    throw new Error(`cloudwatch logs subscription record_id ${JSON.stringify(recordId)} safe_summary contains forbidden raw log substring`);
+  }
+}
+
+function runtimeCloudWatchLogsSubscriptionDecoder(runtime) {
+  const helper =
+    runtime?.decodeCloudWatchLogsSubscriptionRecord ??
+    runtime?.decodeCloudWatchLogsSubscription;
+  if (typeof helper !== "function") {
+    return missingCloudWatchLogsSubscriptionDecoder;
+  }
+  return async (record) => helper(record);
+}
+
+async function missingCloudWatchLogsSubscriptionDecoder() {
+  throw new Error(CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER);
+}
+
+function makeCloudWatchLogsSubscriptionKinesisHandler(fixture, decoder = missingCloudWatchLogsSubscriptionDecoder) {
+  const expectations = buildCloudWatchLogsSubscriptionExpectations(fixture);
+  return async (_ctx, record) => {
+    if (!expectations) {
+      throw new Error("fixture missing validated cloudwatch logs subscription expectations");
+    }
+    const recordId = String(record?.eventID ?? "").trim();
+    const expected = expectations.get(recordId);
+    if (!expected) {
+      throw new Error(`missing cloudwatch logs subscription expectation for kinesis record_id ${JSON.stringify(recordId)}`);
+    }
+
+    const actual = await decoder(record);
+    if (expected.decode_error === true) {
+      throw new Error(`cloudwatch logs subscription record_id ${JSON.stringify(recordId)} expected decode_error=true, got decoded record`);
+    }
+
+    const compare = compareCloudWatchLogsSubscriptionDecodedRecord(expected, actual);
+    if (!compare.ok) {
+      throw new Error(compare.reason);
+    }
+  };
+}
+
+function compareCloudWatchLogsSubscriptionDecodedRecord(expected, actual) {
+  const recordId = String(expected?.record_id ?? "").trim();
+  const actualRecordId = String(actual?.record_id ?? "").trim();
+  if (actualRecordId && actualRecordId !== recordId) {
+    return { ok: false, reason: `cloudwatch logs subscription record_id mismatch: expected ${JSON.stringify(recordId)}, got ${JSON.stringify(actualRecordId)}` };
+  }
+  for (const key of ["message_type", "owner", "log_group", "log_stream"]) {
+    if (String(actual?.[key] ?? "").trim() !== String(expected?.[key] ?? "").trim()) {
+      return { ok: false, reason: `cloudwatch logs subscription record_id ${JSON.stringify(recordId)} ${key} mismatch` };
+    }
+  }
+  if (!deepEqual(expected?.subscription_filters ?? [], actual?.subscription_filters ?? [])) {
+    return { ok: false, reason: `cloudwatch logs subscription record_id ${JSON.stringify(recordId)} subscription_filters mismatch` };
+  }
+  if (!deepEqual(expected?.log_events ?? [], actual?.log_events ?? [])) {
+    return { ok: false, reason: `cloudwatch logs subscription record_id ${JSON.stringify(recordId)} log_events mismatch` };
+  }
+  if (!deepEqual(expected?.safe_summary ?? {}, actual?.safe_summary ?? {})) {
+    return { ok: false, reason: `cloudwatch logs subscription record_id ${JSON.stringify(recordId)} safe_summary mismatch` };
+  }
+  if (cloudWatchLogsSafeSummaryContainsForbidden(
+    actual?.safe_summary ?? {},
+    expected?.forbidden_safe_log_substrings ?? [],
+  )) {
+    return { ok: false, reason: `cloudwatch logs subscription record_id ${JSON.stringify(recordId)} safe_summary contains forbidden raw log substring` };
+  }
+  return { ok: true };
+}
+
+function cloudWatchLogsSafeSummaryContainsForbidden(safeSummary, forbiddenSubstrings) {
+  if (!safeSummary || !Array.isArray(forbiddenSubstrings) || forbiddenSubstrings.length === 0) {
+    return false;
+  }
+  const serialized = JSON.stringify(safeSummary);
+  return forbiddenSubstrings.some((substring) => {
+    const needle = String(substring ?? "");
+    return needle && serialized.includes(needle);
+  });
+}
+
 function compareWebSocketCalls(fixture, wsCalls) {
   const expected = fixture.expect?.ws_calls ?? [];
   const actual = wsCalls?.calls ?? [];
@@ -1133,7 +1341,7 @@ function builtInSQSHandler(name) {
   }
 }
 
-function builtInKinesisHandler(name) {
+function builtInKinesisHandler(runtime, name, fixture) {
   switch (String(name ?? "").trim()) {
     case "kinesis_noop":
       return async () => {};
@@ -1159,10 +1367,11 @@ function builtInKinesisHandler(name) {
           throw new Error("bad trace");
         }
       };
-    case "kinesis_require_cloudwatch_logs_subscription":
-      return async () => {
-        throw new Error("apptheory: cloudwatch logs subscription decoder helper missing");
-      };
+    case CLOUDWATCH_LOGS_SUBSCRIPTION_HANDLER:
+      return makeCloudWatchLogsSubscriptionKinesisHandler(
+        fixture,
+        runtimeCloudWatchLogsSubscriptionDecoder(runtime),
+      );
     default:
       return null;
   }
@@ -1596,7 +1805,7 @@ async function runFixtureM1(fixture) {
   }
 
   for (const route of fixture.setup?.kinesis ?? []) {
-    const handler = builtInKinesisHandler(route.handler);
+    const handler = builtInKinesisHandler(runtime, route.handler, fixture);
     if (!handler) {
       throw new Error(`unknown kinesis handler ${JSON.stringify(route.handler)}`);
     }
@@ -2769,6 +2978,10 @@ async function runAllFixtures({ fixturesRoot } = {}) {
 }
 
 module.exports = {
+  CLOUDWATCH_LOGS_SUBSCRIPTION_MISSING_HELPER,
+  buildCloudWatchLogsSubscriptionExpectations,
+  compareCloudWatchLogsSubscriptionDecodedRecord,
+  makeCloudWatchLogsSubscriptionKinesisHandler,
   runAllFixtures,
 };
 

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -1159,6 +1159,10 @@ function builtInKinesisHandler(name) {
           throw new Error("bad trace");
         }
       };
+    case "kinesis_require_cloudwatch_logs_subscription":
+      return async () => {
+        throw new Error("apptheory: cloudwatch logs subscription decoder helper missing");
+      };
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- Add M1 Kinesis CloudWatch Logs subscription fixtures for valid gzip+JSON decode and malformed-record partial-batch behavior.
- Add the portable `expect.cloudwatch_logs_subscription.records` shape for decoded metadata, ordered log events, safe summaries, and forbidden raw-message substrings.
- Rework the Go/TypeScript/Python runners so `kinesis_require_cloudwatch_logs_subscription` validates expectation hygiene, maps expectations by `record_id`, and is ready to compare runtime decoder results without adding a runner-local decoder.

## Branch / head

- Branch: `theorymcp/theorycloud/apptheory/the-1608-kinesis-log-contract`
- Base: `theorymcp/theorycloud/factory/apptheory-kinesis-ingestion-support`
- Head SHA: `b3168819dd172b685dfb08eeb4b88f305130582e`
- Rework commit: `b316881 test(contract): enforce kinesis log expectations`

## Required fixes addressed

1. **Runner validation scaffold:** Go/TS/Py now build `record_id` expectation maps for `expect.cloudwatch_logs_subscription.records` and compare decoder results against `message_type`, `owner`, `log_group`, `log_stream`, `subscription_filters`, ordered `log_events`, `safe_summary`, and forbidden raw-message substrings.
2. **Fixture-first scope preserved:** the handler still routes through one explicit missing-helper path (`apptheory: cloudwatch logs subscription decoder helper missing`) until THE-1609..THE-1611 add runtime helpers. No runner-local gzip/base64/CloudWatch decoder was added.
3. **Expectation hygiene enforced:** runners validate that every Kinesis input record has exactly one expectation, malformed records are explicit `decode_error` records, decoded fields are not set on `decode_error` expectations, and extra expected records fail instead of being ignored.
4. **Scaffold checks added:** Go unit coverage, TypeScript node-test coverage, and Python `run_self_test.py` cover expectation hygiene, comparison scaffolding, and the missing-helper path.

## Validation

- `./scripts/verify-contract-tests.sh` — expected FAIL only on:
  - `m1.kinesis.cloudwatch_logs_subscription.malformed_partial_batch`
  - `m1.kinesis.cloudwatch_logs_subscription.valid_decode`
  - reason: missing runtime decoder helper causes valid records to be reported in `batchItemFailures` until THE-1609..THE-1611.
- `node contract-tests/runners/ts/run.cjs` — expected FAIL only on the same two fixtures; actual output shows valid records failed by the missing-helper path.
- `PYTHONDONTWRITEBYTECODE=1 python3 contract-tests/runners/py/run.py` — expected FAIL only on the same two fixtures; actual output shows valid records failed by the missing-helper path.
- `jq -e` on the two new fixture files plus fixture payload smoke script — PASS (`kinesis-cwl-fixture-payloads: PASS`).
- `go test ./contract-tests/runners/go -run '^$' && go test ./contract-tests/runners/go -run 'CloudWatchLogsSubscription'` — PASS.
- `node --check contract-tests/runners/ts/run.cjs && node --test --test-name-pattern 'cloudwatch logs subscription' contract-tests/runners/ts/fixtures.test.cjs` — PASS (2 tests).
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile contract-tests/runners/py/run.py contract-tests/runners/py/run_self_test.py && PYTHONDONTWRITEBYTECODE=1 python3 contract-tests/runners/py/run_self_test.py` — PASS (2 tests).
- `git diff --check` — PASS.

## Applied memories / lessons

- Applied prior THE-1608 memory: this PR is contract-test foundation only; it must keep the two new fixtures expected-failing until runtime decoder parity lands, and it must not add CDK, producer, or runtime decoder implementation.
- Applied Kinesis roadmap lesson: CloudWatch Logs subscription decoding is the portable fixture contract consumed by later Go/TS/Python issues.

## Security / non-goals

- No AWS/cloud mutation, live credentials, producer helpers, CDK constructs, examples, or runtime decoder implementation.
- Fixture payloads remain synthetic contract strings; no raw customer logs, secrets, or customer-specific alerting logic.

## Risks / blockers

- Expected blocker remains: THE-1609..THE-1611 must add/wire the Go/TS/Python runtime decoder helpers before these two fixtures pass.

## Cleanup status

- Working tree was clean before push and no target-branch rewrite/force-push was performed.
- No stashes, worktrees, local-only commits, generated release assets, logs, credentials, or non-target branches were intentionally created for this rework.

Refs THE-1608
Refs theory-cloud/AppTheory#572
