### PR TITLE
fix(ci): run release gate verifier from trusted code (THE-1726)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,39 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
       - name: Verify release train promotion path
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
+
+          if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "release-train-promotion: FAIL (pull request number is not numeric)"
+            exit 1
+          fi
+
+          pr_head_data_ref="refs/remotes/origin/pr/${PR_NUMBER}/head"
+          git fetch --no-tags origin \
+            "+refs/pull/${PR_NUMBER}/head:${pr_head_data_ref}"
+
+          fetched_head_sha="$(git rev-parse "${pr_head_data_ref}^{commit}")"
+          if [[ "${fetched_head_sha}" != "${PR_HEAD_SHA}" ]]; then
+            echo "release-train-promotion: FAIL (fetched PR head does not match event head)"
+            echo "fetched=${fetched_head_sha}"
+            echo "event=${PR_HEAD_SHA}"
+            exit 1
+          fi
+
           scripts/verify-release-train-promotion.sh \
             --base "${PR_BASE_REF}" \
             --head "${PR_HEAD_REF}" \
-            --head-ref HEAD
+            --base-ref HEAD \
+            --head-ref "${pr_head_data_ref}"
 
   prerelease-readiness:
     name: Prerelease readiness (staging → premain)

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -294,8 +294,33 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
+    "ref: ${{ github.event.pull_request.base.sha }}",
+    "release train promotion verifier must run from trusted base branch code",
+)
+require_not_contains(
+    ".github/workflows/ci.yml",
     "ref: ${{ github.event.pull_request.head.sha }}",
-    "release train promotion verifier must inspect the PR head commit, not the synthetic merge ref",
+    "release train promotion verifier must not execute verifier code from the untrusted PR head",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "refs/pull/${PR_NUMBER}/head:${pr_head_data_ref}",
+    "release train promotion verifier must fetch the PR head only as git data",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    'fetched_head_sha="$(git rev-parse "${pr_head_data_ref}^{commit}")"',
+    "release train promotion verifier must confirm fetched PR data matches the event head SHA",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "--base-ref HEAD",
+    "release train promotion verifier must treat the trusted checkout as the base ref",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    '--head-ref "${pr_head_data_ref}"',
+    "release train promotion verifier must pass the fetched PR head data ref explicitly",
 )
 require_contains(
     ".github/workflows/ci.yml",


### PR DESCRIPTION
## Linear

THE-1726 — [AppTheory] Release gate runs verifier from untrusted PR head

## Summary

- Check out the pull request base SHA before invoking `scripts/verify-release-train-promotion.sh`, so verifier logic comes from trusted base/staging code.
- Fetch the pull request head only as a `refs/pull/<number>/head` data ref, verify that fetched commit matches the event head SHA, and pass it to the verifier through `--head-ref`.
- Update the release workflow verifier to assert the trusted-checkout/data-ref structure and reject reintroducing direct PR-head checkout for verifier execution.

## Validation output

```text
$ bash -n scripts/verify-release-train-promotion.sh && bash -n scripts/verify-release-workflows.sh && echo 'bash -n: PASS'
bash -n: PASS

$ ./scripts/verify-release-train-promotion.sh --self-test
release-train-promotion: self-test PASS

$ bash ./scripts/verify-release-workflows.sh
release-workflows: PASS

$ ./scripts/verify-release-train-promotion.sh --base premain --head feature/release-fix
release-train-promotion: FAIL (invalid release-train PR feature/release-fix → premain; premain only accepts staging → premain prerelease promotions)
exit=1

$ python3 - <<'PY'
# static trusted-data workflow checks
PY
workflow-trusted-data: PASS (trusted checkout uses pull_request.base.sha)
workflow-trusted-data: PASS (untrusted pull_request.head.sha is not checked out)
workflow-trusted-data: PASS (PR head is fetched via refs/pull data ref)
workflow-trusted-data: PASS (fetched PR data SHA is compared to event head SHA)
workflow-trusted-data: PASS (trusted verifier receives base HEAD and fetched head data ref)

$ git diff --check origin/staging...HEAD && echo 'git diff --check origin/staging...HEAD: PASS'
git diff --check origin/staging...HEAD: PASS

$ git merge-base --is-ancestor origin/main HEAD && echo 'origin/main ancestor of HEAD: PASS'
origin/main ancestor of HEAD: PASS

$ make test
[go test packages passed]
version-alignment: PASS (1.12.0)
```

## Notes

The full GitHub Actions pull_request checkout behavior cannot be executed locally, so validation includes the repo-local release workflow verifier plus a static/behavioral check that the workflow runs trusted base code and treats the PR head only as git data.