### PR TITLE
fix(observability): bound ProfileLogger retention (THE-1722)

### DIFF
--- a/pkg/observability/profile_logger.go
+++ b/pkg/observability/profile_logger.go
@@ -62,6 +62,8 @@ type profileLoggerOptions struct {
 	clock       func() time.Time
 }
 
+const defaultProfileLoggerRetainedEntries = 1024
+
 type ProfileLogger struct {
 	root *ProfileLogger
 
@@ -278,7 +280,19 @@ func (l *ProfileLogger) GetStats() LoggerStats {
 		return LoggerStats{}
 	}
 	root := l.rootLogger()
-	return LoggerStats{EntriesLogged: root.entriesLogged.Load(), LastError: l.lastErrorString()}
+	root.mu.Lock()
+	retained := len(root.entries)
+	root.mu.Unlock()
+	entriesLogged := root.entriesLogged.Load()
+	entriesDropped := entriesLogged - int64(retained)
+	if entriesDropped < 0 {
+		entriesDropped = 0
+	}
+	return LoggerStats{
+		EntriesLogged:  entriesLogged,
+		EntriesDropped: entriesDropped,
+		LastError:      l.lastErrorString(),
+	}
 }
 
 func (l *ProfileLogger) Entries() []map[string]any {
@@ -349,6 +363,11 @@ func (l *ProfileLogger) log(level string, message string, fields ...map[string]a
 
 	root := l.rootLogger()
 	root.mu.Lock()
+	for len(root.entries) >= defaultProfileLoggerRetainedEntries {
+		copy(root.entries, root.entries[1:])
+		root.entries[len(root.entries)-1] = nil
+		root.entries = root.entries[:len(root.entries)-1]
+	}
 	root.entries = append(root.entries, copyAnyMap(encoded))
 	root.mu.Unlock()
 

--- a/pkg/observability/profile_logger_test.go
+++ b/pkg/observability/profile_logger_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -303,6 +304,68 @@ func TestProfileLogger_ContextMethodsCloseAndErrorState(t *testing.T) {
 
 	if hooks := HooksFromLogger(nil); hooks.Log != nil {
 		t.Fatalf("nil logger hooks should be empty: %#v", hooks)
+	}
+}
+
+func TestProfileLogger_RetentionIsBoundedAndSharedByScopedLoggers(t *testing.T) {
+	cfg, err := DefaultLoggingProfile(LoggingProfileCloudWatchJSON)
+	if err != nil {
+		t.Fatalf("DefaultLoggingProfile: %v", err)
+	}
+	cfg.Enrichment = LoggingProfileEnrichment{Context: map[string]string{
+		"request_id": "request.request_id",
+	}}
+	cfg.RequiredFields = []string{"timestamp", "level", "message"}
+
+	var buf bytes.Buffer
+	logger, err := NewProfileLogger(
+		cfg,
+		WithProfileWriter(&buf),
+		WithProfileClock(func() time.Time { return time.Unix(0, 0).UTC() }),
+	)
+	if err != nil {
+		t.Fatalf("NewProfileLogger: %v", err)
+	}
+
+	total := defaultProfileLoggerRetainedEntries + 2
+	scoped := logger.WithRequestID("req_retention")
+	for i := 0; i < total; i++ {
+		scoped.Info("message-" + strconv.Itoa(i))
+	}
+
+	entries := logger.Entries()
+	if len(entries) != defaultProfileLoggerRetainedEntries {
+		t.Fatalf("expected bounded entries length %d, got %d", defaultProfileLoggerRetainedEntries, len(entries))
+	}
+	if entries[0]["message"] != "message-2" {
+		t.Fatalf("expected oldest retained entry after eviction, got %#v", entries[0])
+	}
+	newestMessage := "message-" + strconv.Itoa(total-1)
+	if entries[len(entries)-1]["message"] != newestMessage {
+		t.Fatalf("expected newest retained entry, got %#v", entries[len(entries)-1])
+	}
+	if entries[0]["request_id"] != "req_retention" {
+		t.Fatalf("scoped logger should share root retention with context, got %#v", entries[0])
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != total {
+		t.Fatalf("writer should receive all entries independent of retention, got %d lines", len(lines))
+	}
+	var last map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("parse last writer line: %v", err)
+	}
+	if last["message"] != newestMessage {
+		t.Fatalf("writer did not receive newest entry after evictions: %#v", last)
+	}
+
+	stats := logger.GetStats()
+	if stats.EntriesLogged != int64(total) {
+		t.Fatalf("expected EntriesLogged=%d, got %#v", total, stats)
+	}
+	if stats.EntriesDropped != 2 {
+		t.Fatalf("expected EntriesDropped=2, got %#v", stats)
 	}
 }
 

--- a/py/src/apptheory/logging_profile.py
+++ b/py/src/apptheory/logging_profile.py
@@ -244,6 +244,7 @@ class ProfileLoggerOptions(TypedDict, total=False):
 
 
 _DEFAULT_PROFILE_WRITER = object()
+_DEFAULT_PROFILE_RETAINED_ENTRIES = 1024
 
 
 class ProfileLogger:
@@ -327,7 +328,11 @@ class ProfileLogger:
         return not self._root._closed and not self._root._last_error
 
     def get_stats(self) -> dict[str, Any]:
-        return {"entries_logged": self._root._entries_logged, "last_error": self._root._last_error}
+        return {
+            "entries_logged": self._root._entries_logged,
+            "entries_dropped": max(0, self._root._entries_logged - len(self._root._entries)),
+            "last_error": self._root._last_error,
+        }
 
     def entries(self) -> list[dict[str, Any]]:
         return [dict(entry) for entry in self._root._entries]
@@ -375,12 +380,17 @@ class ProfileLogger:
                 event,
                 self._sanitizer,
             )
-            self._root._entries.append(dict(encoded))
+            self._retain_entry(encoded)
             if self._writer is not None:
                 self._writer(json.dumps(encoded, separators=(",", ":")))
             self._root._entries_logged += 1
         except Exception as exc:  # noqa: BLE001 - logger records encoder failures instead of raising from hooks.
             self._root._last_error = str(exc)
+
+    def _retain_entry(self, encoded: dict[str, Any]) -> None:
+        while len(self._root._entries) >= _DEFAULT_PROFILE_RETAINED_ENTRIES:
+            del self._root._entries[0]
+        self._root._entries.append(dict(encoded))
 
 
 def _default_profile_writer(line: str) -> None:

--- a/py/tests/test_logging_profile.py
+++ b/py/tests/test_logging_profile.py
@@ -471,6 +471,34 @@ class TestLoggingProfile(unittest.TestCase):
         broken.info("missing env")
         self.assertIn("logging profile required fields missing", broken.get_stats()["last_error"])
 
+    def test_profile_logger_retention_is_bounded_and_shared_by_scoped_loggers(self) -> None:
+        cfg = default_logging_profile(LOGGING_PROFILE_CLOUDWATCH_JSON)
+        cfg["enrichment"] = {"context": {"request_id": "request.request_id"}}
+        cfg["required_fields"] = ["timestamp", "level", "message"]
+
+        lines: list[str] = []
+        logger = ProfileLogger(
+            cfg,
+            writer=lines.append,
+            clock=lambda: datetime.fromtimestamp(0, UTC),
+        )
+        retention_cap = 1024
+        total = retention_cap + 2
+        scoped = logger.with_request_id("req_retention")
+        for index in range(total):
+            scoped.info(f"message-{index}")
+
+        entries = logger.entries()
+        self.assertEqual(len(entries), retention_cap)
+        self.assertEqual(entries[0]["message"], "message-2")
+        self.assertEqual(entries[-1]["message"], f"message-{total - 1}")
+        self.assertEqual(entries[0]["request_id"], "req_retention")
+
+        self.assertEqual(len(lines), total)
+        self.assertEqual(json.loads(lines[-1])["message"], f"message-{total - 1}")
+        self.assertEqual(logger.get_stats()["entries_logged"], total)
+        self.assertEqual(logger.get_stats()["entries_dropped"], 2)
+
 
 def _profile_environment() -> dict[str, str]:
     return {

--- a/ts/dist/logging-profile.d.ts
+++ b/ts/dist/logging-profile.d.ts
@@ -126,6 +126,7 @@ export declare class ProfileLogger implements StructuredLogger {
     entries(): Record<string, unknown>[];
     private clone;
     private log;
+    private retainEntry;
 }
 export declare function encodeLoggingProfileEvent(config: LoggingProfileConfig, environment: Record<string, string> | undefined, event: LoggingProfileEvent): Record<string, unknown>;
 export declare function encodeLoggingProfileEventWithSanitizer(config: LoggingProfileConfig, environment: Record<string, string> | undefined, event: LoggingProfileEvent, sanitizer: LoggingProfileSanitizer | undefined): Record<string, unknown>;

--- a/ts/dist/logging-profile.js
+++ b/ts/dist/logging-profile.js
@@ -132,6 +132,7 @@ export function loggingProfileValidationErrors(config) {
     errors.push(...validateAlertingHints(config.alerting_hints));
     return errors;
 }
+const DEFAULT_PROFILE_RETAINED_ENTRIES = 1024;
 export class ProfileLogger {
     root;
     config;
@@ -223,6 +224,7 @@ export class ProfileLogger {
     getStats() {
         return {
             entries_logged: this.root.entriesLogged,
+            entries_dropped: Math.max(0, this.root.entriesLogged - this.root.profileEntries.length),
             last_error: this.root.lastError,
         };
     }
@@ -261,7 +263,7 @@ export class ProfileLogger {
         applyKnownProfileFieldsToEvent(event, merged);
         try {
             const encoded = encodeLoggingProfileEventWithSanitizer(this.config, this.environment, event, this.sanitizer);
-            this.root.profileEntries.push({ ...encoded });
+            this.retainEntry(encoded);
             if (this.writer)
                 this.writer(JSON.stringify(encoded));
             this.root.entriesLogged += 1;
@@ -269,6 +271,12 @@ export class ProfileLogger {
         catch (error) {
             this.root.lastError = errorMessage(error);
         }
+    }
+    retainEntry(encoded) {
+        while (this.root.profileEntries.length >= DEFAULT_PROFILE_RETAINED_ENTRIES) {
+            this.root.profileEntries.shift();
+        }
+        this.root.profileEntries.push({ ...encoded });
     }
 }
 export function encodeLoggingProfileEvent(config, environment, event) {

--- a/ts/src/logging-profile.ts
+++ b/ts/src/logging-profile.ts
@@ -284,6 +284,8 @@ export interface ProfileLoggerOptions {
   clock?: () => Date;
 }
 
+const DEFAULT_PROFILE_RETAINED_ENTRIES = 1024;
+
 interface ProfileLoggerContext {
   fields: LogFields;
   requestId: string;
@@ -408,6 +410,10 @@ export class ProfileLogger implements StructuredLogger {
   getStats(): LogFields {
     return {
       entries_logged: this.root.entriesLogged,
+      entries_dropped: Math.max(
+        0,
+        this.root.entriesLogged - this.root.profileEntries.length,
+      ),
       last_error: this.root.lastError,
     };
   }
@@ -454,12 +460,21 @@ export class ProfileLogger implements StructuredLogger {
         event,
         this.sanitizer,
       );
-      this.root.profileEntries.push({ ...encoded });
+      this.retainEntry(encoded);
       if (this.writer) this.writer(JSON.stringify(encoded));
       this.root.entriesLogged += 1;
     } catch (error) {
       this.root.lastError = errorMessage(error);
     }
+  }
+
+  private retainEntry(encoded: Record<string, unknown>): void {
+    while (
+      this.root.profileEntries.length >= DEFAULT_PROFILE_RETAINED_ENTRIES
+    ) {
+      this.root.profileEntries.shift();
+    }
+    this.root.profileEntries.push({ ...encoded });
   }
 }
 

--- a/ts/test/logging-profile.test.mjs
+++ b/ts/test/logging-profile.test.mjs
@@ -367,3 +367,32 @@ test("profile logger context methods close and record errors", () => {
   broken.info("missing env");
   assert.match(broken.getStats().last_error, /logging profile required fields missing/);
 });
+
+test("profile logger retention is bounded and shared by scoped loggers", () => {
+  const cfg = defaultLoggingProfile(LOGGING_PROFILE_CLOUDWATCH_JSON);
+  cfg.enrichment = { context: { request_id: "request.request_id" } };
+  cfg.required_fields = ["timestamp", "level", "message"];
+
+  const lines = [];
+  const logger = new ProfileLogger(cfg, {
+    writer: (line) => lines.push(line),
+    clock: () => new Date(0),
+  });
+  const retentionCap = 1024;
+  const total = retentionCap + 2;
+  const scoped = logger.withRequestID("req_retention");
+  for (let index = 0; index < total; index += 1) {
+    scoped.info(`message-${index}`);
+  }
+
+  const entries = logger.entries();
+  assert.equal(entries.length, retentionCap);
+  assert.equal(entries[0].message, "message-2");
+  assert.equal(entries.at(-1).message, `message-${total - 1}`);
+  assert.equal(entries[0].request_id, "req_retention");
+
+  assert.equal(lines.length, total);
+  assert.equal(JSON.parse(lines.at(-1)).message, `message-${total - 1}`);
+  assert.equal(logger.getStats().entries_logged, total);
+  assert.equal(logger.getStats().entries_dropped, 2);
+});


### PR DESCRIPTION
## Summary
- Bound ProfileLogger in-memory retention in Go, Python, and TypeScript to a finite FIFO recent-entry window.
- Kept writer/stdout emission independent from retained history, so all encoded entries still go to the configured writer after evictions.
- Added retention tests for bounded readers, scoped/cloned logger root sharing, writer continuity, and entries_dropped stats.
- Regenerated committed TypeScript dist output for the logging profile runtime.

## Linear
Reference THE-1722.
Linear URL: https://linear.app/theorycloud/issue/THE-1722

## Validation
- `git diff --check origin/staging...HEAD`
- `go test ./pkg/observability`
- `python py/tests/test_logging_profile.py`
- `cd ts && npm run build`
- `cd ts && npm run check`
- `cd ts && node --test test/logging-profile.test.mjs`
- `make test`
- `git diff --exit-code -- ts/dist`
- `./scripts/verify-api-snapshots.sh`
