### PR TITLE
fix(ci): authenticate release wrapper gh calls (THE-1733)

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -39,6 +39,7 @@ jobs:
         id: release
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
           scripts/run-release-please-pr.sh \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -118,6 +118,7 @@ jobs:
         id: release_aligned
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           RELEASE_AS: ${{ steps.version.outputs.release_as }}
         run: |
           # NOTE: release-please-action currently does not apply `release-as` when using
@@ -135,6 +136,7 @@ jobs:
         id: release_default
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
           scripts/run-release-please-pr.sh \

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -50,6 +50,20 @@ def require_order_after(path: str, anchor: str, first: str, second: str, descrip
         )
 
 
+def require_step_contains(path: str, step_name: str, needle: str, description: str) -> None:
+    text = Path(path).read_text(encoding="utf-8")
+    marker = f"      - name: {step_name}\n"
+    start_index = text.find(marker)
+    if start_index == -1:
+        raise SystemExit(f"release-workflows: FAIL ({description}; missing step {step_name!r} in {path})")
+    next_step_index = text.find("\n      - ", start_index + len(marker))
+    block = text[start_index : next_step_index if next_step_index != -1 else len(text)]
+    if needle not in block:
+        raise SystemExit(
+            f"release-workflows: FAIL ({description}; missing {needle!r} in {step_name!r} step in {path})"
+        )
+
+
 require_order(
     ".github/workflows/prerelease.yml",
     "Build + verify before prerelease creation",
@@ -408,6 +422,17 @@ require_contains(
     'gh pr ready "${pr_number}" --undo',
     "release-please PR generation must draft-lock valid open release PRs before artifact setup",
 )
+for workflow, step_name in (
+    (".github/workflows/prerelease-pr.yml", "Release Please (PR only)"),
+    (".github/workflows/release-pr.yml", "Release Please (PR only) (aligned)"),
+    (".github/workflows/release-pr.yml", "Release Please (PR only)"),
+):
+    require_step_contains(
+        workflow,
+        step_name,
+        "GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}",
+        "release-please wrapper steps must authenticate gh CLI with the release token fallback",
+    )
 require_order(
     ".github/workflows/prerelease.yml",
     "Verify branch version sync (release preflight)",


### PR DESCRIPTION
## Summary
- Adds `GH_TOKEN` to every release-pr workflow step that invokes `scripts/run-release-please-pr.sh`, using the existing release-token fallback expression.
- Preserves `RELEASE_PLEASE_TOKEN` for release-please itself.
- Adds a narrow `verify-release-workflows.sh` guard so wrapper steps fail release-gate verification if `GH_TOKEN` is omitted again.

## Linear
- THE-1733: https://linear.app/theorycloud/issue/THE-1733/apptheory-release-wrapper-does-not-authenticate-gh-cli

## Validation
- `git diff --check origin/staging...HEAD`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: OK" }' .github/workflows/release-pr.yml .github/workflows/prerelease-pr.yml`
- `bash -n scripts/verify-release-workflows.sh && bash -n scripts/run-release-please-pr.sh`
- `bash scripts/verify-release-workflows.sh && bash scripts/verify-branch-release-supply-chain.sh`
- `git merge-base --is-ancestor origin/main HEAD`

No release, deployment, publishing, or release-please execution was performed.
