### PR TITLE
[codex] fix ci code scanning alert 29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,123 @@ jobs:
         run: |
           set -euo pipefail
 
+          if scripts/verify-release-train-promotion.sh --help | grep -q -- "--head-sha"; then
+            scripts/verify-release-train-promotion.sh \
+              --base "${PR_BASE_REF}" \
+              --head "${PR_HEAD_REF}" \
+              --base-ref HEAD \
+              --head-sha "${PR_HEAD_SHA}" \
+              --github-repository "${GITHUB_REPOSITORY}" \
+              --github-head-repository "${PR_HEAD_REPOSITORY}"
+            exit 0
+          fi
+
+          if [[ ! "${PR_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "release-train-promotion: FAIL (pull request head SHA is invalid)"
+            exit 1
+          fi
+
+          pr_head_data_ref="refs/remotes/origin/pr-head-witness/${PR_HEAD_SHA}"
+          case "${PR_BASE_REF}:${PR_HEAD_REF}" in
+            premain:staging|main:premain|staging:main)
+              git fetch --no-tags origin \
+                "+refs/heads/${PR_HEAD_REF}:refs/remotes/origin/${PR_HEAD_REF}"
+              trusted_head_sha="$(git rev-parse "refs/remotes/origin/${PR_HEAD_REF}^{commit}")"
+              if [[ "${trusted_head_sha}" != "${PR_HEAD_SHA}" ]]; then
+                echo "release-train-promotion: FAIL (event head does not match trusted ${PR_HEAD_REF})"
+                echo "trusted=${trusted_head_sha}"
+                echo "event=${PR_HEAD_SHA}"
+                exit 1
+              fi
+              git update-ref "${pr_head_data_ref}" "${trusted_head_sha}"
+              ;;
+            staging:staging|staging:premain)
+              scripts/verify-release-train-promotion.sh \
+                --base "${PR_BASE_REF}" \
+                --head "${PR_HEAD_REF}" \
+                --base-ref HEAD
+              exit 0
+              ;;
+            staging:*)
+              git fetch --no-tags origin \
+                "+refs/heads/main:refs/remotes/origin/main"
+              ancestor_sha="$(git rev-parse "refs/remotes/origin/main^{commit}")"
+              python3 - "${PR_HEAD_REPOSITORY}" "${ancestor_sha}" "${PR_HEAD_SHA}" <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          repository, ancestor_sha, head_sha = sys.argv[1:]
+
+          def fail(message: str) -> None:
+              print(f"release-train-promotion: FAIL ({message})")
+              raise SystemExit(1)
+
+          if not re.fullmatch(r"[0-9a-f]{40}", ancestor_sha):
+              fail("ancestor SHA is invalid")
+          if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+              fail("pull request head SHA is invalid")
+          if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+              fail("GitHub repository must be in owner/name form")
+
+          token = os.environ.get("GITHUB_TOKEN")
+          if not token:
+              fail("GITHUB_TOKEN is required to verify PR head ancestry without fetching it")
+
+          owner, repo = repository.split("/", 1)
+          api_base = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+          url = (
+              f"{api_base}/repos/"
+              f"{urllib.parse.quote(owner, safe='')}/"
+              f"{urllib.parse.quote(repo, safe='')}/"
+              f"compare/{ancestor_sha}...{head_sha}"
+          )
+          request = urllib.request.Request(
+              url,
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {token}",
+                  "User-Agent": "apptheory-release-train-verifier",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+
+          try:
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as exc:
+              detail = exc.read(512).decode("utf-8", errors="replace").strip()
+              fail(f"GitHub API request failed with HTTP {exc.code}: {detail or exc.reason}")
+          except urllib.error.URLError as exc:
+              fail(f"GitHub API request failed: {exc.reason}")
+
+          merge_base = payload.get("merge_base_commit", {}).get("sha", "")
+          if payload.get("status") not in {"ahead", "identical"} or merge_base.lower() != ancestor_sha:
+              fail(
+                  "staging PR branch does not contain the current main baseline; "
+                  "merge origin/main into the PR branch before targeting staging"
+              )
+          PY
+              git update-ref "${pr_head_data_ref}" "${ancestor_sha}"
+              ;;
+            *)
+              scripts/verify-release-train-promotion.sh \
+                --base "${PR_BASE_REF}" \
+                --head "${PR_HEAD_REF}" \
+                --base-ref HEAD
+              exit 0
+              ;;
+          esac
+
           scripts/verify-release-train-promotion.sh \
             --base "${PR_BASE_REF}" \
             --head "${PR_HEAD_REF}" \
             --base-ref HEAD \
-            --head-sha "${PR_HEAD_SHA}" \
-            --github-repository "${GITHUB_REPOSITORY}" \
-            --github-head-repository "${PR_HEAD_REPOSITORY}"
+            --head-ref "${pr_head_data_ref}"
 
   prerelease-readiness:
     name: Prerelease readiness (staging → premain)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,35 +26,22 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Verify release train promotion path
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-
-          if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-            echo "release-train-promotion: FAIL (pull request number is not numeric)"
-            exit 1
-          fi
-
-          pr_head_data_ref="refs/remotes/origin/pr/${PR_NUMBER}/head"
-          git fetch --no-tags origin \
-            "+refs/pull/${PR_NUMBER}/head:${pr_head_data_ref}"
-
-          fetched_head_sha="$(git rev-parse "${pr_head_data_ref}^{commit}")"
-          if [[ "${fetched_head_sha}" != "${PR_HEAD_SHA}" ]]; then
-            echo "release-train-promotion: FAIL (fetched PR head does not match event head)"
-            echo "fetched=${fetched_head_sha}"
-            echo "event=${PR_HEAD_SHA}"
-            exit 1
-          fi
 
           scripts/verify-release-train-promotion.sh \
             --base "${PR_BASE_REF}" \
             --head "${PR_HEAD_REF}" \
             --base-ref HEAD \
-            --head-ref "${pr_head_data_ref}"
+            --head-sha "${PR_HEAD_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-head-repository "${PR_HEAD_REPOSITORY}"
 
   prerelease-readiness:
     name: Prerelease readiness (staging → premain)

--- a/scripts/verify-release-train-promotion.sh
+++ b/scripts/verify-release-train-promotion.sh
@@ -11,9 +11,13 @@ import contextlib
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -41,6 +45,20 @@ def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[st
 def fail(message: str) -> None:
     print(f"release-train-promotion: FAIL ({message})")
     raise SystemExit(1)
+
+
+def normalize_sha(value: str, label: str) -> str:
+    candidate = value.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", candidate):
+        fail(f"{label} must be a 40-character git commit SHA")
+    return candidate
+
+
+def normalize_repository(repository: str) -> str:
+    parts = repository.split("/")
+    if len(parts) != 2 or not all(re.fullmatch(r"[A-Za-z0-9_.-]+", part) for part in parts):
+        fail(f"GitHub repository must be in owner/name form, got {repository!r}")
+    return repository
 
 
 def ref_exists(ref: str) -> bool:
@@ -113,6 +131,69 @@ def is_ancestor(ancestor_ref: str, descendant_ref: str) -> bool:
     return run(["git", "merge-base", "--is-ancestor", ancestor_ref, descendant_ref], check=False).returncode == 0
 
 
+def github_api_json(repository: str, path: str) -> dict[str, object]:
+    repository = normalize_repository(repository)
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        fail("GITHUB_TOKEN or GH_TOKEN is required to verify PR head ancestry without fetching it")
+
+    owner, repo = repository.split("/", 1)
+    api_base = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    url = (
+        f"{api_base}/repos/"
+        f"{urllib.parse.quote(owner, safe='')}/"
+        f"{urllib.parse.quote(repo, safe='')}/"
+        f"{path}"
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "apptheory-release-train-verifier",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(512).decode("utf-8", errors="replace").strip()
+        fail(f"GitHub API request failed with HTTP {exc.code}: {detail or exc.reason}")
+    except urllib.error.URLError as exc:
+        fail(f"GitHub API request failed: {exc.reason}")
+
+    if not isinstance(payload, dict):
+        fail("GitHub API returned an invalid response")
+    return payload
+
+
+def compare_response_is_ancestor(payload: dict[str, object], ancestor_sha: str) -> bool:
+    ancestor_sha = normalize_sha(ancestor_sha, "ancestor SHA")
+    status = payload.get("status")
+    if status not in {"ahead", "identical"}:
+        return False
+
+    base_commit = payload.get("base_commit")
+    merge_base_commit = payload.get("merge_base_commit")
+    if not isinstance(base_commit, dict) or not isinstance(merge_base_commit, dict):
+        return False
+
+    base_sha = base_commit.get("sha")
+    merge_base_sha = merge_base_commit.get("sha")
+    if not isinstance(base_sha, str) or not isinstance(merge_base_sha, str):
+        return False
+
+    return base_sha.lower() == ancestor_sha and merge_base_sha.lower() == ancestor_sha
+
+
+def github_compare_is_ancestor(repository: str, ancestor_sha: str, descendant_sha: str) -> bool:
+    ancestor_sha = normalize_sha(ancestor_sha, "ancestor SHA")
+    descendant_sha = normalize_sha(descendant_sha, "head SHA")
+    payload = github_api_json(repository, f"compare/{ancestor_sha}...{descendant_sha}")
+    return compare_response_is_ancestor(payload, ancestor_sha)
+
+
 def expected_base_for_release_head(head: str) -> str:
     if head == "staging":
         return "premain"
@@ -170,10 +251,21 @@ def classify(base: str, head: str) -> PromotionPlan:
     return PromotionPlan(True, "non-release-train PR", non_release_pr=True)
 
 
-def validate(base: str, head: str, remote: str, base_ref: str | None, head_ref: str | None) -> None:
+def validate(
+    base: str,
+    head: str,
+    remote: str,
+    base_ref: str | None,
+    head_ref: str | None,
+    head_sha: str | None,
+    github_repository: str | None,
+    github_head_repository: str | None,
+) -> None:
     plan = classify(base, head)
     if not plan.valid:
         fail(plan.message)
+
+    expected_head_sha = normalize_sha(head_sha, "head SHA") if head_sha else None
 
     if plan.non_release_pr:
         print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
@@ -195,11 +287,47 @@ def validate(base: str, head: str, remote: str, base_ref: str | None, head_ref: 
         plan.ancestor_branch,
         base_ref if plan.ancestor_branch == base else None,
     )
+
+    if (
+        plan.descendant_branch == head
+        and expected_head_sha is not None
+        and head_ref is None
+        and head not in RELEASE_BRANCHES
+    ):
+        compare_repository = github_head_repository or github_repository
+        if not compare_repository:
+            fail("GitHub repository is required to verify PR head ancestry without fetching it")
+        if not github_compare_is_ancestor(compare_repository, commit_sha(ancestor_ref), expected_head_sha):
+            if base == "staging":
+                fail(
+                    "staging PR branch does not contain the current main baseline; "
+                    "merge origin/main into the PR branch before targeting staging"
+                )
+            fail(
+                f"{plan.ancestor_branch} is not an ancestor of {plan.descendant_branch}; "
+                "recreate the release-train PR from the current branch heads and do not merge around "
+                "staging → premain → main → staging"
+            )
+
+        print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
+        return
+
     descendant_ref = resolve_branch_ref(
         remote,
         plan.descendant_branch,
         head_ref if plan.descendant_branch == head else None,
     )
+
+    if plan.descendant_branch == head and expected_head_sha is not None:
+        actual_head_sha = commit_sha(descendant_ref).lower()
+        if actual_head_sha != expected_head_sha:
+            if head in RELEASE_BRANCHES:
+                fail(
+                    f"event head SHA for protected release branch {head} "
+                    f"does not match trusted {remote}/{head}; "
+                    "release-train PRs must use the protected branch head content"
+                )
+            fail(f"event head SHA does not match resolved PR head ref {descendant_ref!r}")
 
     if not is_ancestor(ancestor_ref, descendant_ref):
         if base == "staging" and head not in RELEASE_BRANCHES:
@@ -285,11 +413,23 @@ def validate_exit(
     *,
     base_ref: str | None = None,
     head_ref: str | None = None,
+    head_sha: str | None = None,
+    github_repository: str | None = None,
+    github_head_repository: str | None = None,
 ) -> tuple[int, str]:
     output = io.StringIO()
     with contextlib.redirect_stdout(output):
         try:
-            validate(base, head, "origin", base_ref, head_ref)
+            validate(
+                base,
+                head,
+                "origin",
+                base_ref,
+                head_ref,
+                head_sha,
+                github_repository,
+                github_head_repository,
+            )
         except SystemExit as exc:
             code = exc.code if isinstance(exc.code, int) else 1
             return code, output.getvalue()
@@ -303,9 +443,20 @@ def assert_validation(
     *,
     base_ref: str | None = None,
     head_ref: str | None = None,
+    head_sha: str | None = None,
+    github_repository: str | None = None,
+    github_head_repository: str | None = None,
     contains: str | None = None,
 ) -> None:
-    code, output = validate_exit(base, head, base_ref=base_ref, head_ref=head_ref)
+    code, output = validate_exit(
+        base,
+        head,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        head_sha=head_sha,
+        github_repository=github_repository,
+        github_head_repository=github_head_repository,
+    )
     if code != expected_exit:
         raise AssertionError(
             f"{head} → {base}: expected exit {expected_exit}, got {code}; output:\n{output}"
@@ -331,6 +482,14 @@ def self_test_git_topology() -> None:
                 head_ref="staging",
                 contains="staging → premain prerelease promotion",
             )
+            assert_validation(
+                "premain",
+                "staging",
+                0,
+                base_ref="premain",
+                head_sha=commit_sha("staging"),
+                contains="staging → premain prerelease promotion",
+            )
             print("release-train-promotion: positive staging → premain topology accepted")
             assert_validation(
                 "premain",
@@ -338,6 +497,14 @@ def self_test_git_topology() -> None:
                 1,
                 base_ref="premain",
                 head_ref="refs/remotes/origin/pr/1/head",
+                contains="does not match trusted origin/staging",
+            )
+            assert_validation(
+                "premain",
+                "staging",
+                1,
+                base_ref="premain",
+                head_sha=commit_sha("refs/remotes/origin/pr/1/head"),
                 contains="does not match trusted origin/staging",
             )
             print("release-train-promotion: negative forged staging head rejected")
@@ -378,6 +545,27 @@ def self_test() -> None:
     assert_plan("project/apptheory-release-process-reliability", "main", False, None, None)
     assert_plan("project/apptheory-release-process-reliability", "milestone/release-hardening", True, None, None)
 
+    ancestor = "0" * 40
+    descendant = "1" * 40
+    if not compare_response_is_ancestor(
+        {
+            "status": "ahead",
+            "base_commit": {"sha": ancestor},
+            "merge_base_commit": {"sha": ancestor},
+        },
+        ancestor,
+    ):
+        raise AssertionError("GitHub compare ancestry must accept head commits ahead of the baseline")
+    if compare_response_is_ancestor(
+        {
+            "status": "diverged",
+            "base_commit": {"sha": ancestor},
+            "merge_base_commit": {"sha": descendant},
+        },
+        ancestor,
+    ):
+        raise AssertionError("GitHub compare ancestry must reject branches missing the baseline")
+
     self_test_git_topology()
 
     print("release-train-promotion: self-test PASS")
@@ -407,6 +595,9 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--remote", default="origin")
     parser.add_argument("--base-ref", default=None)
     parser.add_argument("--head-ref", default=None)
+    parser.add_argument("--head-sha", default=None)
+    parser.add_argument("--github-repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--github-head-repository", default=None)
     args = parser.parse_args(argv)
 
     if args.self_test:
@@ -416,7 +607,16 @@ def main(argv: list[str]) -> int:
     if not args.base or not args.head:
         fail("base and head branches are required; pass --base/--head or run on a pull_request event")
 
-    validate(args.base, args.head, args.remote, args.base_ref, args.head_ref)
+    validate(
+        args.base,
+        args.head,
+        args.remote,
+        args.base_ref,
+        args.head_ref,
+        args.head_sha,
+        args.github_repository,
+        args.github_head_repository,
+    )
     return 0
 
 

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -316,15 +316,15 @@ require_not_contains(
     "ref: ${{ github.event.pull_request.head.sha }}",
     "release train promotion verifier must not execute verifier code from the untrusted PR head",
 )
-require_contains(
+require_not_contains(
     ".github/workflows/ci.yml",
     "refs/pull/${PR_NUMBER}/head:${pr_head_data_ref}",
-    "release train promotion verifier must fetch the PR head only as git data",
+    "release train promotion verifier must not fetch untrusted PR head content in CI",
 )
 require_contains(
     ".github/workflows/ci.yml",
-    'fetched_head_sha="$(git rev-parse "${pr_head_data_ref}^{commit}")"',
-    "release train promotion verifier must confirm fetched PR data matches the event head SHA",
+    "GITHUB_TOKEN: ${{ github.token }}",
+    "release train promotion verifier must use the read-only workflow token for compare API ancestry checks",
 )
 require_contains(
     ".github/workflows/ci.yml",
@@ -333,8 +333,18 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
-    '--head-ref "${pr_head_data_ref}"',
-    "release train promotion verifier must pass the fetched PR head data ref explicitly",
+    '--head-sha "${PR_HEAD_SHA}"',
+    "release train promotion verifier must pass the event head SHA without fetching PR head content",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    '--github-repository "${GITHUB_REPOSITORY}"',
+    "release train promotion verifier must identify the protected repository for compare checks",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    '--github-head-repository "${PR_HEAD_REPOSITORY}"',
+    "release train promotion verifier must compare fork PR heads in their source repository",
 )
 require_not_contains(
     ".github/workflows/ci.yml",
@@ -355,6 +365,11 @@ require_contains(
     "scripts/verify-release-train-promotion.sh",
     "does not match trusted {remote}/{branch}",
     "release train promotion verifier must reject forged release branch head content",
+)
+require_contains(
+    "scripts/verify-release-train-promotion.sh",
+    "compare/{ancestor_sha}...{descendant_sha}",
+    "release train promotion verifier must use GitHub compare data for untrusted PR head ancestry",
 )
 require_contains(
     "scripts/verify-release-train-promotion.sh",


### PR DESCRIPTION
## Summary
- Sync from current `origin/staging` and keep the branch on the current `origin/main` baseline.
- Address code scanning alert #29 (`actions/untrusted-checkout/medium`) by removing the CI release-train gate fetch of `refs/pull/*/head`.
- Keep the verifier fail-closed: protected release branches are still resolved from trusted branch heads and checked against the event SHA; ordinary staging PR ancestry now uses the GitHub compare API against the event head SHA instead of fetching untrusted PR content.
- Add a backward-compatible CI bridge so the PR can pass while `staging` still has the older verifier CLI; once this lands, the gate uses the verifier's native `--head-sha` path.
- Update release workflow guard checks and verifier self-tests for the new path.

## Validation
- `./scripts/verify-release-train-promotion.sh --self-test`
- `./scripts/verify-release-workflows.sh`
- GitHub compare-path smoke test for `origin/main` ancestry
- Compatibility fallback smoke test against the current `origin/staging` verifier
- `make test`
- `make lint`
- `git diff --check`

No contract fixtures or API snapshots changed.