### PR TITLE
fix(observability): validate logging profile value types

### DIFF
--- a/py/src/apptheory/logging_profile.py
+++ b/py/src/apptheory/logging_profile.py
@@ -139,6 +139,8 @@ def validate_logging_profile(config: LoggingProfileConfig) -> None:
 
 def logging_profile_validation_errors(config: LoggingProfileConfig) -> list[str]:
     errors: list[str] = []
+    if not isinstance(config, dict):
+        return ["logging profile: must be an object"]
 
     schema = _trim(config.get("schema_version"))
     if not schema:
@@ -152,29 +154,46 @@ def logging_profile_validation_errors(config: LoggingProfileConfig) -> list[str]
     elif not _is_supported_profile(profile):
         errors.append("profile: unsupported value " + _trim(config.get("profile")))
 
-    encoding = config.get("encoding") or {}
-    format_value = _trim(encoding.get("format")).lower()
-    if not format_value:
-        errors.append("encoding.format: required")
-    elif format_value != "json":
-        errors.append("encoding.format: unsupported value " + _trim(encoding.get("format")))
+    encoding_value = config.get("encoding")
+    if encoding_value is None:
+        encoding: dict[str, Any] | None = {}
+    elif isinstance(encoding_value, dict):
+        encoding = encoding_value
+    else:
+        errors.append("encoding: must be an object")
+        encoding = None
+    if encoding is not None:
+        format_value = _trim(encoding.get("format")).lower()
+        if not format_value:
+            errors.append("encoding.format: required")
+        elif format_value != "json":
+            errors.append("encoding.format: unsupported value " + _trim(encoding.get("format")))
 
-    timestamp_format = _trim(encoding.get("timestamp_format")).lower()
-    if timestamp_format and timestamp_format not in {"rfc3339nano", "rfc3339"}:
-        errors.append("encoding.timestamp_format: unsupported value " + _trim(encoding.get("timestamp_format")))
-    errors.extend(_validate_encoding_output_field("encoding.timestamp_field", encoding.get("timestamp_field")))
-    errors.extend(_validate_encoding_output_field("encoding.level_field", encoding.get("level_field")))
-    errors.extend(_validate_encoding_output_field("encoding.message_field", encoding.get("message_field")))
+        timestamp_format = _trim(encoding.get("timestamp_format")).lower()
+        if timestamp_format and timestamp_format not in {"rfc3339nano", "rfc3339"}:
+            errors.append("encoding.timestamp_format: unsupported value " + _trim(encoding.get("timestamp_format")))
+        errors.extend(_validate_encoding_output_field("encoding.timestamp_field", encoding.get("timestamp_field")))
+        errors.extend(_validate_encoding_output_field("encoding.level_field", encoding.get("level_field")))
+        errors.extend(_validate_encoding_output_field("encoding.message_field", encoding.get("message_field")))
 
     errors.extend(_validate_level_map(config.get("levels")))
     errors.extend(_validate_profile_field_list("required_fields", config.get("required_fields")))
     errors.extend(_validate_profile_field_list("recommended_fields", config.get("recommended_fields")))
     errors.extend(_validate_field_map(config.get("field_map")))
-    enrichment = config.get("enrichment") or {}
-    errors.extend(_validate_static_enrichment(enrichment.get("static")))
-    errors.extend(_validate_context_enrichment(enrichment.get("context")))
-    errors.extend(_validate_error_capture(config.get("error_capture") or {}))
-    errors.extend(_validate_alerting_hints(config.get("alerting_hints") or {}))
+    enrichment_value = config.get("enrichment")
+    if enrichment_value is None:
+        enrichment: dict[str, Any] | None = {}
+    elif isinstance(enrichment_value, dict):
+        enrichment = enrichment_value
+    else:
+        errors.append("enrichment: must be an object")
+        enrichment = None
+    if enrichment is not None:
+        errors.extend(_validate_static_enrichment(enrichment.get("static")))
+        errors.extend(_validate_context_enrichment(enrichment.get("context")))
+    errors.extend(_validate_error_capture(config.get("error_capture")))
+    errors.extend(_validate_sanitization(config.get("sanitization")))
+    errors.extend(_validate_alerting_hints(config.get("alerting_hints")))
     return errors
 
 
@@ -880,20 +899,28 @@ def _paytheory_alert_profile() -> LoggingProfileConfig:
     return cfg
 
 
-def _validate_level_map(levels: dict[str, str] | None) -> list[str]:
+def _validate_level_map(levels: object) -> list[str]:
     errors: list[str] = []
-    for key in sorted(levels or {}):
+    if levels is None:
+        return errors
+    if not isinstance(levels, dict):
+        return ["levels: must be an object"]
+    for key in sorted(levels):
         if key not in {"debug", "info", "warn", "error"}:
             errors.append(f"levels.{key}: unsupported level {key}")
             continue
-        if not _trim((levels or {}).get(key)):
+        if not _trim(levels.get(key)):
             errors.append(f"levels.{key}: required")
     return errors
 
 
-def _validate_profile_field_list(path: str, fields: list[str] | None) -> list[str]:
+def _validate_profile_field_list(path: str, fields: object) -> list[str]:
     errors: list[str] = []
-    for idx, field in enumerate(fields or []):
+    if fields is None:
+        return errors
+    if not isinstance(fields, list):
+        return [f"{path}: must be an array"]
+    for idx, field in enumerate(fields):
         trimmed = _trim(field)
         if not trimmed:
             errors.append(f"{path}[{idx}]: required")
@@ -912,13 +939,17 @@ def _validate_encoding_output_field(path: str, field: str | None) -> list[str]:
     return []
 
 
-def _validate_field_map(field_map: dict[str, str] | None) -> list[str]:
+def _validate_field_map(field_map: object) -> list[str]:
     errors: list[str] = []
-    for key in sorted(field_map or {}):
+    if field_map is None:
+        return errors
+    if not isinstance(field_map, dict):
+        return ["field_map: must be an object"]
+    for key in sorted(field_map):
         canonical = _trim(key)
         if not _is_supported_canonical_field(canonical):
             errors.append(f"field_map.{key}: unsupported source {canonical}")
-        out = _trim((field_map or {}).get(key))
+        out = _trim(field_map.get(key))
         if not out:
             errors.append(f"field_map.{key}: required")
         elif not is_supported_profile_output_field(out):
@@ -926,22 +957,30 @@ def _validate_field_map(field_map: dict[str, str] | None) -> list[str]:
     return errors
 
 
-def _validate_static_enrichment(static: dict[str, str] | None) -> list[str]:
+def _validate_static_enrichment(static: object) -> list[str]:
     errors: list[str] = []
-    for key in sorted(static or {}):
+    if static is None:
+        return errors
+    if not isinstance(static, dict):
+        return ["enrichment.static: must be an object"]
+    for key in sorted(static):
         trimmed = _trim(key)
         if not is_supported_profile_output_field(trimmed):
             errors.append(f"enrichment.static.{key}: unsupported field {trimmed}")
     return errors
 
 
-def _validate_context_enrichment(context: dict[str, str] | None) -> list[str]:
+def _validate_context_enrichment(context: object) -> list[str]:
     errors: list[str] = []
-    for key in sorted(context or {}):
+    if context is None:
+        return errors
+    if not isinstance(context, dict):
+        return ["enrichment.context: must be an object"]
+    for key in sorted(context):
         trimmed = _trim(key)
         if not is_supported_profile_output_field(trimmed):
             errors.append(f"enrichment.context.{key}: unsupported field {trimmed}")
-        source = _trim((context or {}).get(key))
+        source = _trim(context.get(key))
         if not source:
             errors.append(f"enrichment.context.{key}: required")
         elif not _is_supported_context_source(source):
@@ -949,8 +988,12 @@ def _validate_context_enrichment(context: dict[str, str] | None) -> list[str]:
     return errors
 
 
-def _validate_error_capture(capture: LoggingProfileErrorCapture) -> list[str]:
+def _validate_error_capture(capture: object) -> list[str]:
     errors: list[str] = []
+    if capture is None:
+        return errors
+    if not isinstance(capture, dict):
+        return ["error_capture: must be an object"]
     stack_trace_field = _trim(capture.get("stack_trace_field"))
     if stack_trace_field and not is_supported_profile_output_field(stack_trace_field):
         errors.append("error_capture.stack_trace_field: unsupported field " + stack_trace_field)
@@ -965,7 +1008,19 @@ def _validate_error_capture(capture: LoggingProfileErrorCapture) -> list[str]:
     return errors
 
 
-def _validate_alerting_hints(hints: LoggingProfileAlertingHints) -> list[str]:
+def _validate_sanitization(sanitization: object) -> list[str]:
+    if sanitization is None:
+        return []
+    if not isinstance(sanitization, dict):
+        return ["sanitization: must be an object"]
+    return []
+
+
+def _validate_alerting_hints(hints: object) -> list[str]:
+    if hints is None:
+        return []
+    if not isinstance(hints, dict):
+        return ["alerting_hints: must be an object"]
     return [
         *_validate_profile_field_list("alerting_hints.fingerprint_fields", hints.get("fingerprint_fields")),
         *_validate_profile_field_list("alerting_hints.keeper_lookup_fields", hints.get("keeper_lookup_fields")),

--- a/py/tests/test_logging_profile.py
+++ b/py/tests/test_logging_profile.py
@@ -136,6 +136,52 @@ class TestLoggingProfile(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "root must be an object"):
             decode_logging_profile_json("[]")
 
+    def test_malformed_composite_json_values_fail_with_validation_errors(self) -> None:
+        cases = [
+            ("encoding", {"encoding": True}, "encoding: must be an object"),
+            ("levels", {"levels": True}, "levels: must be an object"),
+            ("required_fields", {"required_fields": True}, "required_fields: must be an array"),
+            (
+                "recommended_fields",
+                {"recommended_fields": {"field": "trace_id"}},
+                "recommended_fields: must be an array",
+            ),
+            ("field_map", {"field_map": True}, "field_map: must be an object"),
+            ("enrichment", {"enrichment": True}, "enrichment: must be an object"),
+            ("enrichment.static", {"enrichment": {"static": True}}, "enrichment.static: must be an object"),
+            ("enrichment.context", {"enrichment": {"context": True}}, "enrichment.context: must be an object"),
+            ("error_capture", {"error_capture": True}, "error_capture: must be an object"),
+            ("sanitization", {"sanitization": True}, "sanitization: must be an object"),
+            ("alerting_hints", {"alerting_hints": True}, "alerting_hints: must be an object"),
+            (
+                "alerting_hints.fingerprint_fields",
+                {"alerting_hints": {"fingerprint_fields": True}},
+                "alerting_hints.fingerprint_fields: must be an array",
+            ),
+            (
+                "alerting_hints.keeper_lookup_fields",
+                {"alerting_hints": {"keeper_lookup_fields": {}}},
+                "alerting_hints.keeper_lookup_fields: must be an array",
+            ),
+        ]
+        for name, patch, expected in cases:
+            with self.subTest(name=name):
+                cfg = json.loads(json.dumps(default_logging_profile(LOGGING_PROFILE_PAYTHEORY_ALERT_V1)))
+                cfg.update(patch)
+                self.assertIn(expected, logging_profile_validation_errors(cfg))
+                with self.assertRaises(LoggingProfileValidationError) as validate_ctx:
+                    validate_logging_profile(cfg)
+                self.assertIn(expected, validate_ctx.exception.errors)
+                with self.assertRaises(LoggingProfileValidationError) as decode_ctx:
+                    decode_logging_profile_json(json.dumps(cfg))
+                self.assertIn(expected, decode_ctx.exception.errors)
+
+    def test_decode_json_valid_profile_still_passes(self) -> None:
+        cfg = default_logging_profile(LOGGING_PROFILE_PAYTHEORY_ALERT_V1)
+        decoded = decode_logging_profile_json(json.dumps(cfg))
+        validate_logging_profile(decoded)
+        self.assertEqual(decoded["profile"], LOGGING_PROFILE_PAYTHEORY_ALERT_V1)
+
     def test_validation_required_and_nested_field_errors(self) -> None:
         cfg = {
             "schema_version": "",

--- a/ts/dist/logging-profile.js
+++ b/ts/dist/logging-profile.js
@@ -82,6 +82,8 @@ export function validateLoggingProfile(config) {
 }
 export function loggingProfileValidationErrors(config) {
     const errors = [];
+    if (!isRecord(config))
+        return ["logging profile: must be an object"];
     const schema = trimString(config.schema_version);
     if (!schema) {
         errors.push("schema_version: required");
@@ -96,30 +98,37 @@ export function loggingProfileValidationErrors(config) {
     else if (!isSupportedProfile(profile)) {
         errors.push(`profile: unsupported value ${trimString(config.profile)}`);
     }
-    const encoding = config.encoding ?? {};
-    const format = trimString(encoding.format).toLowerCase();
-    if (!format) {
-        errors.push("encoding.format: required");
+    const encodingValue = config.encoding;
+    const encoding = objectOrValidationError(errors, "encoding", encodingValue, {});
+    if (encoding) {
+        const format = trimString(encoding.format).toLowerCase();
+        if (!format) {
+            errors.push("encoding.format: required");
+        }
+        else if (format !== "json") {
+            errors.push(`encoding.format: unsupported value ${trimString(encoding.format)}`);
+        }
+        const timestampFormat = trimString(encoding.timestamp_format).toLowerCase();
+        if (timestampFormat &&
+            timestampFormat !== "rfc3339nano" &&
+            timestampFormat !== "rfc3339") {
+            errors.push(`encoding.timestamp_format: unsupported value ${trimString(encoding.timestamp_format)}`);
+        }
+        errors.push(...validateEncodingOutputField("encoding.timestamp_field", encoding.timestamp_field));
+        errors.push(...validateEncodingOutputField("encoding.level_field", encoding.level_field));
+        errors.push(...validateEncodingOutputField("encoding.message_field", encoding.message_field));
     }
-    else if (format !== "json") {
-        errors.push(`encoding.format: unsupported value ${trimString(encoding.format)}`);
-    }
-    const timestampFormat = trimString(encoding.timestamp_format).toLowerCase();
-    if (timestampFormat &&
-        timestampFormat !== "rfc3339nano" &&
-        timestampFormat !== "rfc3339") {
-        errors.push(`encoding.timestamp_format: unsupported value ${trimString(encoding.timestamp_format)}`);
-    }
-    errors.push(...validateEncodingOutputField("encoding.timestamp_field", encoding.timestamp_field));
-    errors.push(...validateEncodingOutputField("encoding.level_field", encoding.level_field));
-    errors.push(...validateEncodingOutputField("encoding.message_field", encoding.message_field));
     errors.push(...validateLevelMap(config.levels));
     errors.push(...validateProfileFieldList("required_fields", config.required_fields));
     errors.push(...validateProfileFieldList("recommended_fields", config.recommended_fields));
     errors.push(...validateFieldMap(config.field_map));
-    errors.push(...validateStaticEnrichment(config.enrichment?.static));
-    errors.push(...validateContextEnrichment(config.enrichment?.context));
+    const enrichment = objectOrValidationError(errors, "enrichment", config.enrichment, {});
+    if (enrichment) {
+        errors.push(...validateStaticEnrichment(enrichment.static));
+        errors.push(...validateContextEnrichment(enrichment.context));
+    }
     errors.push(...validateErrorCapture(config.error_capture));
+    errors.push(...validateSanitization(config.sanitization));
     errors.push(...validateAlertingHints(config.alerting_hints));
     return errors;
 }
@@ -701,19 +710,27 @@ function payTheoryAlertProfile() {
 }
 function validateLevelMap(levels) {
     const errors = [];
+    if (levels === undefined || levels === null)
+        return errors;
+    if (!isRecord(levels))
+        return ["levels: must be an object"];
     for (const key of sortedKeys(levels)) {
         if (!optionNameSet("debug", "info", "warn", "error").has(key)) {
             errors.push(`levels.${key}: unsupported level ${key}`);
             continue;
         }
-        if (!trimString(levels?.[key]))
+        if (!trimString(levels[key]))
             errors.push(`levels.${key}: required`);
     }
     return errors;
 }
 function validateProfileFieldList(path, fields) {
     const errors = [];
-    for (const [index, field] of (fields ?? []).entries()) {
+    if (fields === undefined || fields === null)
+        return errors;
+    if (!Array.isArray(fields))
+        return [`${path}: must be an array`];
+    for (const [index, field] of fields.entries()) {
         const trimmed = trimString(field);
         if (!trimmed) {
             errors.push(`${path}[${index}]: required`);
@@ -735,12 +752,16 @@ function validateEncodingOutputField(path, field) {
 }
 function validateFieldMap(fieldMap) {
     const errors = [];
+    if (fieldMap === undefined || fieldMap === null)
+        return errors;
+    if (!isRecord(fieldMap))
+        return ["field_map: must be an object"];
     for (const key of sortedKeys(fieldMap)) {
         const canonical = trimString(key);
         if (!isSupportedCanonicalField(canonical)) {
             errors.push(`field_map.${key}: unsupported source ${canonical}`);
         }
-        const out = trimString(fieldMap?.[key]);
+        const out = trimString(fieldMap[key]);
         if (!out) {
             errors.push(`field_map.${key}: required`);
         }
@@ -752,6 +773,10 @@ function validateFieldMap(fieldMap) {
 }
 function validateStaticEnrichment(staticFields) {
     const errors = [];
+    if (staticFields === undefined || staticFields === null)
+        return errors;
+    if (!isRecord(staticFields))
+        return ["enrichment.static: must be an object"];
     for (const key of sortedKeys(staticFields)) {
         const trimmed = trimString(key);
         if (!isSupportedProfileOutputField(trimmed)) {
@@ -762,12 +787,16 @@ function validateStaticEnrichment(staticFields) {
 }
 function validateContextEnrichment(contextFields) {
     const errors = [];
+    if (contextFields === undefined || contextFields === null)
+        return errors;
+    if (!isRecord(contextFields))
+        return ["enrichment.context: must be an object"];
     for (const key of sortedKeys(contextFields)) {
         const trimmed = trimString(key);
         if (!isSupportedProfileOutputField(trimmed)) {
             errors.push(`enrichment.context.${key}: unsupported field ${trimmed}`);
         }
-        const source = trimString(contextFields?.[key]);
+        const source = trimString(contextFields[key]);
         if (!source) {
             errors.push(`enrichment.context.${key}: required`);
         }
@@ -779,24 +808,39 @@ function validateContextEnrichment(contextFields) {
 }
 function validateErrorCapture(capture) {
     const errors = [];
-    const stackTraceField = trimString(capture?.stack_trace_field);
+    if (capture === undefined || capture === null)
+        return errors;
+    if (!isRecord(capture))
+        return ["error_capture: must be an object"];
+    const stackTraceField = trimString(capture["stack_trace_field"]);
     if (stackTraceField && !isSupportedProfileOutputField(stackTraceField)) {
         errors.push(`error_capture.stack_trace_field: unsupported field ${stackTraceField}`);
     }
-    const stackHashField = trimString(capture?.stack_hash_field);
+    const stackHashField = trimString(capture["stack_hash_field"]);
     if (stackHashField && !isSupportedProfileOutputField(stackHashField)) {
         errors.push(`error_capture.stack_hash_field: unsupported field ${stackHashField}`);
     }
-    const algorithm = trimString(capture?.stack_hash_algorithm).toLowerCase();
+    const algorithm = trimString(capture["stack_hash_algorithm"]).toLowerCase();
     if (algorithm && algorithm !== "sha256") {
-        errors.push(`error_capture.stack_hash_algorithm: unsupported value ${trimString(capture?.stack_hash_algorithm)}`);
+        errors.push(`error_capture.stack_hash_algorithm: unsupported value ${trimString(capture["stack_hash_algorithm"])}`);
     }
     return errors;
 }
+function validateSanitization(sanitization) {
+    if (sanitization === undefined || sanitization === null)
+        return [];
+    if (!isRecord(sanitization))
+        return ["sanitization: must be an object"];
+    return [];
+}
 function validateAlertingHints(hints) {
+    if (hints === undefined || hints === null)
+        return [];
+    if (!isRecord(hints))
+        return ["alerting_hints: must be an object"];
     return [
-        ...validateProfileFieldList("alerting_hints.fingerprint_fields", hints?.fingerprint_fields),
-        ...validateProfileFieldList("alerting_hints.keeper_lookup_fields", hints?.keeper_lookup_fields),
+        ...validateProfileFieldList("alerting_hints.fingerprint_fields", hints["fingerprint_fields"]),
+        ...validateProfileFieldList("alerting_hints.keeper_lookup_fields", hints["keeper_lookup_fields"]),
     ];
 }
 export function isSupportedProfileOutputField(field) {
@@ -822,6 +866,14 @@ function sortedKeys(object) {
 }
 function trimString(value) {
     return String(value ?? "").trim();
+}
+function objectOrValidationError(errors, path, value, fallback) {
+    if (value === undefined || value === null)
+        return fallback;
+    if (isRecord(value))
+        return value;
+    errors.push(`${path}: must be an object`);
+    return undefined;
 }
 function isRecord(value) {
     return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/ts/src/logging-profile.ts
+++ b/ts/src/logging-profile.ts
@@ -147,6 +147,8 @@ export function loggingProfileValidationErrors(
   config: LoggingProfileConfig,
 ): string[] {
   const errors: string[] = [];
+  if (!isRecord(config as unknown))
+    return ["logging profile: must be an object"];
 
   const schema = trimString(config.schema_version);
   if (!schema) {
@@ -162,44 +164,52 @@ export function loggingProfileValidationErrors(
     errors.push(`profile: unsupported value ${trimString(config.profile)}`);
   }
 
-  const encoding = config.encoding ?? {};
-  const format = trimString(encoding.format).toLowerCase();
-  if (!format) {
-    errors.push("encoding.format: required");
-  } else if (format !== "json") {
-    errors.push(
-      `encoding.format: unsupported value ${trimString(encoding.format)}`,
-    );
-  }
+  const encodingValue = config.encoding as unknown;
+  const encoding = objectOrValidationError(
+    errors,
+    "encoding",
+    encodingValue,
+    {},
+  ) as LoggingProfileEncoding | undefined;
+  if (encoding) {
+    const format = trimString(encoding.format).toLowerCase();
+    if (!format) {
+      errors.push("encoding.format: required");
+    } else if (format !== "json") {
+      errors.push(
+        `encoding.format: unsupported value ${trimString(encoding.format)}`,
+      );
+    }
 
-  const timestampFormat = trimString(encoding.timestamp_format).toLowerCase();
-  if (
-    timestampFormat &&
-    timestampFormat !== "rfc3339nano" &&
-    timestampFormat !== "rfc3339"
-  ) {
+    const timestampFormat = trimString(encoding.timestamp_format).toLowerCase();
+    if (
+      timestampFormat &&
+      timestampFormat !== "rfc3339nano" &&
+      timestampFormat !== "rfc3339"
+    ) {
+      errors.push(
+        `encoding.timestamp_format: unsupported value ${trimString(encoding.timestamp_format)}`,
+      );
+    }
     errors.push(
-      `encoding.timestamp_format: unsupported value ${trimString(encoding.timestamp_format)}`,
+      ...validateEncodingOutputField(
+        "encoding.timestamp_field",
+        encoding.timestamp_field,
+      ),
+    );
+    errors.push(
+      ...validateEncodingOutputField(
+        "encoding.level_field",
+        encoding.level_field,
+      ),
+    );
+    errors.push(
+      ...validateEncodingOutputField(
+        "encoding.message_field",
+        encoding.message_field,
+      ),
     );
   }
-  errors.push(
-    ...validateEncodingOutputField(
-      "encoding.timestamp_field",
-      encoding.timestamp_field,
-    ),
-  );
-  errors.push(
-    ...validateEncodingOutputField(
-      "encoding.level_field",
-      encoding.level_field,
-    ),
-  );
-  errors.push(
-    ...validateEncodingOutputField(
-      "encoding.message_field",
-      encoding.message_field,
-    ),
-  );
 
   errors.push(...validateLevelMap(config.levels));
   errors.push(
@@ -212,9 +222,18 @@ export function loggingProfileValidationErrors(
     ),
   );
   errors.push(...validateFieldMap(config.field_map));
-  errors.push(...validateStaticEnrichment(config.enrichment?.static));
-  errors.push(...validateContextEnrichment(config.enrichment?.context));
+  const enrichment = objectOrValidationError(
+    errors,
+    "enrichment",
+    config.enrichment as unknown,
+    {},
+  ) as LoggingProfileEnrichment | undefined;
+  if (enrichment) {
+    errors.push(...validateStaticEnrichment(enrichment.static));
+    errors.push(...validateContextEnrichment(enrichment.context));
+  }
   errors.push(...validateErrorCapture(config.error_capture));
+  errors.push(...validateSanitization(config.sanitization));
   errors.push(...validateAlertingHints(config.alerting_hints));
 
   return errors;
@@ -1060,26 +1079,25 @@ function payTheoryAlertProfile(): LoggingProfileConfig {
   return cfg;
 }
 
-function validateLevelMap(
-  levels: Record<string, string> | undefined,
-): string[] {
+function validateLevelMap(levels: unknown): string[] {
   const errors: string[] = [];
+  if (levels === undefined || levels === null) return errors;
+  if (!isRecord(levels)) return ["levels: must be an object"];
   for (const key of sortedKeys(levels)) {
     if (!optionNameSet("debug", "info", "warn", "error").has(key)) {
       errors.push(`levels.${key}: unsupported level ${key}`);
       continue;
     }
-    if (!trimString(levels?.[key])) errors.push(`levels.${key}: required`);
+    if (!trimString(levels[key])) errors.push(`levels.${key}: required`);
   }
   return errors;
 }
 
-function validateProfileFieldList(
-  path: string,
-  fields: string[] | undefined,
-): string[] {
+function validateProfileFieldList(path: string, fields: unknown): string[] {
   const errors: string[] = [];
-  for (const [index, field] of (fields ?? []).entries()) {
+  if (fields === undefined || fields === null) return errors;
+  if (!Array.isArray(fields)) return [`${path}: must be an array`];
+  for (const [index, field] of fields.entries()) {
     const trimmed = trimString(field);
     if (!trimmed) {
       errors.push(`${path}[${index}]: required`);
@@ -1103,16 +1121,16 @@ function validateEncodingOutputField(
   return [];
 }
 
-function validateFieldMap(
-  fieldMap: Record<string, string> | undefined,
-): string[] {
+function validateFieldMap(fieldMap: unknown): string[] {
   const errors: string[] = [];
+  if (fieldMap === undefined || fieldMap === null) return errors;
+  if (!isRecord(fieldMap)) return ["field_map: must be an object"];
   for (const key of sortedKeys(fieldMap)) {
     const canonical = trimString(key);
     if (!isSupportedCanonicalField(canonical)) {
       errors.push(`field_map.${key}: unsupported source ${canonical}`);
     }
-    const out = trimString(fieldMap?.[key]);
+    const out = trimString(fieldMap[key]);
     if (!out) {
       errors.push(`field_map.${key}: required`);
     } else if (!isSupportedProfileOutputField(out)) {
@@ -1122,10 +1140,10 @@ function validateFieldMap(
   return errors;
 }
 
-function validateStaticEnrichment(
-  staticFields: Record<string, string> | undefined,
-): string[] {
+function validateStaticEnrichment(staticFields: unknown): string[] {
   const errors: string[] = [];
+  if (staticFields === undefined || staticFields === null) return errors;
+  if (!isRecord(staticFields)) return ["enrichment.static: must be an object"];
   for (const key of sortedKeys(staticFields)) {
     const trimmed = trimString(key);
     if (!isSupportedProfileOutputField(trimmed)) {
@@ -1135,16 +1153,17 @@ function validateStaticEnrichment(
   return errors;
 }
 
-function validateContextEnrichment(
-  contextFields: Record<string, string> | undefined,
-): string[] {
+function validateContextEnrichment(contextFields: unknown): string[] {
   const errors: string[] = [];
+  if (contextFields === undefined || contextFields === null) return errors;
+  if (!isRecord(contextFields))
+    return ["enrichment.context: must be an object"];
   for (const key of sortedKeys(contextFields)) {
     const trimmed = trimString(key);
     if (!isSupportedProfileOutputField(trimmed)) {
       errors.push(`enrichment.context.${key}: unsupported field ${trimmed}`);
     }
-    const source = trimString(contextFields?.[key]);
+    const source = trimString(contextFields[key]);
     if (!source) {
       errors.push(`enrichment.context.${key}: required`);
     } else if (!isSupportedContextSource(source)) {
@@ -1154,42 +1173,48 @@ function validateContextEnrichment(
   return errors;
 }
 
-function validateErrorCapture(
-  capture: LoggingProfileErrorCapture | undefined,
-): string[] {
+function validateErrorCapture(capture: unknown): string[] {
   const errors: string[] = [];
-  const stackTraceField = trimString(capture?.stack_trace_field);
+  if (capture === undefined || capture === null) return errors;
+  if (!isRecord(capture)) return ["error_capture: must be an object"];
+  const stackTraceField = trimString(capture["stack_trace_field"]);
   if (stackTraceField && !isSupportedProfileOutputField(stackTraceField)) {
     errors.push(
       `error_capture.stack_trace_field: unsupported field ${stackTraceField}`,
     );
   }
-  const stackHashField = trimString(capture?.stack_hash_field);
+  const stackHashField = trimString(capture["stack_hash_field"]);
   if (stackHashField && !isSupportedProfileOutputField(stackHashField)) {
     errors.push(
       `error_capture.stack_hash_field: unsupported field ${stackHashField}`,
     );
   }
-  const algorithm = trimString(capture?.stack_hash_algorithm).toLowerCase();
+  const algorithm = trimString(capture["stack_hash_algorithm"]).toLowerCase();
   if (algorithm && algorithm !== "sha256") {
     errors.push(
-      `error_capture.stack_hash_algorithm: unsupported value ${trimString(capture?.stack_hash_algorithm)}`,
+      `error_capture.stack_hash_algorithm: unsupported value ${trimString(capture["stack_hash_algorithm"])}`,
     );
   }
   return errors;
 }
 
-function validateAlertingHints(
-  hints: LoggingProfileAlertingHints | undefined,
-): string[] {
+function validateSanitization(sanitization: unknown): string[] {
+  if (sanitization === undefined || sanitization === null) return [];
+  if (!isRecord(sanitization)) return ["sanitization: must be an object"];
+  return [];
+}
+
+function validateAlertingHints(hints: unknown): string[] {
+  if (hints === undefined || hints === null) return [];
+  if (!isRecord(hints)) return ["alerting_hints: must be an object"];
   return [
     ...validateProfileFieldList(
       "alerting_hints.fingerprint_fields",
-      hints?.fingerprint_fields,
+      hints["fingerprint_fields"],
     ),
     ...validateProfileFieldList(
       "alerting_hints.keeper_lookup_fields",
-      hints?.keeper_lookup_fields,
+      hints["keeper_lookup_fields"],
     ),
   ];
 }
@@ -1299,6 +1324,18 @@ function sortedKeys(object: Record<string, unknown> | undefined): string[] {
 
 function trimString(value: unknown): string {
   return String(value ?? "").trim();
+}
+
+function objectOrValidationError(
+  errors: string[],
+  path: string,
+  value: unknown,
+  fallback: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return fallback;
+  if (isRecord(value)) return value;
+  errors.push(`${path}: must be an object`);
+  return undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/ts/test/logging-profile.test.mjs
+++ b/ts/test/logging-profile.test.mjs
@@ -51,6 +51,7 @@ test("logging profile catalog and default variants", () => {
   const legacy = defaultLoggingProfile(LOGGING_PROFILE_LEGACY);
   const local = defaultLoggingProfile(LOGGING_PROFILE_LOCAL_DEV);
   for (const cfg of [paytheory, cloudwatch, legacy, local]) validateLoggingProfile(cfg);
+  validateLoggingProfile(decodeLoggingProfileJSON(JSON.stringify(paytheory)));
   assert.equal(paytheory.encoding.timestamp_field, "ts");
   assert.deepEqual(cloudwatch.required_fields, ["timestamp", "level", "message"]);
   assert.equal(legacy.encoding.level_field, "level");
@@ -118,6 +119,52 @@ test("logging profile validation fails closed deterministically", () => {
       error.errors.includes("encoding.unknown_encoding_option: unsupported option") &&
       error.errors.includes("unknown_top_level: unsupported option"),
   );
+});
+
+test("logging profile malformed composite values fail with validation errors", () => {
+  const cases = [
+    ["encoding", { encoding: true }, "encoding: must be an object"],
+    ["levels", { levels: true }, "levels: must be an object"],
+    ["required_fields", { required_fields: true }, "required_fields: must be an array"],
+    [
+      "recommended_fields",
+      { recommended_fields: { field: "trace_id" } },
+      "recommended_fields: must be an array",
+    ],
+    ["field_map", { field_map: true }, "field_map: must be an object"],
+    ["enrichment", { enrichment: true }, "enrichment: must be an object"],
+    ["enrichment.static", { enrichment: { static: true } }, "enrichment.static: must be an object"],
+    ["enrichment.context", { enrichment: { context: true } }, "enrichment.context: must be an object"],
+    ["error_capture", { error_capture: true }, "error_capture: must be an object"],
+    ["sanitization", { sanitization: true }, "sanitization: must be an object"],
+    ["alerting_hints", { alerting_hints: true }, "alerting_hints: must be an object"],
+    [
+      "alerting_hints.fingerprint_fields",
+      { alerting_hints: { fingerprint_fields: true } },
+      "alerting_hints.fingerprint_fields: must be an array",
+    ],
+    [
+      "alerting_hints.keeper_lookup_fields",
+      { alerting_hints: { keeper_lookup_fields: {} } },
+      "alerting_hints.keeper_lookup_fields: must be an array",
+    ],
+  ];
+
+  for (const [name, patch, expected] of cases) {
+    const cfg = {
+      ...JSON.parse(JSON.stringify(defaultLoggingProfile(LOGGING_PROFILE_PAYTHEORY_ALERT_V1))),
+      ...patch,
+    };
+    assert.ok(loggingProfileValidationErrors(cfg).includes(expected), name);
+    assert.throws(
+      () => validateLoggingProfile(cfg),
+      (error) => error instanceof LoggingProfileValidationError && error.errors.includes(expected),
+    );
+    assert.throws(
+      () => decodeLoggingProfileJSON(JSON.stringify(cfg)),
+      (error) => error instanceof LoggingProfileValidationError && error.errors.includes(expected),
+    );
+  }
 });
 
 test("logging profile encoder emits paytheory alert shape", () => {


### PR DESCRIPTION
## Summary
- Harden Python logging profile validation so malformed composite/list values return `LoggingProfileValidationError` entries instead of `AttributeError`/`TypeError` crashes.
- Harden TypeScript logging profile validation so malformed list/composite values return structured `LoggingProfileValidationError` entries instead of `.entries()`/type crashes.
- Add focused Python and TypeScript tests for malformed composite/list fields and representative valid decoded profiles.

## Validation
- `python3 py/tests/test_logging_profile.py` — PASS (17 tests)
- `tmp_dir="$(mktemp -d)"; trap 'rm -rf "$tmp_dir"' EXIT; cp -a ts "$tmp_dir/ts"; (cd "$tmp_dir/ts" && npm run build >/tmp/apptheory-ts-logging-build.log && node --test test/logging-profile.test.mjs)` — PASS (7 tests)
- `(cd ts && npm run check)` — PASS
- `./scripts/verify-python-lint.sh` — PASS
- `make test` — PASS, including `version-alignment: PASS (1.12.0)`
- `git diff --check origin/staging...HEAD` — PASS
- `git merge-base --is-ancestor origin/main HEAD` — PASS

Linear: THE-1761
