### PR TITLE
fix(ci): pin Pages docs dependencies (THE-1709)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,10 +32,10 @@ on:
   # Defensive `if:` guards still enforce staging-only at the job level.
   workflow_dispatch:
 
+# Default workflow token stays read-only. Pages/id-token privileges are
+# granted only to the deploy job after the docs build artifact exists.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Coalesce in-flight deploys: if a second `staging` push lands before the
 # previous deploy finishes, queue it (don't cancel) so we never skip a
@@ -48,6 +48,12 @@ jobs:
   build:
     name: Build Jekyll site
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BUNDLE_DEPLOYMENT: "true"
+      BUNDLE_FROZEN: "true"
+      BUNDLE_PATH: vendor/bundle
     # Belt-and-suspenders: even if someone invokes workflow_dispatch from
     # a non-staging ref, the job no-ops rather than building stale content.
     if: github.ref == 'refs/heads/staging'
@@ -61,10 +67,6 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
           working-directory: docs
-
-      - name: Configure Pages
-        id: pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Jekyll build
         working-directory: docs
@@ -93,11 +95,19 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     if: github.ref == 'refs/heads/staging'
     environment:
       name: github-pages
       url: https://apptheory.theorycloud.ai/
     steps:
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ docs/.jekyll-cache/
 docs/.jekyll-metadata
 docs/vendor/
 docs/.bundle/
-docs/Gemfile.lock
 
 # GovTheory generated artifacts
 gov-infra/.tools/

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,179 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.35.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-relative-links (0.7.0)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.19.5)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.100.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.100.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  base64 (~> 0.2)
+  csv (~> 3.3)
+  jekyll (~> 4.3)
+  jekyll-include-cache (~> 0.2)
+  jekyll-relative-links (~> 0.7)
+  jekyll-seo-tag (~> 2.8)
+  jekyll-sitemap (~> 1.4)
+  logger (~> 1.6)
+  webrick (~> 1.8)
+
+BUNDLED WITH
+   2.5.22


### PR DESCRIPTION
## Summary
- Commit `docs/Gemfile.lock` and stop ignoring it so Jekyll dependencies are review-pinned.
- Run the Pages docs build with frozen/deployment Bundler settings so Gemfile/lock drift fails before build/deploy.
- Keep workflow/default and build-job permissions read-only, and grant `pages: write` / `id-token: write` only on the deploy job.
- Move `actions/configure-pages` into the deploy job so the build job does not need Pages privileges.

Closes THE-1709

## Validation
- Initial state recorded: repo `/home/aron/ai-workspace/codebases/theory.cloud/AppTheory`, branch `theorymcp/theorycloud/apptheory/fix-pages-custom-domain-css`, HEAD `744359b38754698d650e8d75966f7db2d67698f6`, clean status.
- Created task branch from fetched `origin/staging` at `ef38bfaa864c22f34139cde64c6e5090e2cabd89`; verified `origin/main` is an ancestor of HEAD before PR.
- `git diff --check origin/staging..HEAD`
- `git ls-files --stage docs/Gemfile.lock` -> `100644 fa580a0ef2d3d9927979b8404d49fefb64bd754a 0 docs/Gemfile.lock`
- `git check-ignore -v docs/Gemfile.lock` -> not ignored
- `bundle _2.5.22_ lock --print` diffed cleanly against `docs/Gemfile.lock`
- Frozen lock-drift probe: modified a temp Gemfile copy and confirmed Bundler exits non-zero: `The dependencies in your gemfile changed, but the lockfile can't be updated because frozen mode is set`
- Docker Ruby 3.3 docs build: `bundle _2.5.22_ install` with `BUNDLE_DEPLOYMENT=true`, `BUNDLE_FROZEN=true`, then `bundle exec jekyll build`; built 54 files and custom-domain root-path grep passed.
- Ruby YAML permission assertion: workflow permissions `contents=read`; build permissions `contents=read` with pages/id-token absent; deploy permissions `contents=read`, `pages=write`, `id-token=write`.

## Behavior compatibility
- Triggers are unchanged: `push` to `staging` and manual `workflow_dispatch`; no PR/premain/main triggers added.
- Existing staging-only job guards remain in place.
- Pages deployment still uses the existing protected `github-pages` environment and `https://apptheory.theorycloud.ai/` URL.
- No AppTheory runtime, contract, API snapshot, package, or release-manifest changes.

## Memory / lessons
- AppTheory memory/knowledge tools were not exposed by tool discovery in this session, so no scoped memories were available or appended.

## Risks / blockers
- `actionlint` was not installed locally; workflow permissions were validated with Ruby YAML parsing instead.
- Local host Ruby lacks development headers, so the full native-gem install/build validation was run in Docker with Ruby 3.3.