### PR TITLE
chore: adopt materialized agent model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ gov-infra/evidence/py-coverage-summary.txt
 gov-infra/evidence/py-coverage.data
 /reference/
 .codex/
+.claude/
+.agents/
+.mcp.json
+GEMINI.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+# AppTheory Steward Bootstrap
+
+This repository's stewardship agent is the published `apptheory` Theory Cloud namespace agent. It is materialized into git-ignored host installs under `.codex/`, `.claude/`, and `.agents/`; the namespace is the source of truth, so these directories are not hand-edited and should be re-materialized to change agent behavior. See `.codex/steward.md` for the steward's full identity and skills.
+
 # Repository Guidelines
 
 ## Project Structure & Module Organization


### PR DESCRIPTION
## Summary
- Prepends an AppTheory steward bootstrap note to `AGENTS.md` while preserving the existing repository guidelines and release-train policy.
- Adds gitignore entries for materialized host agent installs and local MCP/Gemini files.

## Validation
- `git merge-base --is-ancestor origin/main HEAD`
- `make test`

No merge performed.