### PR TITLE
fix(gov): validate rubric report timestamp

### DIFF
--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -28,6 +28,116 @@ REPORT_PATH="${EVIDENCE_DIR}/gov-rubric-report.json"
 # Always run checks from repo root so relative commands are stable.
 cd "${REPO_ROOT}"
 
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  printf '%s' "$s"
+}
+
+is_valid_report_timestamp() {
+  local value="$1"
+
+  [[ "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "${value}" <<'PY'
+from datetime import datetime
+import sys
+
+value = sys.argv[1]
+try:
+    parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+except ValueError:
+    sys.exit(1)
+
+if parsed.strftime("%Y-%m-%dT%H:%M:%SZ") != value:
+    sys.exit(1)
+PY
+    return $?
+  fi
+
+  # The shape check above excludes JSON metacharacter injection. Calendar
+  # validation is applied when python3 is available, which the verifier's
+  # runtime gates require.
+  return 0
+}
+
+read_existing_report_timestamp() {
+  local report_path="$1"
+
+  [[ -f "${report_path}" ]] || return 0
+
+  python3 - "${report_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("timestamp", "")
+except Exception:
+    value = ""
+if isinstance(value, str):
+    print(value)
+PY
+}
+
+select_report_timestamp_value() {
+  local supplied_timestamp="$1"
+  local existing_timestamp="$2"
+  local generated_timestamp="${3:-}"
+
+  if is_valid_report_timestamp "${supplied_timestamp}"; then
+    printf '%s' "${supplied_timestamp}"
+    return 0
+  fi
+
+  if is_valid_report_timestamp "${existing_timestamp}"; then
+    printf '%s' "${existing_timestamp}"
+    return 0
+  fi
+
+  if [[ -z "${generated_timestamp}" ]]; then
+    generated_timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  fi
+  if ! is_valid_report_timestamp "${generated_timestamp}"; then
+    echo "Internal error: generated report timestamp is invalid: ${generated_timestamp}" >&2
+    return 2
+  fi
+  printf '%s' "${generated_timestamp}"
+}
+
+validate_report_json() {
+  local report_path="$1"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "BLOCKED: missing required tool for report JSON validation: python3" >&2
+    return 2
+  fi
+
+  python3 - "${report_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"FAIL: generated rubric report is not valid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+if [[ "${GOV_RUBRIC_TIMESTAMP_HELPER_ONLY:-}" == "1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo "Internal test helper mode is only available when sourced by verifier tests." >&2
+    exit 2
+  fi
+  return 0
+fi
+
 # Optional repo-local tools directory (to enforce pinned tool versions deterministically).
 # Tools are installed here (never system-wide) and put first on PATH.
 GOV_TOOLS_DIR="${GOV_INFRA}/.tools"
@@ -60,20 +170,7 @@ mkdir -p "${EVIDENCE_DIR}"
 
 EXISTING_REPORT_TIMESTAMP=""
 if [[ -f "${REPORT_PATH}" ]]; then
-  EXISTING_REPORT_TIMESTAMP="$({
-    python3 - "${REPORT_PATH}" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-try:
-    value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("timestamp", "")
-except Exception:
-    value = ""
-if isinstance(value, str):
-    print(value)
-PY
-  } 2>/dev/null || true)"
+  EXISTING_REPORT_TIMESTAMP="$(read_existing_report_timestamp "${REPORT_PATH}" 2>/dev/null || true)"
 fi
 
 # Clean previous run outputs to prevent stale evidence from being misattributed.
@@ -89,13 +186,7 @@ rm -f \
 
 # Initialize report structure
 REPORT_SCHEMA_VERSION=1
-REPORT_TIMESTAMP="${GOV_REPORT_TIMESTAMP:-}"
-if [[ -z "${REPORT_TIMESTAMP}" ]]; then
-  REPORT_TIMESTAMP="${EXISTING_REPORT_TIMESTAMP}"
-fi
-if [[ -z "${REPORT_TIMESTAMP}" ]]; then
-  REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-fi
+REPORT_TIMESTAMP="$(select_report_timestamp_value "${GOV_REPORT_TIMESTAMP:-}" "${EXISTING_REPORT_TIMESTAMP}")"
 PASS_COUNT=0
 FAIL_COUNT=0
 BLOCKED_COUNT=0
@@ -105,15 +196,6 @@ declare -a NONPASS_IDS=()
 declare -a NONPASS_STATUSES=()
 declare -a NONPASS_MESSAGES=()
 declare -a NONPASS_EVIDENCE_PATHS=()
-
-json_escape() {
-  local s="$1"
-  s="${s//\\/\\\\}"
-  s="${s//\"/\\\"}"
-  s="${s//$'\n'/\\n}"
-  s="${s//$'\r'/\\r}"
-  printf '%s' "$s"
-}
 
 record_result() {
   local id="$1"
@@ -2495,7 +2577,7 @@ cat > "${REPORT_PATH}" <<EOF
 {
   "\$schema": "https://gov.pai.dev/schemas/gov-rubric-report.schema.json",
   "schemaVersion": ${REPORT_SCHEMA_VERSION},
-  "timestamp": "${REPORT_TIMESTAMP}",
+  "timestamp": "$(json_escape "$REPORT_TIMESTAMP")",
   "pack": {
     "version": "2ba585f48951",
     "digest": "22406dbb1031ebc4dcd83e02912bbc307ab0983629463aa6106b76415e6280af"
@@ -2513,6 +2595,8 @@ cat > "${REPORT_PATH}" <<EOF
   "results": ${RESULTS_JSON}
 }
 EOF
+
+validate_report_json "${REPORT_PATH}"
 
 echo "Report written to: ${REPORT_PATH}"
 echo ""

--- a/gov-infra/verifiers/test-gov-rubric-timestamp.sh
+++ b/gov-infra/verifiers/test-gov-rubric-timestamp.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "BLOCKED: missing required tool for timestamp regression test: python3" >&2
+  exit 2
+fi
+
+# Source only the timestamp/report helpers from the production verifier. The
+# verifier refuses helper-only mode when executed directly, so this cannot be
+# used as a rubric bypass.
+GOV_RUBRIC_TIMESTAMP_HELPER_ONLY=1 source "${SCRIPT_DIR}/gov-verify-rubric.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    fail "${message}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+assert_report_json_has_only_timestamp() {
+  local timestamp="$1"
+  local expected="$2"
+  local rendered
+
+  rendered="{\"timestamp\":\"$(json_escape "${timestamp}")\"}"
+  REPORT_JSON="${rendered}" python3 - "${expected}" <<'PY'
+import json
+import os
+import sys
+
+expected = sys.argv[1]
+doc = json.loads(os.environ["REPORT_JSON"])
+if list(doc.keys()) != ["timestamp"]:
+    raise SystemExit(f"unexpected keys: {list(doc.keys())}")
+if doc["timestamp"] != expected:
+    raise SystemExit(f"timestamp mismatch: {doc['timestamp']!r} != {expected!r}")
+PY
+}
+
+write_report_with_timestamp() {
+  local path="$1"
+  local timestamp="$2"
+
+  REPORT_TIMESTAMP_VALUE="${timestamp}" python3 - "${path}" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    json.dumps({"timestamp": os.environ["REPORT_TIMESTAMP_VALUE"]}),
+    encoding="utf-8",
+)
+PY
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+fallback_timestamp="2026-05-30T00:00:00Z"
+valid_env_timestamp="2026-05-30T12:34:56Z"
+valid_existing_timestamp="2026-05-29T12:34:56Z"
+malicious_timestamp=$'2026-05-30T12:34:56Z",\n  "injected": true,\n  "timestamp": "1999-01-01T00:00:00Z'
+
+if ! is_valid_report_timestamp "${valid_env_timestamp}"; then
+  fail "valid UTC seconds timestamp was rejected"
+fi
+if is_valid_report_timestamp "${malicious_timestamp}"; then
+  fail "malicious timestamp was accepted"
+fi
+if is_valid_report_timestamp "2026-02-30T12:34:56Z"; then
+  fail "invalid calendar timestamp was accepted"
+fi
+if is_valid_report_timestamp "2026-05-30T12:34:56+00:00"; then
+  fail "offset timestamp was accepted"
+fi
+
+selected="$(select_report_timestamp_value "${valid_env_timestamp}" "${malicious_timestamp}" "${fallback_timestamp}")"
+assert_eq "${valid_env_timestamp}" "${selected}" "valid GOV_REPORT_TIMESTAMP should win"
+
+selected="$(select_report_timestamp_value "${malicious_timestamp}" "" "${fallback_timestamp}")"
+assert_eq "${fallback_timestamp}" "${selected}" "malicious GOV_REPORT_TIMESTAMP should fall back"
+assert_report_json_has_only_timestamp "${selected}" "${fallback_timestamp}"
+
+malicious_report="${tmpdir}/malicious-report.json"
+write_report_with_timestamp "${malicious_report}" "${malicious_timestamp}"
+existing_timestamp="$(read_existing_report_timestamp "${malicious_report}")"
+assert_eq "${malicious_timestamp}" "${existing_timestamp}" "existing timestamp fixture read failed"
+selected="$(select_report_timestamp_value "" "${existing_timestamp}" "${fallback_timestamp}")"
+assert_eq "${fallback_timestamp}" "${selected}" "malicious existing report timestamp should fall back"
+assert_report_json_has_only_timestamp "${selected}" "${fallback_timestamp}"
+
+valid_report="${tmpdir}/valid-report.json"
+write_report_with_timestamp "${valid_report}" "${valid_existing_timestamp}"
+existing_timestamp="$(read_existing_report_timestamp "${valid_report}")"
+selected="$(select_report_timestamp_value "" "${existing_timestamp}" "${fallback_timestamp}")"
+assert_eq "${valid_existing_timestamp}" "${selected}" "valid existing report timestamp should be preserved"
+
+corrupt_report="${tmpdir}/corrupt-report.json"
+printf '{"timestamp": "2026-05-30T12:34:56Z",' > "${corrupt_report}"
+existing_timestamp="$(read_existing_report_timestamp "${corrupt_report}" 2>/dev/null || true)"
+assert_eq "" "${existing_timestamp}" "corrupt existing report should not provide a timestamp"
+
+# Defense-in-depth: even a raw malicious value must render as a single JSON
+# string field if it reaches the JSON writer.
+assert_report_json_has_only_timestamp "${malicious_timestamp}" "${malicious_timestamp}"
+
+if ! grep -Fq '  "timestamp": "$(json_escape "$REPORT_TIMESTAMP")",' "${SCRIPT_DIR}/gov-verify-rubric.sh"; then
+  fail "production report writer is not using json_escape for the timestamp"
+fi
+
+echo "gov-rubric timestamp regression: PASS"


### PR DESCRIPTION
## Summary
- Validate `GOV_REPORT_TIMESTAMP` and existing rubric report timestamps against strict UTC ISO-8601 seconds before reuse.
- Fall back to a fresh `date -u` timestamp for invalid sources, escape the selected timestamp in generated evidence JSON, and fail closed if the generated report is not valid JSON.
- Add a focused timestamp regression script covering malicious env timestamps, malicious existing-report timestamps, corrupt existing reports, and valid timestamp preservation.

## Root cause
The rubric verifier selected the report timestamp from env or existing evidence and interpolated it into the JSON report without timestamp validation or JSON escaping.

## Validation
- `bash -n gov-infra/verifiers/gov-verify-rubric.sh`
- `bash -n gov-infra/verifiers/test-gov-rubric-timestamp.sh`
- `bash gov-infra/verifiers/test-gov-rubric-timestamp.sh` — PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (29 pass, 0 fail, 0 blocked)
- `make test` — PASS (`version-alignment: PASS (1.12.0)`)
- `git diff --check origin/staging...HEAD` — PASS

Linear: THE-1765
