### PR TITLE
fix(ci): unshallow release train topology checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,17 @@ jobs:
             pr_title_args=(--pr-title "${PR_TITLE}")
           fi
 
+          release_ref_depth_args=()
+          if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+            release_ref_depth_args=(--unshallow)
+          fi
+          git fetch --no-tags "${release_ref_depth_args[@]}" origin \
+            "+refs/heads/staging:refs/remotes/origin/staging" \
+            "+refs/heads/premain:refs/remotes/origin/premain" \
+            "+refs/heads/main:refs/remotes/origin/main"
+
           case "${PR_BASE_REF}" in
             staging|premain|main)
-              git fetch --no-tags origin \
-                "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
               base_ref_args=(--base-ref "refs/remotes/origin/${PR_BASE_REF}")
               ;;
           esac

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -365,6 +365,17 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
+    'release_ref_depth_args=(--unshallow)',
+    "release train promotion verifier must unshallow trusted protected release branch history",
+)
+for branch in ("staging", "premain", "main"):
+    require_contains(
+        ".github/workflows/ci.yml",
+        f"+refs/heads/{branch}:refs/remotes/origin/{branch}",
+        f"release train promotion verifier must fetch protected {branch} history for topology checks",
+    )
+require_contains(
+    ".github/workflows/ci.yml",
     '--head-sha "${PR_HEAD_SHA}"',
     "release train promotion verifier must pass the event head SHA without fetching PR head content",
 )


### PR DESCRIPTION
## Root cause

PR #671 is a trusted release-train PR from `staging` to `premain`, but the release-train promotion job checks out trusted `refs/heads/staging` at `fetch-depth: 1`. That preserves the alert #30 fix by avoiding PR-head code execution, but it leaves the protected branch checkout too shallow for `git merge-base --is-ancestor origin/premain origin/staging` to prove the valid topology.

## Security invariant

The gate still runs verifier code from trusted protected `refs/heads/staging` with `persist-credentials: false`. It does not check out or fetch ordinary PR-head code. The only additional fetch is full history for protected release refs: `staging`, `premain`, and `main`.

## What changed

- Unshallow the trusted release refs before the release-train verifier runs.
- Keep the verifier inputs based on protected refs and the event head SHA.
- Add workflow invariant coverage so the gate continues to fetch protected release history without reintroducing PR-head fetches.

## Validation

```text
git diff --check
PASS

bash -n scripts/verify-release-workflows.sh
PASS

bash scripts/verify-release-train-promotion.sh --self-test
release-train-promotion: positive staging → premain topology accepted
release-train-promotion: negative forged staging head rejected
release-train-promotion: self-test PASS

bash scripts/verify-release-workflows.sh
release-workflows: PASS

bash scripts/verify-ci-rubric-enforced.sh
ci-rubric: PASS
```

Focused shallow simulation from trusted `staging` only:

```text
checkout_head=62ac7fb127998079b264ccaf67c592482e0774dd
before_shallow=true
after_shallow=false
fetched_refs=origin,origin/main,origin/premain,origin/staging
release-train-promotion: PASS (staging → premain prerelease promotion; staging → premain)
```

Current PR #671 state before this fix PR: `Release train promotion gate` is failing; CodeQL/code scanning checks are passing and full rubric is skipped for the `premain` target.

## Next step

Merge this staging fix, then rerun PR #671's release-train promotion gate.