### PR TITLE
fix(cdk): update AWS CDK baseline for THE-1671

### DIFF
--- a/cdk/.jsii
+++ b/cdk/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "dependencies": {
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "dependencyClosure": {
@@ -520,6 +520,19 @@
             },
             "python": {
               "module": "aws_cdk.aws_autoscalingplans"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_awsexternalanthropic": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AWSExternalAnthropic"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.awsexternalanthropic"
+            },
+            "python": {
+              "module": "aws_cdk.aws_awsexternalanthropic"
             }
           }
         },
@@ -4697,6 +4710,22 @@
             },
             "python": {
               "module": "aws_cdk.interfaces.aws_autoscalingplans"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_awsexternalanthropic": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AWSExternalAnthropic"
+            },
+            "go": {
+              "packageName": "interfacesawsawsexternalanthropic"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.awsexternalanthropic"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_awsexternalanthropic"
             }
           }
         },
@@ -21662,5 +21691,5 @@
     }
   },
   "version": "1.10.0",
-  "fingerprint": "6EnEZiMm6MIv5RYMo87ltora5tPtGWqPjzPysO/L/n4="
+  "fingerprint": "o4ytLELh3GsW+0NTVA16f6RbpN9FVbqsmmjD2lJ+G4U="
 }

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -20,7 +20,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -39,9 +39,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -49,15 +49,15 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -66,7 +66,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -212,8 +212,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -234,30 +234,31 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -24,12 +24,12 @@
     "test": "node --test test/*.test.cjs"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {
     "@types/node": "25.5.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "jsii": "5.9.34",
     "jsii-pacmak": "1.127.0",

--- a/examples/cdk/codebuild-job-runner/package-lock.json
+++ b/examples/cdk/codebuild-job-runner/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -22,12 +22,12 @@
     },
     "../../../cdk": {
       "name": "@theory-cloud/apptheory-cdk",
-      "version": "1.4.1",
+      "version": "1.10.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,36 +268,37 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -306,15 +307,15 @@
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -323,7 +324,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/examples/cdk/codebuild-job-runner/package.json
+++ b/examples/cdk/codebuild-job-runner/package.json
@@ -12,7 +12,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/examples/cdk/import-pipeline/package-lock.json
+++ b/examples/cdk/import-pipeline/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -22,12 +22,12 @@
     },
     "../../../cdk": {
       "name": "@theory-cloud/apptheory-cdk",
-      "version": "1.4.1",
+      "version": "1.10.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,36 +268,37 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -306,15 +307,15 @@
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -323,7 +324,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/examples/cdk/import-pipeline/package.json
+++ b/examples/cdk/import-pipeline/package.json
@@ -11,7 +11,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/examples/cdk/kinesis-cloudwatch-logs/package-lock.json
+++ b/examples/cdk/kinesis-cloudwatch-logs/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -22,12 +22,12 @@
     },
     "../../../cdk": {
       "name": "@theory-cloud/apptheory-cdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,30 +268,71 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {

--- a/examples/cdk/kinesis-cloudwatch-logs/package.json
+++ b/examples/cdk/kinesis-cloudwatch-logs/package.json
@@ -13,7 +13,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/examples/cdk/lambda-role/package.json
+++ b/examples/cdk/lambda-role/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@theory-cloud/apptheory-cdk": "file:../../..",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {

--- a/examples/cdk/lesser-parity/package-lock.json
+++ b/examples/cdk/lesser-parity/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -27,7 +27,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,36 +268,37 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -306,15 +307,15 @@
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -323,7 +324,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/examples/cdk/lesser-parity/package.json
+++ b/examples/cdk/lesser-parity/package.json
@@ -11,7 +11,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/examples/cdk/media-cdn/package.json
+++ b/examples/cdk/media-cdn/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {

--- a/examples/cdk/multilang/package-lock.json
+++ b/examples/cdk/multilang/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -27,7 +27,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,36 +268,37 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -306,15 +307,15 @@
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -323,7 +324,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/examples/cdk/multilang/package.json
+++ b/examples/cdk/multilang/package.json
@@ -11,7 +11,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/examples/cdk/path-routed-frontend/package.json
+++ b/examples/cdk/path-routed-frontend/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {

--- a/examples/cdk/restv1-router/package.json
+++ b/examples/cdk/restv1-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {

--- a/examples/cdk/sqs-queue/package.json
+++ b/examples/cdk/sqs-queue/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@theory-cloud/apptheory-cdk": "file:../../..",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {

--- a/examples/cdk/ssr-only-provided-assets-site/package-lock.json
+++ b/examples/cdk/ssr-only-provided-assets-site/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -27,7 +27,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,36 +268,37 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -306,15 +307,15 @@
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -323,7 +324,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/examples/cdk/ssr-only-provided-assets-site/package.json
+++ b/examples/cdk/ssr-only-provided-assets-site/package.json
@@ -13,7 +13,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/examples/cdk/ssr-site/package-lock.json
+++ b/examples/cdk/ssr-site/package-lock.json
@@ -11,7 +11,7 @@
         "@theory-cloud/apptheory-cdk": "file:../../../cdk",
         "@types/node": "25.5.0",
         "aws-cdk": "2.1113.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -27,7 +27,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "25.5.0",
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
         "jsii": "5.9.34",
         "jsii-pacmak": "1.127.0",
@@ -37,7 +37,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.254.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       }
     },
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -246,8 +246,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -268,36 +268,37 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -306,15 +307,15 @@
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -323,7 +324,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/examples/cdk/ssr-site/package.json
+++ b/examples/cdk/ssr-site/package.json
@@ -11,7 +11,7 @@
     "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "@types/node": "25.5.0",
     "aws-cdk": "2.1113.0",
-    "aws-cdk-lib": "2.254.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -564,7 +564,7 @@ const allowed = {
   packageName: "brace-expansion",
   packageVersion: "5.0.5",
   packagePath: "node_modules/aws-cdk-lib/node_modules/brace-expansion",
-  cdkVersion: "2.254.0",
+  cdkVersion: "2.257.0",
   minimatchVersion: "10.2.5",
 };
 

--- a/scripts/verify-cdk-audit.sh
+++ b/scripts/verify-cdk-audit.sh
@@ -95,7 +95,7 @@ function isAllowedBundledAwsCdkBraceExpansion(vuln) {
     sameStringSet(vuln.nodes, ["node_modules/aws-cdk-lib/node_modules/brace-expansion"]) &&
     sameStringSet(viaUrls, allowedBraceExpansionAdvisories) &&
     sameStringSet(viaRanges, [">=5.0.0 <5.0.6"]) &&
-    cdkPackage?.version === "2.254.0" &&
+    cdkPackage?.version === "2.257.0" &&
     Array.isArray(cdkPackage?.bundleDependencies) &&
     cdkPackage.bundleDependencies.includes("minimatch") &&
     minimatchPackage?.version === "10.2.5" &&


### PR DESCRIPTION
## Summary
- Bump the AppTheory CDK package and CDK examples from `aws-cdk-lib` 2.254.0 to 2.257.0.
- Refresh npm lockfiles and jsii dependency metadata generated by the CDK build.
- Keep audit/OSV gates fail-closed by updating the existing bundled `brace-expansion` exception to the exact aws-cdk-lib 2.257.0 bundle state.

## Validation
- `git diff --check`
- `./scripts/verify-cdk-audit.sh`
- `cd cdk && npm test`
- npm lockfile/package consistency regeneration: `npm --prefix cdk install --ignore-scripts` and per-example `npm --prefix <example> install --package-lock-only --ignore-scripts`
- package consistency check verified all AppTheory CDK/example `aws-cdk-lib` pins, locks, and `.jsii` metadata are 2.257.0

Closes THE-1671.
References theory-cloud/AppTheory#634.