### PR TITLE
fix(runtime): sanitize kinesis safe_log values (THE-1748)

### DIFF
--- a/py/src/apptheory/_safe_log.py
+++ b/py/src/apptheory/_safe_log.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import unicodedata
+
+
+def log_safe_value(value: object) -> str:
+    raw = "" if value is None else str(value)
+    if not raw:
+        return raw
+
+    out: list[str] = []
+    for char in raw:
+        if not _is_unsafe_log_value_char(char):
+            out.append(char)
+            continue
+        out.extend(f"%{byte:02X}" for byte in char.encode("utf-8", errors="replace"))
+    return "".join(out)
+
+
+def _is_unsafe_log_value_char(char: str) -> bool:
+    return char in {"%", "="} or char.isspace() or unicodedata.category(char) == "Cc"

--- a/py/src/apptheory/kinesis_cloudwatch_logs.py
+++ b/py/src/apptheory/kinesis_cloudwatch_logs.py
@@ -10,6 +10,8 @@ import json
 import math
 from typing import Any
 
+from apptheory._safe_log import log_safe_value
+
 CloudWatchLogsSubscription = dict[str, Any]
 CloudWatchLogsSubscriptionLogEvent = dict[str, Any]
 CloudWatchLogsSubscriptionSummary = dict[str, Any]
@@ -113,9 +115,10 @@ def _cloudwatch_logs_subscription_safe_summary(decoded: dict[str, Any]) -> Cloud
     subscription_filter_count = len(decoded.get("subscription_filters") or [])
     log_event_count = len(decoded.get("log_events") or [])
     safe_log = (
-        f"record_id={decoded.get('record_id')} owner={decoded.get('owner')} "
-        f"log_group={decoded.get('log_group')} log_stream={decoded.get('log_stream')} "
-        f"message_type={decoded.get('message_type')} log_events={log_event_count} "
+        f"record_id={log_safe_value(decoded.get('record_id'))} owner={log_safe_value(decoded.get('owner'))} "
+        f"log_group={log_safe_value(decoded.get('log_group'))} "
+        f"log_stream={log_safe_value(decoded.get('log_stream'))} "
+        f"message_type={log_safe_value(decoded.get('message_type'))} log_events={log_event_count} "
         f"subscription_filters={subscription_filter_count}"
     )
     return {

--- a/py/src/apptheory/kinesis_producer.py
+++ b/py/src/apptheory/kinesis_producer.py
@@ -6,6 +6,8 @@ import json
 import math
 from typing import Any
 
+from apptheory._safe_log import log_safe_value
+
 KinesisJsonRecord = dict[str, Any]
 KinesisJsonRecordSummary = dict[str, Any]
 KinesisPutRecordsFailure = dict[str, Any]
@@ -189,15 +191,17 @@ def _kinesis_json_record_safe_summary(
     data_byte_length: int,
     explicit_hash_key: str,
 ) -> KinesisJsonRecordSummary:
+    safe_partition_key = log_safe_value(partition_key)
     summary: KinesisJsonRecordSummary = {
         "partition_key": partition_key,
         "data_byte_length": data_byte_length,
-        "safe_log": f"partition_key={partition_key} data_bytes={data_byte_length}",
+        "safe_log": f"partition_key={safe_partition_key} data_bytes={data_byte_length}",
     }
     if explicit_hash_key:
         summary["explicit_hash_key"] = explicit_hash_key
         summary["safe_log"] = (
-            f"partition_key={partition_key} explicit_hash_key={explicit_hash_key} data_bytes={data_byte_length}"
+            f"partition_key={safe_partition_key} explicit_hash_key={log_safe_value(explicit_hash_key)} "
+            f"data_bytes={data_byte_length}"
         )
     return summary
 
@@ -273,14 +277,18 @@ def _kinesis_put_records_failure(
 def _kinesis_put_records_failure_safe_log(failure: KinesisPutRecordsFailure) -> str:
     if failure.get("explicit_hash_key"):
         return (
-            f"kinesis_put_records_failure index={failure['index']} partition_key={failure['partition_key']} "
-            f"explicit_hash_key={failure['explicit_hash_key']} data_bytes={failure['data_byte_length']} "
-            f"error_code={failure['error_code']} error_message_present={failure['error_message_present']} "
+            f"kinesis_put_records_failure index={failure['index']} "
+            f"partition_key={log_safe_value(failure['partition_key'])} "
+            f"explicit_hash_key={log_safe_value(failure['explicit_hash_key'])} "
+            f"data_bytes={failure['data_byte_length']} "
+            f"error_code={log_safe_value(failure['error_code'])} "
+            f"error_message_present={failure['error_message_present']} "
             f"error_message_bytes={failure['error_message_byte_length']}"
         )
     return (
-        f"kinesis_put_records_failure index={failure['index']} partition_key={failure['partition_key']} "
-        f"data_bytes={failure['data_byte_length']} error_code={failure['error_code']} "
+        f"kinesis_put_records_failure index={failure['index']} "
+        f"partition_key={log_safe_value(failure['partition_key'])} "
+        f"data_bytes={failure['data_byte_length']} error_code={log_safe_value(failure['error_code'])} "
         f"error_message_present={failure['error_message_present']} "
         f"error_message_bytes={failure['error_message_byte_length']}"
     )

--- a/py/tests/test_kinesis_cloudwatch_logs.py
+++ b/py/tests/test_kinesis_cloudwatch_logs.py
@@ -85,6 +85,51 @@ class CloudWatchLogsSubscriptionTests(unittest.TestCase):
         self.assertNotIn(raw_message, safe_summary_json)
         self.assertNotIn("contract log line beta", safe_summary_json)
 
+    def test_decode_cloudwatch_logs_subscription_sanitizes_metadata_in_safe_log(self) -> None:
+        raw_message = "raw log line must stay out owner=customer-secret"
+        payload = gzip.compress(
+            json.dumps(
+                {
+                    "messageType": "DATA_MESSAGE\rmessage_type=FORGED",
+                    "owner": "111122223333\nlog_events=999",
+                    "logGroup": "/aws/lambda/apptheory-contract owner=spoof",
+                    "logStream": "2026/05/26/[$LATEST]contract-a\tcontrol=\x1fafter",
+                    "subscriptionFilters": ["apptheory-contract-filter"],
+                    "logEvents": [{"id": "cwl-event-a1", "timestamp": 1779806400000, "message": raw_message}],
+                }
+            ).encode("utf-8"),
+            mtime=0,
+        )
+
+        decoded = decode_cloudwatch_logs_subscription(
+            {"eventID": "kin-cwl\nowner=spoof", "kinesis": {"data": base64.b64encode(payload).decode("ascii")}}
+        )
+
+        self.assertEqual(decoded["record_id"], "kin-cwl\nowner=spoof")
+        self.assertEqual(decoded["owner"], "111122223333\nlog_events=999")
+
+        safe_log = decoded["safe_summary"]["safe_log"]
+        for forbidden in [
+            "\n",
+            "\r",
+            "\t",
+            "\x1f",
+            "owner=spoof",
+            "log_events=999",
+            "message_type=FORGED",
+            raw_message,
+        ]:
+            self.assertNotIn(forbidden, safe_log)
+        for wanted in [
+            "record_id=kin-cwl%0Aowner%3Dspoof",
+            "owner=111122223333%0Alog_events%3D999",
+            "log_group=/aws/lambda/apptheory-contract%20owner%3Dspoof",
+            "log_stream=2026/05/26/[$LATEST]contract-a%09control%3D%1Fafter",
+            "message_type=DATA_MESSAGE%0Dmessage_type%3DFORGED",
+            "log_events=1",
+        ]:
+            self.assertIn(wanted, safe_log)
+
     def test_decode_failures_do_not_leak_raw_payload_data(self) -> None:
         raw_log_message = "do-not-log-customer-message"
         with self.assertRaisesRegex(RuntimeError, "invalid payload") as gzip_error:

--- a/py/tests/test_kinesis_producer.py
+++ b/py/tests/test_kinesis_producer.py
@@ -30,6 +30,17 @@ class KinesisProducerTests(unittest.TestCase):
             self.assertNotIn(forbidden, summary_json)
             self.assertNotIn(forbidden, record["safe_summary"]["safe_log"])
 
+    def test_create_kinesis_json_record_sanitizes_unsafe_partition_key_in_safe_log(self) -> None:
+        partition_key = "tenant\nforged=true\rcontrol=\x1f key=value\tpercent%"
+        record = create_kinesis_json_record(partition_key=partition_key, payload={"ok": True})
+
+        self.assertEqual(record["partition_key"], partition_key)
+        self._assert_safe_log_cannot_forge_fields(record["safe_summary"]["safe_log"])
+        self.assertIn(
+            "partition_key=tenant%0Aforged%3Dtrue%0Dcontrol%3D%1F%20key%3Dvalue%09percent%25",
+            record["safe_summary"]["safe_log"],
+        )
+
     def test_create_kinesis_json_record_fails_closed_for_invalid_inputs(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "partition key is required"):
             create_kinesis_json_record(partition_key="", payload={"ok": True})
@@ -76,6 +87,23 @@ class KinesisProducerTests(unittest.TestCase):
             self.assertNotIn(forbidden, report_json)
         self.assertIn("failed_record_count=1", report["safe_summary"]["safe_log"])
 
+    def test_report_kinesis_put_records_failures_sanitizes_partition_key_in_failure_safe_log(self) -> None:
+        record = create_kinesis_json_record(
+            partition_key="tenant\nerror_code=ForgedException key=value",
+            payload={"ok": True},
+        )
+
+        report = report_kinesis_put_records_failures(
+            [record],
+            [{"error_code": "ProvisionedThroughputExceededException"}],
+        )
+
+        self.assertEqual(len(report["failures"]), 1)
+        safe_log = report["failures"][0]["safe_log"]
+        self._assert_safe_log_cannot_forge_fields(safe_log)
+        self.assertNotIn("error_code=ForgedException", safe_log)
+        self.assertIn("%0Aerror_code%3D", safe_log)
+
     def test_report_kinesis_put_records_failures_fails_closed_for_shape_drift(self) -> None:
         record = create_kinesis_json_record(partition_key="pk-1", payload={"ok": True})
 
@@ -83,6 +111,10 @@ class KinesisProducerTests(unittest.TestCase):
             report_kinesis_put_records_failures([record], [])
         with self.assertRaisesRegex(RuntimeError, "error message without error code"):
             report_kinesis_put_records_failures([record], [{"error_message": "message without code"}])
+
+    def _assert_safe_log_cannot_forge_fields(self, safe_log: str) -> None:
+        for forbidden in ["\n", "\r", "\t", "\x1f", " forged=", " key=value"]:
+            self.assertNotIn(forbidden, safe_log)
 
 
 if __name__ == "__main__":

--- a/runtime/kinesis_cloudwatch_logs.go
+++ b/runtime/kinesis_cloudwatch_logs.go
@@ -178,11 +178,11 @@ func cloudWatchLogsSubscriptionSafeSummary(decoded CloudWatchLogsSubscription) C
 	logEventCount := len(decoded.LogEvents)
 	safeLog := fmt.Sprintf(
 		"record_id=%s owner=%s log_group=%s log_stream=%s message_type=%s log_events=%d subscription_filters=%d",
-		decoded.RecordID,
-		decoded.Owner,
-		decoded.LogGroup,
-		decoded.LogStream,
-		decoded.MessageType,
+		logSafeValue(decoded.RecordID),
+		logSafeValue(decoded.Owner),
+		logSafeValue(decoded.LogGroup),
+		logSafeValue(decoded.LogStream),
+		logSafeValue(decoded.MessageType),
 		logEventCount,
 		filterCount,
 	)

--- a/runtime/kinesis_cloudwatch_logs_test.go
+++ b/runtime/kinesis_cloudwatch_logs_test.go
@@ -64,6 +64,61 @@ func TestDecodeCloudWatchLogsSubscription_DecodesEnvelopeAndSafeSummary(t *testi
 	}
 }
 
+func TestDecodeCloudWatchLogsSubscription_SanitizesMetadataInSafeLog(t *testing.T) {
+	t.Parallel()
+
+	rawMessage := "raw log line must stay out owner=customer-secret"
+	record := events.KinesisEventRecord{
+		EventID: "kin-cwl\nowner=spoof",
+		Kinesis: events.KinesisRecord{Data: gzipCloudWatchLogsSubscriptionTestPayload(t, map[string]any{
+			"messageType":         "DATA_MESSAGE\rmessage_type=FORGED",
+			"owner":               "111122223333\nlog_events=999",
+			"logGroup":            "/aws/lambda/apptheory-contract owner=spoof",
+			"logStream":           "2026/05/26/[$LATEST]contract-a\tcontrol=\x1fafter",
+			"subscriptionFilters": []string{"apptheory-contract-filter"},
+			"logEvents": []map[string]any{
+				{"id": "cwl-event-a1", "timestamp": int64(1779806400000), "message": rawMessage},
+			},
+		})},
+	}
+
+	decoded, err := DecodeCloudWatchLogsSubscription(record)
+	if err != nil {
+		t.Fatalf("DecodeCloudWatchLogsSubscription returned error: %v", err)
+	}
+	if decoded.RecordID != "kin-cwl\nowner=spoof" || decoded.Owner != "111122223333\nlog_events=999" {
+		t.Fatalf("decoded metadata should remain API-compatible: %#v", decoded)
+	}
+
+	safeLog := decoded.SafeSummary.SafeLog
+	for _, forbidden := range []string{
+		"\n",
+		"\r",
+		"\t",
+		"\x1f",
+		"owner=spoof",
+		"log_events=999",
+		"message_type=FORGED",
+		rawMessage,
+	} {
+		if strings.Contains(safeLog, forbidden) {
+			t.Fatalf("safe log permits forged metadata %q: %q", forbidden, safeLog)
+		}
+	}
+	for _, want := range []string{
+		"record_id=kin-cwl%0Aowner%3Dspoof",
+		"owner=111122223333%0Alog_events%3D999",
+		"log_group=/aws/lambda/apptheory-contract%20owner%3Dspoof",
+		"log_stream=2026/05/26/[$LATEST]contract-a%09control%3D%1Fafter",
+		"message_type=DATA_MESSAGE%0Dmessage_type%3DFORGED",
+		"log_events=1",
+	} {
+		if !strings.Contains(safeLog, want) {
+			t.Fatalf("safe log missing sanitized metadata %q: %q", want, safeLog)
+		}
+	}
+}
+
 func TestDecodeCloudWatchLogsSubscription_FailsClosedWithoutLeakingRawData(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/kinesis_producer.go
+++ b/runtime/kinesis_producer.go
@@ -218,9 +218,15 @@ func normalizeKinesisExplicitHashKey(value string) (string, error) {
 
 func kinesisJSONRecordSafeSummary(record KinesisJSONRecord) KinesisJSONRecordSummary {
 	dataByteLength := len(record.Data)
-	safeLog := fmt.Sprintf("partition_key=%s data_bytes=%d", record.PartitionKey, dataByteLength)
+	safePartitionKey := logSafeValue(record.PartitionKey)
+	safeLog := fmt.Sprintf("partition_key=%s data_bytes=%d", safePartitionKey, dataByteLength)
 	if record.ExplicitHashKey != "" {
-		safeLog = fmt.Sprintf("partition_key=%s explicit_hash_key=%s data_bytes=%d", record.PartitionKey, record.ExplicitHashKey, dataByteLength)
+		safeLog = fmt.Sprintf(
+			"partition_key=%s explicit_hash_key=%s data_bytes=%d",
+			safePartitionKey,
+			logSafeValue(record.ExplicitHashKey),
+			dataByteLength,
+		)
 	}
 	return KinesisJSONRecordSummary{
 		PartitionKey:    record.PartitionKey,
@@ -304,9 +310,9 @@ func kinesisPutRecordsFailureSafeLog(failure KinesisPutRecordsFailure) string {
 	base := fmt.Sprintf(
 		"kinesis_put_records_failure index=%d partition_key=%s data_bytes=%d error_code=%s error_message_present=%t error_message_bytes=%d",
 		failure.Index,
-		failure.PartitionKey,
+		logSafeValue(failure.PartitionKey),
 		failure.DataByteLength,
-		failure.ErrorCode,
+		logSafeValue(failure.ErrorCode),
 		failure.ErrorMessagePresent,
 		failure.ErrorMessageByteLength,
 	)
@@ -316,10 +322,10 @@ func kinesisPutRecordsFailureSafeLog(failure KinesisPutRecordsFailure) string {
 	return fmt.Sprintf(
 		"kinesis_put_records_failure index=%d partition_key=%s explicit_hash_key=%s data_bytes=%d error_code=%s error_message_present=%t error_message_bytes=%d",
 		failure.Index,
-		failure.PartitionKey,
-		failure.ExplicitHashKey,
+		logSafeValue(failure.PartitionKey),
+		logSafeValue(failure.ExplicitHashKey),
 		failure.DataByteLength,
-		failure.ErrorCode,
+		logSafeValue(failure.ErrorCode),
 		failure.ErrorMessagePresent,
 		failure.ErrorMessageByteLength,
 	)

--- a/runtime/kinesis_producer_test.go
+++ b/runtime/kinesis_producer_test.go
@@ -47,6 +47,31 @@ func TestNewKinesisJSONRecord_EncodesDeterministicPayloadAndSummary(t *testing.T
 	}
 }
 
+func TestNewKinesisJSONRecord_SanitizesUnsafePartitionKeyInSafeLog(t *testing.T) {
+	t.Parallel()
+
+	partitionKey := "tenant\nforged=true\rcontrol=\x1f key=value\tpercent%"
+	record, err := NewKinesisJSONRecord(KinesisJSONRecordOptions{
+		PartitionKey: partitionKey,
+		Payload:      map[string]any{"ok": true},
+	})
+	if err != nil {
+		t.Fatalf("NewKinesisJSONRecord returned error: %v", err)
+	}
+	if record.PartitionKey != partitionKey {
+		t.Fatalf("partition key should remain API-compatible, got %q", record.PartitionKey)
+	}
+
+	safeLog := record.SafeSummary.SafeLog
+	assertKinesisSafeLogCannotForgeFields(t, safeLog)
+	if !strings.Contains(
+		safeLog,
+		"partition_key=tenant%0Aforged%3Dtrue%0Dcontrol%3D%1F%20key%3Dvalue%09percent%25",
+	) {
+		t.Fatalf("unsafe partition key was not percent-encoded in safe log: %q", safeLog)
+	}
+}
+
 func TestNewKinesisJSONRecord_FailsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -122,6 +147,35 @@ func TestReportKinesisPutRecordsFailures_AlignsByIndexAndOmitsPayloads(t *testin
 	}
 }
 
+func TestReportKinesisPutRecordsFailures_SanitizesPartitionKeyInFailureSafeLog(t *testing.T) {
+	t.Parallel()
+
+	record, err := NewKinesisJSONRecord(KinesisJSONRecordOptions{
+		PartitionKey: "tenant\nerror_code=ForgedException key=value",
+		Payload:      map[string]any{"ok": true},
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	report, err := ReportKinesisPutRecordsFailures(
+		[]KinesisJSONRecord{record},
+		[]KinesisPutRecordsResultRecord{{ErrorCode: "ProvisionedThroughputExceededException"}},
+	)
+	if err != nil {
+		t.Fatalf("ReportKinesisPutRecordsFailures returned error: %v", err)
+	}
+	if len(report.Failures) != 1 {
+		t.Fatalf("expected one failure: %#v", report)
+	}
+
+	safeLog := report.Failures[0].SafeLog
+	assertKinesisSafeLogCannotForgeFields(t, safeLog)
+	if strings.Contains(safeLog, "error_code=ForgedException") || !strings.Contains(safeLog, "%0Aerror_code%3D") {
+		t.Fatalf("unsafe partition key was not sanitized in failure safe log: %q", safeLog)
+	}
+}
+
 func TestReportKinesisPutRecordsFailures_FailsClosedForShapeDrift(t *testing.T) {
 	t.Parallel()
 
@@ -140,5 +194,15 @@ func TestReportKinesisPutRecordsFailures_FailsClosedForShapeDrift(t *testing.T) 
 		[]KinesisPutRecordsResultRecord{{ErrorMessage: "message without code"}},
 	); err == nil {
 		t.Fatal("expected error message without code to fail")
+	}
+}
+
+func assertKinesisSafeLogCannotForgeFields(t *testing.T, safeLog string) {
+	t.Helper()
+
+	for _, forbidden := range []string{"\n", "\r", "\t", "\x1f", " forged=", " key=value"} {
+		if strings.Contains(safeLog, forbidden) {
+			t.Fatalf("safe log permits forged delimiter or field %q: %q", forbidden, safeLog)
+		}
 	}
 }

--- a/runtime/safe_log.go
+++ b/runtime/safe_log.go
@@ -1,0 +1,32 @@
+package apptheory
+
+import (
+	"strings"
+	"unicode"
+)
+
+const logSafeHex = "0123456789ABCDEF"
+
+func logSafeValue(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	var out strings.Builder
+	for _, r := range value {
+		if !isUnsafeLogValueRune(r) {
+			out.WriteRune(r)
+			continue
+		}
+		for _, b := range []byte(string(r)) {
+			out.WriteByte('%')
+			out.WriteByte(logSafeHex[b>>4])
+			out.WriteByte(logSafeHex[b&0x0f])
+		}
+	}
+	return out.String()
+}
+
+func isUnsafeLogValueRune(r rune) bool {
+	return r == '%' || r == '=' || unicode.IsSpace(r) || unicode.IsControl(r)
+}

--- a/ts/dist/internal/safe-log.d.ts
+++ b/ts/dist/internal/safe-log.d.ts
@@ -1,0 +1,1 @@
+export declare function logSafeValue(value: string): string;

--- a/ts/dist/internal/safe-log.js
+++ b/ts/dist/internal/safe-log.js
@@ -1,0 +1,26 @@
+import { Buffer } from "node:buffer";
+const LOG_SAFE_WHITESPACE_PATTERN = /\s/u;
+export function logSafeValue(value) {
+    const raw = String(value ?? "");
+    if (!raw)
+        return raw;
+    let out = "";
+    for (const char of raw) {
+        if (!isUnsafeLogValueChar(char)) {
+            out += char;
+            continue;
+        }
+        for (const byte of Buffer.from(char, "utf8")) {
+            out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+        }
+    }
+    return out;
+}
+function isUnsafeLogValueChar(char) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    return (char === "%" ||
+        char === "=" ||
+        LOG_SAFE_WHITESPACE_PATTERN.test(char) ||
+        codePoint <= 0x1f ||
+        (codePoint >= 0x7f && codePoint <= 0x9f));
+}

--- a/ts/dist/kinesis-cloudwatch-logs.js
+++ b/ts/dist/kinesis-cloudwatch-logs.js
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { gunzipSync } from "node:zlib";
+import { logSafeValue } from "./internal/safe-log.js";
 const CLOUDWATCH_LOGS_SUBSCRIPTION_MAX_DECODED_BYTES = 6 * 1024 * 1024;
 const CLOUDWATCH_LOGS_SUBSCRIPTION_DECODE_MESSAGE = "apptheory: decode cloudwatch logs subscription";
 /**
@@ -99,9 +100,11 @@ function validateCloudWatchLogsSubscription(decoded) {
 function cloudWatchLogsSubscriptionSafeSummary(decoded) {
     const subscriptionFilterCount = decoded.subscription_filters.length;
     const logEventCount = decoded.log_events.length;
-    const safeLog = `record_id=${decoded.record_id} owner=${decoded.owner} ` +
-        `log_group=${decoded.log_group} log_stream=${decoded.log_stream} ` +
-        `message_type=${decoded.message_type} log_events=${logEventCount} ` +
+    const safeLog = `record_id=${logSafeValue(decoded.record_id)} ` +
+        `owner=${logSafeValue(decoded.owner)} ` +
+        `log_group=${logSafeValue(decoded.log_group)} ` +
+        `log_stream=${logSafeValue(decoded.log_stream)} ` +
+        `message_type=${logSafeValue(decoded.message_type)} log_events=${logEventCount} ` +
         `subscription_filters=${subscriptionFilterCount}`;
     return {
         record_id: decoded.record_id,

--- a/ts/dist/kinesis-producer.js
+++ b/ts/dist/kinesis-producer.js
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { logSafeValue } from "./internal/safe-log.js";
 const KINESIS_JSON_RECORD_INVALID_MESSAGE = "apptheory: kinesis json record invalid";
 const KINESIS_PUT_RECORDS_INVALID_MESSAGE = "apptheory: kinesis put-records result invalid";
 const KINESIS_MAX_PARTITION_KEY_BYTES = 256;
@@ -95,14 +96,17 @@ function normalizeKinesisExplicitHashKey(value) {
     return explicitHashKey;
 }
 function kinesisJsonRecordSafeSummary(partitionKey, dataByteLength, explicitHashKey) {
+    const safePartitionKey = logSafeValue(partitionKey);
     const summary = {
         partition_key: partitionKey,
         data_byte_length: dataByteLength,
-        safe_log: `partition_key=${partitionKey} data_bytes=${dataByteLength}`,
+        safe_log: `partition_key=${safePartitionKey} data_bytes=${dataByteLength}`,
     };
     if (explicitHashKey) {
         summary.explicit_hash_key = explicitHashKey;
-        summary.safe_log = `partition_key=${partitionKey} explicit_hash_key=${explicitHashKey} data_bytes=${dataByteLength}`;
+        summary.safe_log =
+            `partition_key=${safePartitionKey} ` +
+                `explicit_hash_key=${logSafeValue(explicitHashKey)} data_bytes=${dataByteLength}`;
     }
     return summary;
 }
@@ -182,14 +186,17 @@ function kinesisPutRecordsFailure(index, record, result) {
 function kinesisPutRecordsFailureSafeLog(failure) {
     if (failure.explicit_hash_key) {
         return (`kinesis_put_records_failure index=${failure.index} ` +
-            `partition_key=${failure.partition_key} explicit_hash_key=${failure.explicit_hash_key} ` +
-            `data_bytes=${failure.data_byte_length} error_code=${failure.error_code} ` +
+            `partition_key=${logSafeValue(failure.partition_key)} ` +
+            `explicit_hash_key=${logSafeValue(failure.explicit_hash_key)} ` +
+            `data_bytes=${failure.data_byte_length} ` +
+            `error_code=${logSafeValue(failure.error_code)} ` +
             `error_message_present=${failure.error_message_present} ` +
             `error_message_bytes=${failure.error_message_byte_length}`);
     }
     return (`kinesis_put_records_failure index=${failure.index} ` +
-        `partition_key=${failure.partition_key} data_bytes=${failure.data_byte_length} ` +
-        `error_code=${failure.error_code} ` +
+        `partition_key=${logSafeValue(failure.partition_key)} ` +
+        `data_bytes=${failure.data_byte_length} ` +
+        `error_code=${logSafeValue(failure.error_code)} ` +
         `error_message_present=${failure.error_message_present} ` +
         `error_message_bytes=${failure.error_message_byte_length}`);
 }

--- a/ts/src/internal/safe-log.ts
+++ b/ts/src/internal/safe-log.ts
@@ -1,0 +1,31 @@
+import { Buffer } from "node:buffer";
+
+const LOG_SAFE_WHITESPACE_PATTERN = /\s/u;
+
+export function logSafeValue(value: string): string {
+  const raw = String(value ?? "");
+  if (!raw) return raw;
+
+  let out = "";
+  for (const char of raw) {
+    if (!isUnsafeLogValueChar(char)) {
+      out += char;
+      continue;
+    }
+    for (const byte of Buffer.from(char, "utf8")) {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+function isUnsafeLogValueChar(char: string): boolean {
+  const codePoint = char.codePointAt(0) ?? 0;
+  return (
+    char === "%" ||
+    char === "=" ||
+    LOG_SAFE_WHITESPACE_PATTERN.test(char) ||
+    codePoint <= 0x1f ||
+    (codePoint >= 0x7f && codePoint <= 0x9f)
+  );
+}

--- a/ts/src/kinesis-cloudwatch-logs.ts
+++ b/ts/src/kinesis-cloudwatch-logs.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import { gunzipSync } from "node:zlib";
 
 import type { KinesisEventRecord } from "./aws-types.js";
+import { logSafeValue } from "./internal/safe-log.js";
 
 const CLOUDWATCH_LOGS_SUBSCRIPTION_MAX_DECODED_BYTES = 6 * 1024 * 1024;
 const CLOUDWATCH_LOGS_SUBSCRIPTION_DECODE_MESSAGE =
@@ -176,9 +177,11 @@ function cloudWatchLogsSubscriptionSafeSummary(
   const subscriptionFilterCount = decoded.subscription_filters.length;
   const logEventCount = decoded.log_events.length;
   const safeLog =
-    `record_id=${decoded.record_id} owner=${decoded.owner} ` +
-    `log_group=${decoded.log_group} log_stream=${decoded.log_stream} ` +
-    `message_type=${decoded.message_type} log_events=${logEventCount} ` +
+    `record_id=${logSafeValue(decoded.record_id)} ` +
+    `owner=${logSafeValue(decoded.owner)} ` +
+    `log_group=${logSafeValue(decoded.log_group)} ` +
+    `log_stream=${logSafeValue(decoded.log_stream)} ` +
+    `message_type=${logSafeValue(decoded.message_type)} log_events=${logEventCount} ` +
     `subscription_filters=${subscriptionFilterCount}`;
 
   return {

--- a/ts/src/kinesis-producer.ts
+++ b/ts/src/kinesis-producer.ts
@@ -1,5 +1,7 @@
 import { Buffer } from "node:buffer";
 
+import { logSafeValue } from "./internal/safe-log.js";
+
 const KINESIS_JSON_RECORD_INVALID_MESSAGE =
   "apptheory: kinesis json record invalid";
 const KINESIS_PUT_RECORDS_INVALID_MESSAGE =
@@ -200,14 +202,17 @@ function kinesisJsonRecordSafeSummary(
   dataByteLength: number,
   explicitHashKey: string,
 ): KinesisJsonRecordSummary {
+  const safePartitionKey = logSafeValue(partitionKey);
   const summary: KinesisJsonRecordSummary = {
     partition_key: partitionKey,
     data_byte_length: dataByteLength,
-    safe_log: `partition_key=${partitionKey} data_bytes=${dataByteLength}`,
+    safe_log: `partition_key=${safePartitionKey} data_bytes=${dataByteLength}`,
   };
   if (explicitHashKey) {
     summary.explicit_hash_key = explicitHashKey;
-    summary.safe_log = `partition_key=${partitionKey} explicit_hash_key=${explicitHashKey} data_bytes=${dataByteLength}`;
+    summary.safe_log =
+      `partition_key=${safePartitionKey} ` +
+      `explicit_hash_key=${logSafeValue(explicitHashKey)} data_bytes=${dataByteLength}`;
   }
   return summary;
 }
@@ -325,16 +330,19 @@ function kinesisPutRecordsFailureSafeLog(
   if (failure.explicit_hash_key) {
     return (
       `kinesis_put_records_failure index=${failure.index} ` +
-      `partition_key=${failure.partition_key} explicit_hash_key=${failure.explicit_hash_key} ` +
-      `data_bytes=${failure.data_byte_length} error_code=${failure.error_code} ` +
+      `partition_key=${logSafeValue(failure.partition_key)} ` +
+      `explicit_hash_key=${logSafeValue(failure.explicit_hash_key)} ` +
+      `data_bytes=${failure.data_byte_length} ` +
+      `error_code=${logSafeValue(failure.error_code)} ` +
       `error_message_present=${failure.error_message_present} ` +
       `error_message_bytes=${failure.error_message_byte_length}`
     );
   }
   return (
     `kinesis_put_records_failure index=${failure.index} ` +
-    `partition_key=${failure.partition_key} data_bytes=${failure.data_byte_length} ` +
-    `error_code=${failure.error_code} ` +
+    `partition_key=${logSafeValue(failure.partition_key)} ` +
+    `data_bytes=${failure.data_byte_length} ` +
+    `error_code=${logSafeValue(failure.error_code)} ` +
     `error_message_present=${failure.error_message_present} ` +
     `error_message_bytes=${failure.error_message_byte_length}`
   );

--- a/ts/test/kinesis-cloudwatch-logs.test.mjs
+++ b/ts/test/kinesis-cloudwatch-logs.test.mjs
@@ -83,6 +83,64 @@ test("decodeCloudWatchLogsSubscription decodes payload and omits raw messages fr
   assert.equal(safeSummaryJson.includes("contract log line beta"), false);
 });
 
+test("decodeCloudWatchLogsSubscription sanitizes metadata in safe_log", () => {
+  const rawMessage = "raw log line must stay out owner=customer-secret";
+  const decoded = decodeCloudWatchLogsSubscription({
+    eventID: "kin-cwl\nowner=spoof",
+    kinesis: {
+      data: gzipPayload({
+        messageType: "DATA_MESSAGE\rmessage_type=FORGED",
+        owner: "111122223333\nlog_events=999",
+        logGroup: "/aws/lambda/apptheory-contract owner=spoof",
+        logStream: "2026/05/26/[$LATEST]contract-a\tcontrol=\u001fafter",
+        subscriptionFilters: ["apptheory-contract-filter"],
+        logEvents: [
+          {
+            id: "cwl-event-a1",
+            timestamp: 1779806400000,
+            message: rawMessage,
+          },
+        ],
+      }).toString("base64"),
+    },
+  });
+
+  assert.equal(decoded.record_id, "kin-cwl\nowner=spoof");
+  assert.equal(decoded.owner, "111122223333\nlog_events=999");
+
+  const safeLog = decoded.safe_summary.safe_log;
+  for (const forbidden of [
+    "\n",
+    "\r",
+    "\t",
+    "\u001f",
+    "owner=spoof",
+    "log_events=999",
+    "message_type=FORGED",
+    rawMessage,
+  ]) {
+    assert.equal(
+      safeLog.includes(forbidden),
+      false,
+      `safe_log permits forged metadata ${JSON.stringify(forbidden)}: ${safeLog}`,
+    );
+  }
+  for (const wanted of [
+    "record_id=kin-cwl%0Aowner%3Dspoof",
+    "owner=111122223333%0Alog_events%3D999",
+    "log_group=/aws/lambda/apptheory-contract%20owner%3Dspoof",
+    "log_stream=2026/05/26/[$LATEST]contract-a%09control%3D%1Fafter",
+    "message_type=DATA_MESSAGE%0Dmessage_type%3DFORGED",
+    "log_events=1",
+  ]) {
+    assert.equal(
+      safeLog.includes(wanted),
+      true,
+      `safe_log missing sanitized metadata ${wanted}: ${safeLog}`,
+    );
+  }
+});
+
 test("decodeCloudWatchLogsSubscription failures do not leak raw payload data", () => {
   const secret = "do-not-log-customer-message";
 

--- a/ts/test/kinesis-producer.test.mjs
+++ b/ts/test/kinesis-producer.test.mjs
@@ -35,6 +35,23 @@ test("createKinesisJsonRecord encodes deterministic payload bytes and safe summa
   }
 });
 
+test("createKinesisJsonRecord sanitizes unsafe partition keys in safe_log", () => {
+  const partitionKey = "tenant\nforged=true\rcontrol=\u001f key=value\tpercent%";
+  const record = createKinesisJsonRecord({
+    partitionKey,
+    payload: { ok: true },
+  });
+
+  assert.equal(record.partition_key, partitionKey);
+  assertSafeLogCannotForgeFields(record.safe_summary.safe_log);
+  assert.equal(
+    record.safe_summary.safe_log.includes(
+      "partition_key=tenant%0Aforged%3Dtrue%0Dcontrol%3D%1F%20key%3Dvalue%09percent%25",
+    ),
+    true,
+  );
+});
+
 test("createKinesisJsonRecord fails closed for invalid inputs", () => {
   assert.throws(
     () => createKinesisJsonRecord({ partitionKey: "", payload: { ok: true } }),
@@ -100,6 +117,24 @@ test("reportKinesisPutRecordsFailures aligns failures and omits payload bodies",
   );
 });
 
+test("reportKinesisPutRecordsFailures sanitizes partition keys in failure safe_log", () => {
+  const record = createKinesisJsonRecord({
+    partitionKey: "tenant\nerror_code=ForgedException key=value",
+    payload: { ok: true },
+  });
+
+  const report = reportKinesisPutRecordsFailures(
+    [record],
+    [{ error_code: "ProvisionedThroughputExceededException" }],
+  );
+
+  assert.equal(report.failures.length, 1);
+  const safeLog = report.failures[0].safe_log;
+  assertSafeLogCannotForgeFields(safeLog);
+  assert.equal(safeLog.includes("error_code=ForgedException"), false);
+  assert.equal(safeLog.includes("%0Aerror_code%3D"), true);
+});
+
 test("reportKinesisPutRecordsFailures fails closed for shape drift", () => {
   const record = createKinesisJsonRecord({
     partitionKey: "pk-1",
@@ -118,3 +153,20 @@ test("reportKinesisPutRecordsFailures fails closed for shape drift", () => {
     /error message without error code/,
   );
 });
+
+function assertSafeLogCannotForgeFields(safeLog) {
+  for (const forbidden of [
+    "\n",
+    "\r",
+    "\t",
+    "\u001f",
+    " forged=",
+    " key=value",
+  ]) {
+    assert.equal(
+      safeLog.includes(forbidden),
+      false,
+      `safe_log permits forged delimiter or field ${JSON.stringify(forbidden)}: ${safeLog}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Reference THE-1748.

- Add private log-safe value helpers that percent-encode whitespace, control characters, `%`, and `=` before values are interpolated into safe_log/SafeLog strings.
- Apply the helper to Kinesis producer record/failure safe logs and CloudWatch Logs subscription metadata safe logs across Go, TypeScript, and Python.
- Keep raw Kinesis partition keys and decoded CloudWatch metadata API-compatible while ensuring safe_log output cannot forge additional lines or key/value fields.
- Preserve the existing invariant that raw CloudWatch log event messages are excluded from safe summaries.
- Regenerate and commit matching TypeScript `ts/dist/*` artifacts.

## Validation

- `git diff --check origin/staging...HEAD`
- `python3 py/tests/test_kinesis_producer.py`
- `python3 py/tests/test_kinesis_cloudwatch_logs.py`
- `cd ts && npm ci`
- `cd ts && npm run build`
- `cd ts && npm run check`
- `node --test ts/test/kinesis-producer.test.mjs ts/test/kinesis-cloudwatch-logs.test.mjs`
- `go test ./runtime`
- `make test`
- `git diff --exit-code -- ts/dist`

## Notes

This PR references Linear issue THE-1748. It intentionally does not use GitHub closing keywords because no GitHub issue is associated with THE-1748.
