### PR TITLE
release: promote staging to premain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
 
   builds:
     name: Verify deterministic builds
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
       - staging
       - main
       - premain
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      run_full_rubric:
+        description: "Run Rubric (full gate set)"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -184,7 +190,7 @@ jobs:
 
   rubric:
     name: Rubric (full gate set)
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')
+    if: (github.event_name == 'workflow_dispatch' && (inputs.run_full_rubric == true || inputs.run_full_rubric == 'true')) || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -23,7 +23,7 @@ No branch may skip a leg of that cycle. `premain` only receives `staging`, `main
 
 Release automation is driven by Conventional Commits. `feat:` and `fix:` entries ship; `docs:`, `test:`, `chore:`, and `refactor:` do not trigger a release by themselves. Version state must remain aligned across `VERSION`, TypeScript and CDK package manifests and lockfiles, Python metadata, and both Release Please manifests.
 
-The full rubric runs only for PRs targeting `staging` and optional manual `workflow_dispatch` CI runs. Manual CI dispatch defaults to running the rubric; generated release-PR artifact sync dispatches CI with the full rubric disabled and waits only for release hygiene/build checks. `premain` and `main` run release hygiene, branch version sync, release-branch provenance, package build, and publish postcondition checks; they must not run the full rubric on release publish paths.
+The full rubric runs only for PRs targeting `staging` and optional manual `workflow_dispatch` CI runs. Manual CI dispatch defaults to running the rubric; generated release-PR artifact sync dispatches CI with the full rubric disabled and waits only for release hygiene/build checks. The standalone `Verify deterministic builds` CI job also runs only for PRs targeting `staging`; generated release PR sync must not require or wait for that skipped context. `premain` and `main` run release hygiene, branch version sync, release-branch provenance, package build, and publish postcondition checks; they must not run the full rubric or deterministic-build job on release publish paths.
 
 ## Full cycle checklist
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -23,7 +23,7 @@ No branch may skip a leg of that cycle. `premain` only receives `staging`, `main
 
 Release automation is driven by Conventional Commits. `feat:` and `fix:` entries ship; `docs:`, `test:`, `chore:`, and `refactor:` do not trigger a release by themselves. Version state must remain aligned across `VERSION`, TypeScript and CDK package manifests and lockfiles, Python metadata, and both Release Please manifests.
 
-The full rubric runs only for PRs targeting `staging` and optional manual `workflow_dispatch` CI runs. `premain` and `main` run release hygiene, branch version sync, release-branch provenance, package build, and publish postcondition checks; they must not run the full rubric on release publish paths.
+The full rubric runs only for PRs targeting `staging` and optional manual `workflow_dispatch` CI runs. Manual CI dispatch defaults to running the rubric; generated release-PR artifact sync dispatches CI with the full rubric disabled and waits only for release hygiene/build checks. `premain` and `main` run release hygiene, branch version sync, release-branch provenance, package build, and publish postcondition checks; they must not run the full rubric on release publish paths.
 
 ## Full cycle checklist
 
@@ -45,7 +45,7 @@ The full rubric runs only for PRs targeting `staging` and optional manual `workf
 - Open a PR from `staging` into `premain`.
 - Do not retarget the PR from another branch.
 - CI must run the release train promotion gate and branch version sync checks.
-- The prerelease Release Please workflow must create or update the release-candidate PR. A Release Please no-op is a failed RC gate.
+- The prerelease Release Please workflow must create or update the release-candidate PR. A Release Please no-op is a failed RC gate; annotated `VERSION` markers such as `# x-release-please-version` are ignored only after the leading RC semver is validated.
 - The release-candidate PR remains draft-locked while generated CDK artifacts are synchronized and required checks run.
 - Merge the release-candidate PR only after generated artifacts are in sync and all required checks are green.
 - The prerelease publisher creates immutable assets for the `vX.Y.Z-rc.N` GitHub Release.

--- a/scripts/run-release-please-pr.sh
+++ b/scripts/run-release-please-pr.sh
@@ -120,9 +120,24 @@ use_existing_open_release_pr() {
   return 0
 }
 
-if use_existing_open_release_pr "valid release PR already exists"; then
-  exit 0
-fi
+draft_lock_existing_open_release_pr_before_refresh() {
+  local pr_json
+  pr_json="$(detect_open_release_pr)"
+  if [[ -z "${pr_json}" ]]; then
+    return 0
+  fi
+
+  local pr_number
+  pr_number="$(jq -r '.number' <<<"${pr_json}")"
+  if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+    return 0
+  fi
+
+  draft_lock_release_pr "${pr_number}"
+  echo "release-please-pr: found open ${target_branch} release PR #${pr_number}; refreshing it through release-please"
+}
+
+draft_lock_existing_open_release_pr_before_refresh
 
 args=(
   -y

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -154,7 +154,7 @@ wait_for_required_checks() {
   local interval_seconds="${RELEASE_PR_CHECK_INTERVAL_SECONDS:-15}"
   local required_checks="${RELEASE_PR_READY_CHECKS:-}"
   if [[ -z "${required_checks}" ]]; then
-    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)\nRubric (full gate set)'
+    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)'
   fi
 
   local deadline=$((SECONDS + timeout_seconds))
@@ -258,7 +258,7 @@ wait_for_required_checks_to_start() {
   local interval_seconds="${RELEASE_PR_CHECK_INTERVAL_SECONDS:-15}"
   local required_checks="${RELEASE_PR_READY_CHECKS:-}"
   if [[ -z "${required_checks}" ]]; then
-    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)\nRubric (full gate set)'
+    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)'
   fi
 
   local deadline=$((SECONDS + timeout_seconds))
@@ -320,9 +320,14 @@ PY
 
 dispatch_required_checks() {
   local required_check_workflow="${RELEASE_PR_CHECK_WORKFLOW:-ci.yml}"
+  local dispatch_args=(workflow run "${required_check_workflow}" --ref "${release_branch}")
 
-  echo "sync-release-pr-generated: dispatching ${required_check_workflow} for ${release_branch}"
-  if ! gh workflow run "${required_check_workflow}" --ref "${release_branch}"; then
+  if [[ "${required_check_workflow}" == "ci.yml" ]]; then
+    dispatch_args+=(--raw-field run_full_rubric=false)
+  fi
+
+  echo "sync-release-pr-generated: dispatching ${required_check_workflow} for ${release_branch} with full rubric disabled"
+  if ! gh "${dispatch_args[@]}"; then
     echo "sync-release-pr-generated: FAIL (could not dispatch ${required_check_workflow} for ${release_branch})"
     exit 1
   fi

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -154,7 +154,7 @@ wait_for_required_checks() {
   local interval_seconds="${RELEASE_PR_CHECK_INTERVAL_SECONDS:-15}"
   local required_checks="${RELEASE_PR_READY_CHECKS:-}"
   if [[ -z "${required_checks}" ]]; then
-    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)'
+    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nContract tests (fixtures)'
   fi
 
   local deadline=$((SECONDS + timeout_seconds))
@@ -258,7 +258,7 @@ wait_for_required_checks_to_start() {
   local interval_seconds="${RELEASE_PR_CHECK_INTERVAL_SECONDS:-15}"
   local required_checks="${RELEASE_PR_READY_CHECKS:-}"
   if [[ -z "${required_checks}" ]]; then
-    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nVerify deterministic builds\nContract tests (fixtures)'
+    required_checks=$'Version alignment\nGo (test + vet)\nTypeScript (npm pack)\nPython (build wheel + sdist)\nContract tests (fixtures)'
   fi
 
   local deadline=$((SECONDS + timeout_seconds))

--- a/scripts/verify-ci-rubric-enforced.sh
+++ b/scripts/verify-ci-rubric-enforced.sh
@@ -38,10 +38,19 @@ require_contains \
   "${ci}" \
   "if: (github.event_name == 'workflow_dispatch' && (inputs.run_full_rubric == true || inputs.run_full_rubric == 'true')) || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')" \
   "full rubric must run only for PRs targeting staging plus opted-in manual dispatch"
+require_contains "${ci}" "  builds:" "CI must define the standalone deterministic-build job"
+require_contains "${ci}" "name: Verify deterministic builds" \
+  "CI must keep the deterministic-build job name stable for branch protection visibility"
+require_contains \
+  "${ci}" \
+  "if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'" \
+  "deterministic builds must run only for PRs targeting staging"
 require_contains "scripts/sync-release-pr-generated.sh" "--raw-field run_full_rubric=false" \
   "automated generated release PR CI dispatch must opt out of the full rubric"
 require_not_contains "scripts/sync-release-pr-generated.sh" "Rubric (full gate set)" \
   "generated release PR required checks must exclude the full rubric"
+require_not_contains "scripts/sync-release-pr-generated.sh" "Verify deterministic builds" \
+  "generated release PR required checks must exclude skipped deterministic builds"
 
 for release_path in \
   ".github/workflows/prerelease.yml" \
@@ -49,6 +58,10 @@ for release_path in \
   "scripts/publish-release-assets.sh" \
   "scripts/render-release-notes.sh"; do
   require_not_contains "${release_path}" "make rubric" "full rubric must not run in release build/publish paths"
+  require_not_contains "${release_path}" "Verify deterministic builds" \
+    "deterministic builds must not be a release build/publish path"
+  require_not_contains "${release_path}" "scripts/verify-builds.sh" \
+    "release build/publish paths must not run deterministic builds"
 done
 
 require_contains ".github/workflows/prerelease.yml" "scripts/verify-release-publish-postcondition.sh prerelease" \

--- a/scripts/verify-ci-rubric-enforced.sh
+++ b/scripts/verify-ci-rubric-enforced.sh
@@ -13,7 +13,7 @@ require_contains() {
   local needle="$2"
   local description="$3"
 
-  grep -Fq "${needle}" "${path}" || fail "${description}; missing ${needle} in ${path}"
+  grep -Fq -- "${needle}" "${path}" || fail "${description}; missing ${needle} in ${path}"
 }
 
 require_not_contains() {
@@ -21,7 +21,7 @@ require_not_contains() {
   local needle="$2"
   local description="$3"
 
-  if grep -Fq "${needle}" "${path}"; then
+  if grep -Fq -- "${needle}" "${path}"; then
     fail "${description}; unexpected ${needle} in ${path}"
   fi
 }
@@ -30,10 +30,18 @@ ci=".github/workflows/ci.yml"
 
 require_contains "${ci}" "  rubric:" "CI must define the full rubric job"
 require_contains "${ci}" "run: make rubric" "CI rubric job must run make rubric"
+require_contains "${ci}" "run_full_rubric:" \
+  "manual CI dispatch must expose an explicit full-rubric toggle"
+require_contains "${ci}" "default: true" \
+  "manual CI dispatch must continue to run the full rubric by default"
 require_contains \
   "${ci}" \
-  "if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')" \
-  "full rubric must run only for PRs targeting staging plus manual dispatch"
+  "if: (github.event_name == 'workflow_dispatch' && (inputs.run_full_rubric == true || inputs.run_full_rubric == 'true')) || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')" \
+  "full rubric must run only for PRs targeting staging plus opted-in manual dispatch"
+require_contains "scripts/sync-release-pr-generated.sh" "--raw-field run_full_rubric=false" \
+  "automated generated release PR CI dispatch must opt out of the full rubric"
+require_not_contains "scripts/sync-release-pr-generated.sh" "Rubric (full gate set)" \
+  "generated release PR required checks must exclude the full rubric"
 
 for release_path in \
   ".github/workflows/prerelease.yml" \

--- a/scripts/verify-release-pr-postcondition.sh
+++ b/scripts/verify-release-pr-postcondition.sh
@@ -3,6 +3,85 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+version_line_re='^[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?)[[:space:]]*(#.*)?$'
+rc_version_re='^[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$'
+stable_version_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+parse_version_value() {
+  local raw="$1"
+
+  raw="${raw//$'\r'/}"
+  raw="${raw//$'\n'/}"
+  if [[ "${raw}" =~ ${version_line_re} ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  return 1
+}
+
+is_rc_version() {
+  [[ "$1" =~ ${rc_version_re} ]]
+}
+
+is_stable_version() {
+  [[ "$1" =~ ${stable_version_re} ]]
+}
+
+self_test_version_parser() {
+  local parsed
+
+  parsed="$(parse_version_value '1.12.2-rc # x-release-please-version')"
+  [[ "${parsed}" == "1.12.2-rc" ]] || {
+    echo "release-pr-postcondition: FAIL (self-test annotated RC parsed as ${parsed})" >&2
+    return 1
+  }
+  is_rc_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated RC was not accepted as RC)" >&2
+    return 1
+  }
+  ! is_stable_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated RC was accepted as stable)" >&2
+    return 1
+  }
+
+  parsed="$(parse_version_value '1.12.2-rc.7 # x-release-please-version')"
+  [[ "${parsed}" == "1.12.2-rc.7" ]] || {
+    echo "release-pr-postcondition: FAIL (self-test numbered annotated RC parsed as ${parsed})" >&2
+    return 1
+  }
+  is_rc_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test numbered annotated RC was not accepted as RC)" >&2
+    return 1
+  }
+
+  parsed="$(parse_version_value '1.12.2 # x-release-please-version')"
+  [[ "${parsed}" == "1.12.2" ]] || {
+    echo "release-pr-postcondition: FAIL (self-test annotated stable parsed as ${parsed})" >&2
+    return 1
+  }
+  is_stable_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated stable was not accepted as stable)" >&2
+    return 1
+  }
+  ! is_rc_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated stable was accepted as RC)" >&2
+    return 1
+  }
+
+  if parse_version_value '1.12.2-rcx # x-release-please-version' >/dev/null; then
+    echo "release-pr-postcondition: FAIL (self-test malformed RC was parsed)" >&2
+    return 1
+  fi
+
+  echo "release-pr-postcondition: PASS (self-test VERSION parser; annotated RC accepted and stable/RC mismatches rejected)"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test_version_parser
+  exit $?
+fi
+
 channel="${1:-}"
 case "${channel}" in
   prerelease)
@@ -58,14 +137,17 @@ print(urllib.parse.quote(sys.argv[1], safe=""))
 PY
 )"
 version_b64="$(gh api "repos/${repository}/contents/VERSION?ref=${encoded_ref}" --jq '.content // ""' | tr -d '\n')"
-version="$(printf '%s' "${version_b64}" | base64 --decode | tr -d '\r\n')"
+version_raw="$(printf '%s' "${version_b64}" | base64 --decode | tr -d '\r\n')"
+if ! version="$(parse_version_value "${version_raw}")"; then
+  echo "release-pr-postcondition: FAIL (generated ${base_branch} release PR #${pr_number} VERSION ${version_raw} does not start with a supported stable/RC semver value)" >&2
+  exit 1
+fi
 
 rc_re='(^|[^0-9A-Za-z.])v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?([^0-9A-Za-z.]|$)'
-stable_re='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 case "${channel}" in
   prerelease)
-    if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
+    if ! is_rc_version "${version}"; then
       echo "release-pr-postcondition: FAIL (generated premain release PR #${pr_number} VERSION ${version} is not RC-shaped)" >&2
       exit 1
     fi
@@ -79,7 +161,7 @@ case "${channel}" in
       echo "release-pr-postcondition: FAIL (generated main release PR #${pr_number} VERSION ${version} is RC-shaped; main owns stable releases only)" >&2
       exit 1
     fi
-    if ! [[ "${version}" =~ ${stable_re} ]]; then
+    if ! is_stable_version "${version}"; then
       echo "release-pr-postcondition: FAIL (generated main release PR #${pr_number} VERSION ${version} is not stable semver)" >&2
       exit 1
     fi

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -341,6 +341,16 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
+    "name: Verify deterministic builds",
+    "CI must keep the standalone deterministic-build job name stable",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'",
+    "deterministic builds must run only on staging PRs",
+)
+require_contains(
+    ".github/workflows/ci.yml",
     "Release train promotion gate",
     "CI must gate release train promotion PRs before release state can advance",
 )
@@ -562,6 +572,11 @@ require_not_contains(
     "scripts/sync-release-pr-generated.sh",
     "Rubric (full gate set)",
     "release PR sync required checks must exclude the full rubric context",
+)
+require_not_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "Verify deterministic builds",
+    "release PR sync required checks must exclude skipped deterministic-build contexts",
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 python3 - <<'PY'
+import subprocess
 from pathlib import Path
 
 
@@ -325,8 +326,18 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
-    "workflow_dispatch: {}",
-    "CI must be dispatchable for bot-authored release PR branch updates",
+    "workflow_dispatch:\n    inputs:\n      run_full_rubric:",
+    "CI must be dispatchable for bot-authored release PR branch updates with explicit rubric control",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "default: true",
+    "manual CI workflow_dispatch must continue to run the full rubric by default",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "if: (github.event_name == 'workflow_dispatch' && (inputs.run_full_rubric == true || inputs.run_full_rubric == 'true')) || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')",
+    "full rubric must run only on staging PRs and opted-in manual dispatch",
 )
 require_contains(
     ".github/workflows/ci.yml",
@@ -483,11 +494,16 @@ for workflow in (".github/workflows/prerelease-pr.yml", ".github/workflows/relea
         "scripts/run-release-please-pr.sh",
         "release PR workflows must create release-please PRs through the stale-state-tolerant wrapper",
     )
+require_not_contains(
+    "scripts/run-release-please-pr.sh",
+    'valid release PR already exists',
+    "release-please PR generation must not short-circuit before release-please can refresh stale open PRs",
+)
 require_order(
     "scripts/run-release-please-pr.sh",
-    'if use_existing_open_release_pr "valid release PR already exists"; then',
+    "draft_lock_existing_open_release_pr_before_refresh",
     'npx "${args[@]}"',
-    "release-please PR generation must tolerate already-open draft release PRs before invoking release-please",
+    "release-please PR generation may draft-lock already-open PRs but must still invoke release-please",
 )
 require_order(
     "scripts/run-release-please-pr.sh",
@@ -526,6 +542,26 @@ require_contains(
     ".github/workflows/release-pr.yml",
     "scripts/verify-release-pr-postcondition.sh stable",
     "stable Release PR generation must fail closed when release-please no-ops",
+)
+require_contains(
+    "scripts/verify-release-pr-postcondition.sh",
+    "parse_version_value",
+    "release PR postcondition verifier must parse annotated VERSION values before shape validation",
+)
+require_contains(
+    "scripts/verify-release-pr-postcondition.sh",
+    "1.12.2-rc # x-release-please-version",
+    "release PR postcondition verifier self-test must cover annotated RC VERSION values",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "--raw-field run_full_rubric=false",
+    "automated release PR CI dispatch must disable the full rubric",
+)
+require_not_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "Rubric (full gate set)",
+    "release PR sync required checks must exclude the full rubric context",
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
@@ -646,6 +682,8 @@ for forbidden in (
         forbidden,
         "release PR sync must not self-attest protected contexts",
     )
+
+subprocess.run(["bash", "scripts/verify-release-pr-postcondition.sh", "--self-test"], check=True)
 
 print("release-workflows: PASS")
 PY


### PR DESCRIPTION
## Summary

Promote current `staging` to `premain` for the next AppTheory release-candidate cycle.

This promotion includes the AppTheory release-cycle normalization already merged to `staging`:

- TableTheory v1.9.4 / Go 1.26.4 alignment from the prior staging work.
- Release PR hygiene fixes so generated RC/stable PRs refresh instead of stale-skipping.
- Premain ancestry repair from PR #675 so `staging` contains current `premain` before promotion.
- CI cost normalization: full rubric and deterministic builds are staging-PR-only; premain/main release paths use release hygiene/build checks.

## Validation before opening

- `origin/premain` is an ancestor of `origin/staging`.
- `origin/main` is an ancestor of `origin/staging`.
- `bash scripts/verify-release-train-promotion.sh --base premain --head staging ...` passed.
- `origin/premain..origin/staging` contains release-eligible `fix:` commits, so this promotion should create/update the RC release PR rather than silently no-op.

## Release lane

This is the required AppTheory lane step:

`staging -> premain -> RC PR/publish -> premain -> main -> stable PR/publish -> main -> staging`

Do not merge the generated RC release PR until it has refreshed from this premain head, artifact sync has completed, and required release checks are green.
