### PR TITLE
docs: document kinesis ingestion path

### DIFF
--- a/cdk/docs/README.md
+++ b/cdk/docs/README.md
@@ -28,6 +28,8 @@
 - [SQS Queue + Consumer Patterns](./sqs-queue-consumer.md) — queue-only, queue+consumer, and processor patterns (DLQs + partial batch failures).
 - [EventBridge Bus](./eventbridge-bus.md) — custom EventBridge bus with explicit cross-account publish allowlist.
 - [EventBridge Rule Target](./eventbridge-rule-target.md) — rule → Lambda wiring for schedules and event patterns.
+- [Canonical Kinesis + CloudWatch Logs](../../docs/cdk/kinesis-cloudwatch-logs.md) — AppTheory Kinesis stream,
+  stream mapping, and Logs destination path.
 - [EventBus Table](./eventbus-table.md) — durable EventBus DynamoDB table with binding guidance for publish and replay flows.
 - [HTTP Ingestion Endpoint](./http-ingestion-endpoint.md) — authenticated server-to-server ingestion endpoint with Lambda request authorizer.
 - [S3 Ingest Front Door](./s3-ingest.md) — secure bucket + optional EventBridge/SQS notifications for import workloads.

--- a/cdk/docs/_concepts.yaml
+++ b/cdk/docs/_concepts.yaml
@@ -31,6 +31,18 @@ concepts:
     related_docs:
       - cdk/docs/eventbridge-rule-target.md
 
+  kinesis_ingestion_constructs:
+    type: construct_group
+    purpose: "AppTheory Kinesis stream, stream mapping, and CloudWatch Logs destination path."
+    provides:
+      - encrypted_stream_create_or_wrap
+      - lambda_kinesis_event_source_mapping
+      - cloudwatch_logs_destination_allowlist
+      - partial_batch_failure_default
+    related_docs:
+      - docs/cdk/kinesis-cloudwatch-logs.md
+      - cdk/docs/api-reference.md
+
   s3_ingest:
     type: construct
     purpose: "Secure S3 ingest bucket with optional EventBridge/SQS notifications (import pipeline front door)."

--- a/cdk/docs/api-reference.md
+++ b/cdk/docs/api-reference.md
@@ -26,6 +26,9 @@ AppTheory CDK exports constructs such as:
 - `AppTheoryS3Ingest` (secure S3 ingest bucket + optional EventBridge/SQS notifications)
 - `AppTheoryCodeBuildJobRunner` (CodeBuild project wrapper for batch steps; safe defaults + logs + state-change hook)
 - `AppTheoryDynamoDBStreamMapping` (Streams mapping + permissions)
+- `AppTheoryKinesisStream` (Kinesis Data Stream create/wrap surface with encryption and grant helpers)
+- `AppTheoryKinesisStreamMapping` (Kinesis stream → Lambda event-source mapping; partial-batch failures default on)
+- `AppTheoryCloudWatchLogsDestination` (CloudWatch Logs destination → Kinesis with explicit source allowlists)
 - `AppTheoryEventBusTable` (opinionated EventBus DynamoDB table + required GSIs + Lambda binding helper)
 - `AppTheoryDynamoTable` (general-purpose DynamoDB table; schema-explicit + consistent defaults)
 - `AppTheoryJobsTable` (opinionated Jobs table for import pipelines; schema + GSIs + TTL)
@@ -37,3 +40,27 @@ AppTheory CDK exports constructs such as:
 - Higher-level "app"/SSR patterns now converge on the FaceTheory-first deployment contract rather than a weaker helper path
 
 For the exact list and prop types, read `cdk/lib/*.d.ts`.
+
+## Kinesis and CloudWatch Logs path
+
+The supported AppTheory Kinesis ingestion path is:
+
+```text
+CloudWatch Logs subscription
+  -> AppTheoryCloudWatchLogsDestination
+  -> AppTheoryKinesisStream
+  -> AppTheoryKinesisStreamMapping
+  -> AppTheory Lambda runtime decoder
+```
+
+Use `AppTheoryKinesisStream` to create or wrap the stream, `AppTheoryKinesisStreamMapping` to connect the stream to the
+consumer Lambda, and `AppTheoryCloudWatchLogsDestination` to expose a fail-closed Logs destination. The destination
+requires `allowedSourceAccounts` and/or `allowedOrganizationIds`; placeholder IDs in examples are examples only and are
+not live account claims.
+
+Keep the handler on the AppTheory runtime entrypoint and decode Kinesis-delivered CloudWatch Logs envelopes with
+`DecodeCloudWatchLogsSubscription` / `decodeCloudWatchLogsSubscription` /
+`decode_cloudwatch_logs_subscription`.
+
+Canonical guide: `docs/cdk/kinesis-cloudwatch-logs.md`.
+Canonical example: `examples/cdk/kinesis-cloudwatch-logs`.

--- a/docs/_concepts.yaml
+++ b/docs/_concepts.yaml
@@ -92,6 +92,32 @@ concepts:
       - appsync_resolver_detection
       - single_lambda_entrypoint
 
+  kinesis_ingestion:
+    type: component
+    purpose: "AppTheory-owned Kinesis ingestion path for stream records and CloudWatch Logs subscription envelopes."
+    provides:
+      - kinesis_stream_routing
+      - partial_batch_failure_responses
+      - cloudwatch_logs_subscription_decoder
+      - bounded_kinesis_json_producer_helpers
+      - deterministic_kinesis_testkit_builders
+      - cdk_stream_destination_and_mapping_constructs
+    configuration:
+      - runtime/aws_eventsources.go
+      - runtime/kinesis_cloudwatch_logs.go
+      - runtime/kinesis_producer.go
+      - ts/src/kinesis-cloudwatch-logs.ts
+      - ts/src/kinesis-producer.ts
+      - py/src/apptheory/kinesis_cloudwatch_logs.py
+      - py/src/apptheory/kinesis_producer.py
+      - cdk/lib/kinesis-stream.ts
+      - cdk/lib/kinesis-stream-mapping.ts
+      - cdk/lib/cloudwatch-logs-destination.ts
+    docs:
+      - docs/features/event-workloads.md
+      - docs/cdk/kinesis-cloudwatch-logs.md
+      - examples/cdk/kinesis-cloudwatch-logs/README.md
+
   appsync_resolvers:
     type: component
     purpose: "Direct Lambda resolver support that adapts standard AWS AppSync events into the normal AppTheory router."
@@ -183,6 +209,7 @@ concepts:
       - rest_api_constructs
       - mcp_server_constructs
       - import_pipeline_constructs
+      - kinesis_ingestion_constructs
       - lambda_defaults
     configuration:
       - cdk/

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -155,8 +155,38 @@ Event workload contract notes:
 - `metadata.correlation_id` and top-level `headers["x-correlation-id"]` are AppTheory portable envelope conventions, not AWS-native EventBridge fields.
 - Scheduled workloads use EventBridge scheduled events and derive run IDs, idempotency keys, remaining-time/deadline fields, and structured result summaries.
 - DynamoDB Streams workloads keep the Lambda partial-batch response contract and derive only safe record summaries.
+- Kinesis workloads keep the Lambda partial-batch response contract, route by stream name, and fail closed for
+  unregistered streams by returning every record ID as a failure.
+
+### Kinesis runtime and helpers
+
+Kinesis uses the universal Lambda dispatcher. Register one stream handler through the AppTheory app and keep the Lambda
+handler on `HandleLambda`, `handleLambda`, or `handle_lambda`.
+
+| Concern | Go | TypeScript | Python |
+| --- | --- | --- | --- |
+| Register stream handler | `app.Kinesis(streamName, handler)` | `app.kinesis(streamName, handler)` | `app.kinesis(stream_name, handler)` |
+| Direct Kinesis entrypoint | `app.ServeKinesis(ctx, event)` | `app.serveKinesisEvent(event, ctx)` | `app.serve_kinesis(event, ctx)` |
+| CloudWatch Logs decoder | `DecodeCloudWatchLogsSubscription(record)` | `decodeCloudWatchLogsSubscription(record)` | `decode_cloudwatch_logs_subscription(record)` |
+| JSON producer record helper | `NewKinesisJSONRecord(opts)` | `createKinesisJsonRecord(opts)` | `create_kinesis_json_record(...)` |
+| PutRecords failure reporter | `ReportKinesisPutRecordsFailures(records, results)` | `reportKinesisPutRecordsFailures(records, results)` | `report_kinesis_put_records_failures(records, results)` |
+
+Kinesis handler failures are returned as Lambda partial-batch failures by record `eventID`; successful records are
+omitted. `DecodeCloudWatchLogsSubscription` and its TypeScript/Python equivalents decode the gzip CloudWatch Logs
+subscription envelope carried in Kinesis data and return a `safe_summary` that excludes raw log messages. The producer
+helpers create deterministic JSON record bytes and safe failure summaries without introducing a second per-service
+record or failure shape.
+
+Testkit helpers:
+
+| Concern | Go | TypeScript | Python |
+| --- | --- | --- | --- |
+| Build Kinesis event | `KinesisEvent` | `buildKinesisEvent` | `build_kinesis_event` |
+| Build CloudWatch Logs subscription record | `KinesisCloudWatchLogsSubscriptionRecord` | `kinesisCloudWatchLogsSubscriptionRecord` | `kinesis_cloudwatch_logs_subscription_record` |
+| Build CloudWatch Logs subscription data | `CloudWatchLogsSubscriptionData` | `cloudWatchLogsSubscriptionData` | `cloudwatch_logs_subscription_data` |
 
 Guide: [Event Workload Contracts](./features/event-workloads.md)
+Canonical CDK example: `examples/cdk/kinesis-cloudwatch-logs`
 
 ### AppSync resolvers
 
@@ -338,11 +368,15 @@ includes:
 - `AppTheoryJobsTable`
 - `AppTheoryS3Ingest`
 - `AppTheoryCodeBuildJobRunner`
+- `AppTheoryKinesisStream`
+- `AppTheoryKinesisStreamMapping`
+- `AppTheoryCloudWatchLogsDestination`
 
 Start with:
 
 - [CDK Getting Started](./cdk/getting-started.md)
 - [CDK API Reference](./cdk/api-reference.md)
+- [Kinesis + CloudWatch Logs](./cdk/kinesis-cloudwatch-logs.md)
 - [CDK Import Pipeline Guides](./cdk/import-pipeline.md)
 
 Package-local docs remain available under `ts/docs/`, `py/docs/`, and `cdk/docs/` for language-specific examples, but

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -14,6 +14,7 @@ patterns and treat `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts` as the 
 - [Claude Remote MCP + Streaming](./mcp-server-remote-mcp.md)
 - [MCP Protected Resource Metadata](./mcp-protected-resource.md)
 - [Import Pipeline Constructs](./import-pipeline.md)
+- [Kinesis + CloudWatch Logs](./kinesis-cloudwatch-logs.md)
 
 ## Scope
 
@@ -26,5 +27,6 @@ These pages cover the canonical user-facing CDK patterns for:
 - MCP and OAuth discovery endpoints
 - import-pipeline infrastructure primitives
 - EventBridge bus and rule-target transport primitives
+- Kinesis stream, stream mapping, and CloudWatch Logs destination transport primitives
 
 Package-local authoring docs may still exist outside `docs/cdk/`, but canonical external guidance lives here.

--- a/docs/cdk/api-reference.md
+++ b/docs/cdk/api-reference.md
@@ -16,6 +16,11 @@ constructs, read `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts`.
 - `AppTheoryCodeBuildJobRunner`: batch-step runner for import pipelines
 - `AppTheoryEventBridgeBus`: custom EventBridge bus with explicit cross-account publish allowlist
 - `AppTheoryEventBridgeRuleTarget`: EventBridge rule or schedule to Lambda target
+- `AppTheoryKinesisStream`: create or wrap the encrypted Kinesis Data Stream used by AppTheory stream consumers
+- `AppTheoryKinesisStreamMapping`: Kinesis stream to AppTheory Lambda event-source mapping with partial-batch failures
+  enabled by default
+- `AppTheoryCloudWatchLogsDestination`: CloudWatch Logs destination and fail-closed source allowlist for Logs-to-Kinesis
+  delivery
 - `AppTheoryHttpIngestionEndpoint`: authenticated HTTP API v2 ingestion endpoint with Lambda request authorizer
 - `AppTheorySsrSite`: FaceTheory-first CloudFront + S3 + Lambda URL deployment for SSR, SSG, and ISR
 - `AppTheoryQueue`, `AppTheoryQueueConsumer`, `AppTheoryQueueProcessor`: SQS queue and consumer patterns
@@ -47,12 +52,20 @@ Event workload wiring:
 - use `AppTheoryEventBridgeRuleTarget` for scheduled workloads and EventBridge pattern intake
 - use `targetProps` on EventBridge targets for DLQ, retry, and maximum-event-age policy
 - use `AppTheoryDynamoDBStreamMapping` for DynamoDB Streams to Lambda wiring
+- use `AppTheoryKinesisStream` plus `AppTheoryKinesisStreamMapping` for Kinesis stream consumers
+- use `AppTheoryCloudWatchLogsDestination` when CloudWatch Logs subscriptions deliver through Kinesis; configure
+  `allowedSourceAccounts` and/or `allowedOrganizationIds` explicitly
 - use `AppTheoryJobsTable` when the workload needs durable run state, idempotency, leases, or record status
 - keep handlers on AppTheory runtime entrypoints so routing, retry posture, and observability stay fixture-backed
 
 Runtime guide:
 
 - [Event Workload Contracts](../features/event-workloads.md)
+
+Kinesis guide and example:
+
+- [Kinesis + CloudWatch Logs](./kinesis-cloudwatch-logs.md)
+- `examples/cdk/kinesis-cloudwatch-logs`
 
 Guide:
 

--- a/docs/cdk/kinesis-cloudwatch-logs.md
+++ b/docs/cdk/kinesis-cloudwatch-logs.md
@@ -1,0 +1,129 @@
+# Kinesis + CloudWatch Logs
+
+AppTheory's Kinesis ingestion path is a single chain:
+
+```text
+CloudWatch Logs subscription
+  -> AppTheoryCloudWatchLogsDestination
+  -> AppTheoryKinesisStream
+  -> AppTheoryKinesisStreamMapping
+  -> AppTheory Lambda runtime
+  -> DecodeCloudWatchLogsSubscription
+```
+
+Use this path when CloudWatch Logs subscription records need to land in an AppTheory Lambda through Kinesis. Do not
+replace the stream, destination, or event-source mapping with bespoke raw CDK resources for one service; if the supported
+path is missing a needed control, grow the AppTheory construct surface.
+
+## Construct roles
+
+- `AppTheoryKinesisStream` creates or wraps the encrypted Kinesis Data Stream. New streams default to on-demand capacity,
+  AWS-managed Kinesis encryption, and `RETAIN`; imports reject create-time props so they cannot silently synthesize a
+  replacement stream.
+- `AppTheoryKinesisStreamMapping` wires the stream to the Lambda consumer and grants read permissions. It defaults
+  `reportBatchItemFailures` to `true` so the runtime can fail individual records without replaying successful records.
+- `AppTheoryCloudWatchLogsDestination` creates the CloudWatch Logs destination, service role, and destination policy. It
+  requires `allowedSourceAccounts` and/or `allowedOrganizationIds`; there is no broad default destination policy.
+
+The CloudWatch Logs subscription filter is the source-side attachment that points a log group at
+`destination.destinationArn`. Keep the destination, stream, mapping, and handler on the AppTheory path.
+
+## CDK shape
+
+```ts
+import {
+  AppTheoryCloudWatchLogsDestination,
+  AppTheoryFunction,
+  AppTheoryKinesisStream,
+  AppTheoryKinesisStreamMapping,
+} from "@theory-cloud/apptheory-cdk";
+import { Duration } from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
+
+const sourceAccountId = "111122223333";
+const organizationId = "o-example1234";
+
+const stream = new AppTheoryKinesisStream(this, "LogsStream", {
+  retentionPeriod: Duration.hours(24),
+});
+
+const consumer = new AppTheoryFunction(this, "LogsConsumer", {
+  runtime: lambda.Runtime.PROVIDED_AL2023,
+  handler: "bootstrap",
+  code: lambda.Code.fromAsset("dist/handler"),
+  environment: {
+    APPTHEORY_KINESIS_STREAM_NAME: stream.streamName,
+  },
+});
+
+new AppTheoryKinesisStreamMapping(this, "LogsConsumerMapping", {
+  stream: stream.stream,
+  consumer: consumer.fn,
+  batchSize: 100,
+  maxBatchingWindow: Duration.seconds(5),
+});
+
+const destination = new AppTheoryCloudWatchLogsDestination(this, "LogsDestination", {
+  stream: stream.stream,
+  allowedSourceAccounts: [sourceAccountId],
+  allowedOrganizationIds: [organizationId],
+});
+
+new logs.CfnSubscriptionFilter(this, "SourceSubscription", {
+  logGroupName: "/aws/lambda/source-function",
+  destinationArn: destination.destinationArn,
+  filterPattern: "",
+  distribution: "ByLogStream",
+});
+```
+
+`111122223333`, `o-example1234`, and the log group name above are placeholders. They are examples only, not live account
+claims. Replace them with the trusted source accounts, organization IDs, and log groups for the deployment. A destination
+without an explicit source-account or organization allowlist fails closed.
+
+## Runtime handler shape
+
+The Lambda handler still delegates to the AppTheory runtime:
+
+- Go: `HandleLambda` detects Kinesis and calls `ServeKinesis`.
+- TypeScript: `handleLambda` detects Kinesis and calls `serveKinesisEvent`.
+- Python: `handle_lambda` detects Kinesis and calls `serve_kinesis`.
+
+Register the stream handler by stream name, then decode CloudWatch Logs envelopes per record:
+
+```go
+app.Kinesis(streamName, func(ctx *apptheory.EventContext, record events.KinesisEventRecord) error {
+	decoded, err := apptheory.DecodeCloudWatchLogsSubscription(record)
+	if err != nil {
+		return err
+	}
+
+	for _, event := range decoded.LogEvents {
+		_ = event.Message // domain processing only; do not copy raw messages into safe logs
+	}
+	return nil
+})
+```
+
+If a record fails decoding or processing, the runtime returns that record's `eventID` in `batchItemFailures`. Successful
+records are omitted from the response. `DecodeCloudWatchLogsSubscription` returns `SafeSummary` for logs/metrics/traces;
+raw log messages stay inside the decoded log events for local domain work.
+
+## Producer and testkit helpers
+
+When an AppTheory workload produces Kinesis JSON records, use the runtime helper for deterministic bytes and safe
+summaries:
+
+- Go: `NewKinesisJSONRecord` and `ReportKinesisPutRecordsFailures`
+- TypeScript: `createKinesisJsonRecord` and `reportKinesisPutRecordsFailures`
+- Python: `create_kinesis_json_record` and `report_kinesis_put_records_failures`
+
+Use the testkit helpers for deterministic Kinesis and CloudWatch Logs subscription tests:
+
+- Go: `KinesisEvent`, `KinesisCloudWatchLogsSubscriptionRecord`, `CloudWatchLogsSubscriptionData`
+- TypeScript: `buildKinesisEvent`, `kinesisCloudWatchLogsSubscriptionRecord`, `cloudWatchLogsSubscriptionData`
+- Python: `build_kinesis_event`, `kinesis_cloudwatch_logs_subscription_record`,
+  `cloudwatch_logs_subscription_data`
+
+Canonical example: `examples/cdk/kinesis-cloudwatch-logs`.

--- a/docs/features/event-workloads.md
+++ b/docs/features/event-workloads.md
@@ -5,9 +5,9 @@ AppTheory's non-HTTP Lambda story uses the same single entrypoint as HTTP and Ap
 Streams are detected by event shape and routed through the AppTheory event-source registry. Do not add a second dispatcher
 for "background jobs"; grow the contract and fixtures when workload behavior needs to become portable.
 
-This page documents the event workload contract pinned by the shared `m1` fixtures. Runtime helper APIs and framework-owned
-panic recovery are implemented in follow-up runtime milestones; until those land, the fixtures are the specification and
-runner handlers emulate the future contract shape.
+This page documents the event workload contract pinned by the shared `m1` fixtures. The fixtures remain the
+specification for every event-source behavior. When a helper is part of the public API, use that helper instead of
+copying event-shape or decoding logic into service code.
 
 ## EventBridge workload envelope
 
@@ -59,6 +59,63 @@ Retry and reliability guidance:
 - Configure EventBridge target retry policy, maximum event age, and DLQ through the deployment construct instead of
   branching inside the handler.
 - Use the Lambda remaining-time/deadline fields to stop before timeout and return a structured summary when possible.
+
+## Kinesis workloads and CloudWatch Logs subscriptions
+
+Kinesis uses the same AppTheory Lambda entrypoint as every other trigger. `HandleLambda`, `handleLambda`, and
+`handle_lambda` detect `Records[0].eventSource == "aws:kinesis"` and route to the registered Kinesis stream handler:
+
+- Go: `app.Kinesis(streamName, handler)` and `app.ServeKinesis(ctx, event)`
+- TypeScript: `app.kinesis(streamName, handler)` and `app.serveKinesisEvent(event, ctx)`
+- Python: `app.kinesis(stream_name, handler)` and `app.serve_kinesis(event, ctx)`
+
+Kinesis handlers run per record. If a handler returns an error or throws, the record's `eventID` is returned in
+`batchItemFailures`. Successful records are omitted. An event for an unregistered stream fails closed by returning every
+record ID as a failure, matching Lambda's partial-batch response model.
+
+The AppTheory-owned path for CloudWatch Logs delivered through Kinesis is:
+
+1. A CloudWatch Logs subscription filter targets an `AppTheoryCloudWatchLogsDestination`.
+2. `AppTheoryCloudWatchLogsDestination` delivers records to an `AppTheoryKinesisStream`.
+3. `AppTheoryKinesisStreamMapping` wires the stream to the AppTheory Lambda consumer with partial-batch failures enabled.
+4. The Lambda handler stays on `HandleLambda` / `handleLambda` / `handle_lambda`.
+5. The Kinesis handler decodes each CloudWatch Logs envelope with the runtime decoder before domain processing.
+
+Runtime decoder names:
+
+| Language | Decoder |
+| --- | --- |
+| Go | `DecodeCloudWatchLogsSubscription(record)` |
+| TypeScript | `decodeCloudWatchLogsSubscription(record)` |
+| Python | `decode_cloudwatch_logs_subscription(record)` |
+
+The decoder understands the gzip-compressed CloudWatch Logs subscription envelope carried in the Lambda Kinesis record's
+data field. It returns typed log envelope fields plus `safe_summary`. Raw CloudWatch log messages are available only in
+the decoded `log_events` / `LogEvents` payload for the handler's local domain work; `safe_summary` intentionally contains
+only record/log identity and counts.
+
+Kinesis producer helper names:
+
+| Language | Record helper | Failure report helper |
+| --- | --- | --- |
+| Go | `NewKinesisJSONRecord` | `ReportKinesisPutRecordsFailures` |
+| TypeScript | `createKinesisJsonRecord` | `reportKinesisPutRecordsFailures` |
+| Python | `create_kinesis_json_record` | `report_kinesis_put_records_failures` |
+
+Use these helpers when an AppTheory workload needs deterministic JSON bytes and safe PutRecords-style failure summaries.
+They validate partition keys, canonicalize explicit hash keys, enforce Kinesis record bounds, align failures by
+input/result index, and exclude JSON payload bodies and raw error messages from safe summaries. If a service needs a
+broader producer abstraction, grow the AppTheory helper surface instead of inventing a per-service record or failure
+shape.
+
+Deterministic testkit helpers are available for Kinesis events and CloudWatch Logs subscription records:
+
+- Go: `KinesisEvent`, `KinesisCloudWatchLogsSubscriptionRecord`, and `CloudWatchLogsSubscriptionData`
+- TypeScript: `buildKinesisEvent`, `kinesisCloudWatchLogsSubscriptionRecord`, and `cloudWatchLogsSubscriptionData`
+- Python: `build_kinesis_event`, `kinesis_cloudwatch_logs_subscription_record`, and
+  `cloudwatch_logs_subscription_data`
+
+Canonical example: `examples/cdk/kinesis-cloudwatch-logs`.
 
 ## DynamoDB Streams workloads
 
@@ -128,6 +185,11 @@ Use AppTheory CDK constructs for deployment wiring; do not drop to bespoke raw C
   retries, and maximum event age.
 - `AppTheoryEventBridgeBus`: custom bus plus explicit cross-account publisher allowlist.
 - `AppTheoryDynamoDBStreamMapping`: DynamoDB stream to Lambda event-source mapping.
+- `AppTheoryKinesisStream`: create or wrap the encrypted Kinesis Data Stream for AppTheory event ingestion.
+- `AppTheoryKinesisStreamMapping`: stream-to-Lambda event-source mapping with `reportBatchItemFailures` defaulting to
+  `true`.
+- `AppTheoryCloudWatchLogsDestination`: CloudWatch Logs destination with explicit source account and/or organization
+  allowlists; it does not synthesize a broad default destination policy.
 - `AppTheoryQueue`, `AppTheoryQueueConsumer`, and `AppTheoryQueueProcessor`: SQS queue and worker patterns when a DLQ or
   queue boundary is the correct retry domain.
 - `AppTheoryJobsTable`: job/run ledger storage for long-running workloads that need idempotency, leases, and record-level
@@ -135,3 +197,8 @@ Use AppTheory CDK constructs for deployment wiring; do not drop to bespoke raw C
 
 The CDK constructs provide transport and IAM wiring. The handler still owns domain idempotency and must stay on the
 AppTheory runtime entrypoint so the event workload contract remains fixture-backed across Go, TypeScript, and Python.
+
+For CloudWatch Logs through Kinesis, use the single AppTheory-owned chain documented above. Placeholder account IDs such
+as `111122223333` and organization IDs such as `o-example1234` in examples are examples only; replace them before any
+real deployment. The Logs destination must be explicitly allowlisted and should fail closed when no trusted source is
+configured.


### PR DESCRIPTION
## Summary

- Documents the AppTheory-owned CloudWatch Logs -> CloudWatch Logs destination -> Kinesis stream -> Lambda mapping -> runtime decoder path.
- Adds a canonical `docs/cdk/kinesis-cloudwatch-logs.md` guide and links it from CDK/API docs.
- Updates runtime/API docs and docs metadata with Kinesis runtime, decoder, producer helper, testkit, CDK construct, and canonical example references.

## Validation

- `bash scripts/verify-docs-standard.sh` — PASS
- `git diff --check` — PASS
- `make rubric` — PASS (`Status: PASS`, `Pass: 29`, `Fail: 0`, `Blocked: 0`)
- Additional docs generation/API-doc validation: no separate repo-local docs generation command is required beyond `verify-docs-standard` for this docs-only change.

## Risks

- Docs-only change; no runtime, fixture, CDK implementation, generated binding, example code, or cloud resource changes.
- The guide uses placeholder account/org IDs only and states that Logs destinations must be explicitly allowlisted/fail closed.
- Source-side CloudWatch Logs subscription filters are described only as the attachment to the AppTheory destination; the supported AppTheory path remains the stream, destination, mapping, runtime decoder, producer helpers, and testkit surfaces.

Refs theory-cloud/AppTheory#571
Refs theory-cloud/AppTheory#572
Refs THE-1617
