### PR TITLE
feat(mcp): add MCP tool lifecycle wrapper (THE-2034/THE-2047/THE-2048/THE-2049)

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2243,6 +2243,20 @@ const TaskSupportOptional TaskSupport = "optional"
 
 const TaskSupportRequired TaskSupport = "required"
 
+const ToolLifecycleOutcomeContextCanceled ToolLifecycleOutcome = "context_canceled"
+
+const ToolLifecycleOutcomeHandledError ToolLifecycleOutcome = "handled_error"
+
+const ToolLifecycleOutcomeInvalidParams ToolLifecycleOutcome = "invalid_params"
+
+const ToolLifecycleOutcomePanic ToolLifecycleOutcome = "panic"
+
+const ToolLifecycleOutcomeSuccess ToolLifecycleOutcome = "success"
+
+const ToolLifecycleOutcomeTimeout ToolLifecycleOutcome = "timeout"
+
+const ToolLifecycleOutcomeUnhandledError ToolLifecycleOutcome = "unhandled_error"
+
 var ErrEventNotFound = errors.New("event not found")
 
 var ErrSessionNotFound = errors.New("session not found")
@@ -2620,6 +2634,39 @@ type ToolExecution struct {
 
 type ToolHandler func(context.Context, json.RawMessage) (*ToolResult, error)
 
+type ToolLifecycleFinish struct {
+	Name              string               `json:"name"`
+	StartedAt         time.Time            `json:"startedAt"`
+	FinishedAt        time.Time            `json:"finishedAt"`
+	Duration          time.Duration        `json:"duration"`
+	Outcome           ToolLifecycleOutcome `json:"outcome"`
+	JSONRPCErrorCode  int                  `json:"jsonrpcErrorCode,omitempty"`
+	ResultMarkedError bool                 `json:"resultMarkedError,omitempty"`
+}
+
+type ToolLifecycleOptions[Args any] struct {
+	Name        string
+	Timeout     time.Duration
+	NoArgs      bool
+	StrictJSON  bool
+	Validate    func(context.Context, Args) error
+	HandleError func(context.Context, error) (*ToolResult, bool)
+	Telemetry   ToolLifecycleTelemetry
+	Clock       apptheory.Clock
+}
+
+type ToolLifecycleOutcome string
+
+type ToolLifecycleStart struct {
+	Name      string    `json:"name"`
+	StartedAt time.Time `json:"startedAt"`
+}
+
+type ToolLifecycleTelemetry struct {
+	Start  func(context.Context, ToolLifecycleStart)
+	Finish func(context.Context, ToolLifecycleFinish)
+}
+
 type ToolRegistry struct {
 	mu    sync.RWMutex
 	tools []registeredTool
@@ -2693,6 +2740,13 @@ func WithStreamIDGenerator(apptheory.IDGenerator) MemoryStreamStoreOption
 func WithStreamStore(StreamStore) ServerOption
 
 func WithTaskRuntime(TaskRuntimeOptions) ServerOption
+
+func WrapStreamingTool[Args any](
+	ToolLifecycleOptions[Args],
+	func(context.Context, Args, func(SSEEvent)) (*ToolResult, error),
+) StreamingToolHandler
+
+func WrapTool[Args any](ToolLifecycleOptions[Args], func(context.Context, Args) (*ToolResult, error)) ToolHandler
 
 func (*DynamoSessionStore) Delete(context.Context, string) error
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -195,6 +195,10 @@ All three conditions must hold:
 Example:
 
 ```go
+type slowReportArgs struct {
+  ReportID string `json:"reportId"`
+}
+
 srv := mcp.NewServer("my-mcp-server", "dev",
   mcp.WithTaskRuntime(mcp.TaskRuntimeOptions{
     Store: mcp.NewDynamoTaskStore(db),
@@ -205,8 +209,15 @@ _ = srv.Registry().RegisterTool(mcp.ToolDef{
   Name:        "slow-report",
   Description: "Generate a report asynchronously.",
   Execution:   &mcp.ToolExecution{TaskSupport: mcp.TaskSupportOptional},
-  InputSchema: json.RawMessage(`{"type":"object"}`),
-}, runSlowReport)
+  InputSchema: json.RawMessage(`{
+    "type":"object",
+    "properties":{"reportId":{"type":"string"}},
+    "required":["reportId"]
+  }`),
+}, mcp.WrapTool(mcp.ToolLifecycleOptions[slowReportArgs]{
+  Name:       "slow-report",
+  StrictJSON: true,
+}, runSlowReport))
 ```
 
 Tool support is fail-closed:
@@ -317,9 +328,14 @@ fallback hook.
 
 ## Tools
 
-Register tools on the tool registry:
+Register tools on the tool registry. Production tools should use the lifecycle wrapper and then register the wrapped
+handler; the wrapper is not a second registry or dispatcher.
 
 ```go
+type echoArgs struct {
+  Message string `json:"message"`
+}
+
 _ = srv.Registry().RegisterTool(mcp.ToolDef{
   Name:        "echo",
   Description: "Echo back the provided message.",
@@ -328,16 +344,42 @@ _ = srv.Registry().RegisterTool(mcp.ToolDef{
     "properties": { "message": { "type":"string" } },
     "required": ["message"]
   }`),
-}, func(ctx context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
-  var in struct{ Message string `json:"message"` }
-  if err := json.Unmarshal(args, &in); err != nil {
-    return nil, err
-  }
+}, mcp.WrapTool(mcp.ToolLifecycleOptions[echoArgs]{
+  Name:       "echo",
+  StrictJSON: true,
+  Validate: func(ctx context.Context, in echoArgs) error {
+    if strings.TrimSpace(in.Message) == "" {
+      return errors.New("message is required")
+    }
+    return nil
+  },
+}, func(ctx context.Context, in echoArgs) (*mcp.ToolResult, error) {
   return &mcp.ToolResult{
     Content: []mcp.ContentBlock{{Type: "text", Text: in.Message}},
   }, nil
-})
+}))
 ```
+
+### Tool lifecycle wrapper
+
+`mcp.WrapTool[Args]` and `mcp.WrapStreamingTool[Args]` are the blessed lifecycle adapters for product MCP tools. They
+compose over `RegisterTool` and `RegisterStreamingTool`; buffered JSON calls, Streamable HTTP SSE calls, and task
+execution still route through `ToolRegistry.Call` / `ToolRegistry.CallStreaming`.
+
+Use `mcp.ToolLifecycleOptions[Args]` to keep lifecycle behavior in one place:
+
+- `Name`: safe tool name used in lifecycle telemetry
+- `NoArgs`: accepts omitted, `null`, or `{}` arguments and rejects extra fields
+- `StrictJSON`: rejects unknown fields and trailing JSON values for typed tool arguments
+- `Validate`: maps validation failures to JSON-RPC invalid params with a sanitized message
+- `HandleError`: maps expected product errors to a safe `ToolResult{IsError:true}` when appropriate
+- `Timeout`: derives a per-tool context timeout and maps deadline expiry to AppTheory's existing safe timeout error
+- `Telemetry`: emits start/finish hooks with name, timestamps, duration, outcome, JSON-RPC code, and `isError` status
+- `Clock`: supplies deterministic time for telemetry tests
+
+Telemetry payloads intentionally exclude raw arguments, bearer tokens, raw unhandled errors, and panic values. Validation
+and no-arg failures return JSON-RPC `CodeInvalidParams`; unhandled errors and panics return sanitized internal errors.
+Handled product failures should be converted to safe tool results through `HandleError`.
 
 `ToolDef` exposes more than the minimal name + schema shape:
 
@@ -383,16 +425,23 @@ For streaming tools, AppTheory responds as SSE:
 Register a streaming tool with `RegisterStreamingTool`:
 
 ```go
+type longTaskArgs struct {
+  Steps int `json:"steps"`
+}
+
 _ = srv.Registry().RegisterStreamingTool(mcp.ToolDef{
   Name:        "long_task",
   Description: "Example long-running task with progress.",
   InputSchema: json.RawMessage(`{"type":"object"}`),
-}, func(ctx context.Context, args json.RawMessage, emit func(mcp.SSEEvent)) (*mcp.ToolResult, error) {
+}, mcp.WrapStreamingTool(mcp.ToolLifecycleOptions[longTaskArgs]{
+  Name:       "long_task",
+  StrictJSON: true,
+}, func(ctx context.Context, args longTaskArgs, emit func(mcp.SSEEvent)) (*mcp.ToolResult, error) {
   emit(mcp.SSEEvent{Data: map[string]any{"progress": 1, "total": 10, "message": "started"}})
   // ... do work ...
   emit(mcp.SSEEvent{Data: map[string]any{"progress": 10, "total": 10, "message": "done"}})
   return &mcp.ToolResult{Content: []mcp.ContentBlock{{Type: "text", Text: "ok"}}}, nil
-})
+}))
 ```
 
 Important deployment note:

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -30,17 +30,20 @@ import (
 func buildApp() *apptheory.App {
   srv := mcp.NewServer("ExampleServer", "dev")
 
+  type echoArgs struct {
+    Message string `json:"message"`
+  }
+
   _ = srv.Registry().RegisterTool(mcp.ToolDef{
     Name: "echo",
     Description: "Echo back the provided message.",
     InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`),
-  }, func(ctx context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
-    var in struct{ Message string `json:"message"` }
-    if err := json.Unmarshal(args, &in); err != nil {
-      return nil, err
-    }
+  }, mcp.WrapTool(mcp.ToolLifecycleOptions[echoArgs]{
+    Name:       "echo",
+    StrictJSON: true,
+  }, func(ctx context.Context, in echoArgs) (*mcp.ToolResult, error) {
     return &mcp.ToolResult{Content: []mcp.ContentBlock{{Type: "text", Text: in.Message}}}, nil
-  })
+  }))
 
   app := apptheory.New()
   h := srv.Handler()

--- a/examples/mcp/resumable-sse/main.go
+++ b/examples/mcp/resumable-sse/main.go
@@ -11,6 +11,10 @@ import (
 	"github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
+type countdownArgs struct {
+	Steps int `json:"steps"`
+}
+
 func buildServer() *mcp.Server {
 	srv := mcp.NewServer("resumable-sse", "dev",
 		// On Lambda, cap the initial keepalive listener before the function deadline.
@@ -25,11 +29,10 @@ func buildServer() *mcp.Server {
 		Name:        "countdown",
 		Description: "Emits progress events then returns a result.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"steps":{"type":"integer","minimum":1}}}`),
-	}, func(ctx context.Context, args json.RawMessage, emit func(mcp.SSEEvent)) (*mcp.ToolResult, error) {
-		var in struct {
-			Steps int `json:"steps"`
-		}
-		_ = json.Unmarshal(args, &in)
+	}, mcp.WrapStreamingTool(mcp.ToolLifecycleOptions[countdownArgs]{
+		Name:       "countdown",
+		StrictJSON: true,
+	}, func(ctx context.Context, in countdownArgs, emit func(mcp.SSEEvent)) (*mcp.ToolResult, error) {
 		if in.Steps <= 0 {
 			in.Steps = 3
 		}
@@ -52,7 +55,7 @@ func buildServer() *mcp.Server {
 		return &mcp.ToolResult{
 			Content: []mcp.ContentBlock{{Type: "text", Text: "done"}},
 		}, nil
-	})
+	}))
 
 	return srv
 }

--- a/examples/mcp/tools-only/main.go
+++ b/examples/mcp/tools-only/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"github.com/theory-cloud/apptheory/runtime/mcp"
 )
+
+type echoArgs struct {
+	Message string `json:"message"`
+}
 
 func buildServer() *mcp.Server {
 	srv := mcp.NewServer("tools-only", "dev")
@@ -16,17 +22,20 @@ func buildServer() *mcp.Server {
 		Name:        "echo",
 		Description: "Echo back the provided message.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`),
-	}, func(_ context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
-		var in struct {
-			Message string `json:"message"`
-		}
-		if err := json.Unmarshal(args, &in); err != nil {
-			return nil, err
-		}
+	}, mcp.WrapTool(mcp.ToolLifecycleOptions[echoArgs]{
+		Name:       "echo",
+		StrictJSON: true,
+		Validate: func(_ context.Context, args echoArgs) error {
+			if strings.TrimSpace(args.Message) == "" {
+				return errors.New("message is required")
+			}
+			return nil
+		},
+	}, func(_ context.Context, in echoArgs) (*mcp.ToolResult, error) {
 		return &mcp.ToolResult{
 			Content: []mcp.ContentBlock{{Type: "text", Text: in.Message}},
 		}, nil
-	})
+	}))
 
 	return srv
 }

--- a/examples/mcp/tools-resources-prompts/main.go
+++ b/examples/mcp/tools-resources-prompts/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"github.com/theory-cloud/apptheory/runtime/mcp"
 )
+
+type echoArgs struct {
+	Message string `json:"message"`
+}
 
 func buildServer() *mcp.Server {
 	srv := mcp.NewServer("tools-resources-prompts", "dev")
@@ -16,17 +22,20 @@ func buildServer() *mcp.Server {
 		Name:        "echo",
 		Description: "Echo back the provided message.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`),
-	}, func(_ context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
-		var in struct {
-			Message string `json:"message"`
-		}
-		if err := json.Unmarshal(args, &in); err != nil {
-			return nil, err
-		}
+	}, mcp.WrapTool(mcp.ToolLifecycleOptions[echoArgs]{
+		Name:       "echo",
+		StrictJSON: true,
+		Validate: func(_ context.Context, args echoArgs) error {
+			if strings.TrimSpace(args.Message) == "" {
+				return errors.New("message is required")
+			}
+			return nil
+		},
+	}, func(_ context.Context, in echoArgs) (*mcp.ToolResult, error) {
 		return &mcp.ToolResult{
 			Content: []mcp.ContentBlock{{Type: "text", Text: in.Message}},
 		}, nil
-	})
+	}))
 
 	_ = srv.Resources().RegisterResource(mcp.ResourceDef{
 		URI:      "file://hello.txt",

--- a/runtime/mcp/lifecycle.go
+++ b/runtime/mcp/lifecycle.go
@@ -1,0 +1,324 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+const (
+	lifecycleInvalidToolArgumentsMessage = "Invalid params: invalid tool arguments"
+	lifecycleMissingToolArgumentsMessage = "Invalid params: missing tool arguments"
+	lifecycleNoArgsMessage               = "Invalid params: tool accepts no arguments"
+	lifecycleValidationMessage           = "Invalid params: validation failed"
+	lifecycleInternalMessage             = "internal error"
+)
+
+var (
+	errToolLifecycleInvalidArguments = errors.New(lifecycleInvalidToolArgumentsMessage)
+	errToolLifecycleMissingArguments = errors.New(lifecycleMissingToolArgumentsMessage)
+	errToolLifecycleNoArgs           = errors.New(lifecycleNoArgsMessage)
+	errToolLifecycleValidation       = errors.New(lifecycleValidationMessage)
+	errToolLifecycleInternal         = errors.New(lifecycleInternalMessage)
+)
+
+// ToolLifecycleOutcome describes the sanitized result class for a wrapped MCP
+// tool invocation. Outcomes intentionally carry no raw tool arguments, bearer
+// tokens, panic values, or unhandled error text.
+type ToolLifecycleOutcome string
+
+const (
+	ToolLifecycleOutcomeSuccess         ToolLifecycleOutcome = "success"
+	ToolLifecycleOutcomeInvalidParams   ToolLifecycleOutcome = "invalid_params"
+	ToolLifecycleOutcomeHandledError    ToolLifecycleOutcome = "handled_error"
+	ToolLifecycleOutcomeTimeout         ToolLifecycleOutcome = "timeout"
+	ToolLifecycleOutcomePanic           ToolLifecycleOutcome = "panic"
+	ToolLifecycleOutcomeUnhandledError  ToolLifecycleOutcome = "unhandled_error"
+	ToolLifecycleOutcomeContextCanceled ToolLifecycleOutcome = "context_canceled"
+)
+
+// ToolLifecycleStart is emitted before a wrapped MCP tool handler runs. It is a
+// sanitized telemetry payload and intentionally excludes raw arguments.
+type ToolLifecycleStart struct {
+	Name      string    `json:"name"`
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// ToolLifecycleFinish is emitted after a wrapped MCP tool handler finishes. It
+// is a sanitized telemetry payload and intentionally excludes raw arguments,
+// bearer tokens, panic values, and unhandled error text.
+type ToolLifecycleFinish struct {
+	Name              string               `json:"name"`
+	StartedAt         time.Time            `json:"startedAt"`
+	FinishedAt        time.Time            `json:"finishedAt"`
+	Duration          time.Duration        `json:"duration"`
+	Outcome           ToolLifecycleOutcome `json:"outcome"`
+	JSONRPCErrorCode  int                  `json:"jsonrpcErrorCode,omitempty"`
+	ResultMarkedError bool                 `json:"resultMarkedError,omitempty"`
+}
+
+// ToolLifecycleTelemetry configures sanitized lifecycle hooks for wrapped MCP
+// tool handlers. Hook payloads are deliberately small and safe for logs or
+// metrics; raw request arguments and raw error values are never supplied.
+type ToolLifecycleTelemetry struct {
+	Start  func(context.Context, ToolLifecycleStart)
+	Finish func(context.Context, ToolLifecycleFinish)
+}
+
+// ToolLifecycleOptions configures WrapTool and WrapStreamingTool. The wrapper is
+// a handler adapter only: callers still register the returned handler through
+// RegisterTool or RegisterStreamingTool, so all buffered, streaming, and task
+// execution stays on the single registry dispatch path.
+type ToolLifecycleOptions[Args any] struct {
+	Name        string
+	Timeout     time.Duration
+	NoArgs      bool
+	StrictJSON  bool
+	Validate    func(context.Context, Args) error
+	HandleError func(context.Context, error) (*ToolResult, bool)
+	Telemetry   ToolLifecycleTelemetry
+	Clock       apptheory.Clock
+}
+
+// WrapTool adapts a typed MCP tool handler to the raw ToolHandler contract while
+// applying one lifecycle policy for argument binding, validation, timeout,
+// handled product failures, sanitized unhandled failures, panic recovery, and
+// telemetry.
+func WrapTool[Args any](options ToolLifecycleOptions[Args], handler func(context.Context, Args) (*ToolResult, error)) ToolHandler {
+	return func(ctx context.Context, raw json.RawMessage) (result *ToolResult, err error) {
+		return runToolLifecycle(ctx, raw, options, func(runCtx context.Context, args Args) (*ToolResult, error) {
+			return handler(runCtx, args)
+		})
+	}
+}
+
+// WrapStreamingTool adapts a typed MCP streaming tool handler to the raw
+// StreamingToolHandler contract while applying the same lifecycle policy as
+// WrapTool. It remains a registration-time adapter; streaming dispatch still
+// goes through ToolRegistry.CallStreaming.
+func WrapStreamingTool[Args any](
+	options ToolLifecycleOptions[Args],
+	handler func(context.Context, Args, func(SSEEvent)) (*ToolResult, error),
+) StreamingToolHandler {
+	return func(ctx context.Context, raw json.RawMessage, emit func(SSEEvent)) (result *ToolResult, err error) {
+		return runToolLifecycle(ctx, raw, options, func(runCtx context.Context, args Args) (*ToolResult, error) {
+			return handler(runCtx, args, emit)
+		})
+	}
+}
+
+func runToolLifecycle[Args any](
+	ctx context.Context,
+	raw json.RawMessage,
+	options ToolLifecycleOptions[Args],
+	handler func(context.Context, Args) (*ToolResult, error),
+) (result *ToolResult, err error) {
+	clock := options.Clock
+	if clock == nil {
+		clock = apptheory.RealClock{}
+	}
+
+	startedAt := clock.Now().UTC()
+	if options.Telemetry.Start != nil {
+		callToolLifecycleStart(ctx, options.Telemetry.Start, ToolLifecycleStart{Name: options.Name, StartedAt: startedAt})
+	}
+
+	outcome := ToolLifecycleOutcomeSuccess
+	jsonrpcCode := 0
+	resultMarkedError := false
+	telemetryCtx := ctx
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			outcome = ToolLifecycleOutcomePanic
+			jsonrpcCode = CodeInternalError
+			result = nil
+			err = lifecycleInternalError()
+		}
+
+		if options.Telemetry.Finish != nil {
+			finishedAt := clock.Now().UTC()
+			duration := finishedAt.Sub(startedAt)
+			if duration < 0 {
+				duration = 0
+			}
+			callToolLifecycleFinish(telemetryCtx, options.Telemetry.Finish, ToolLifecycleFinish{
+				Name:              options.Name,
+				StartedAt:         startedAt,
+				FinishedAt:        finishedAt,
+				Duration:          duration,
+				Outcome:           outcome,
+				JSONRPCErrorCode:  jsonrpcCode,
+				ResultMarkedError: resultMarkedError,
+			})
+		}
+	}()
+
+	args, bindErr := bindToolLifecycleArgs(ctx, raw, options)
+	if bindErr != nil {
+		outcome = ToolLifecycleOutcomeInvalidParams
+		jsonrpcCode = CodeInvalidParams
+		return nil, bindErr
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if options.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, options.Timeout)
+	}
+	defer cancel()
+	telemetryCtx = runCtx
+
+	result, err = handler(runCtx, args)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || runCtx.Err() == context.DeadlineExceeded {
+			outcome = ToolLifecycleOutcomeTimeout
+			jsonrpcCode = CodeServerError
+			return nil, context.DeadlineExceeded
+		}
+		if errors.Is(err, context.Canceled) || runCtx.Err() == context.Canceled {
+			outcome = ToolLifecycleOutcomeContextCanceled
+			jsonrpcCode = CodeServerError
+			return nil, context.Canceled
+		}
+		if options.HandleError != nil {
+			if handled, ok := options.HandleError(runCtx, err); ok {
+				outcome = ToolLifecycleOutcomeHandledError
+				if handled == nil {
+					handled = &ToolResult{IsError: true}
+				}
+				if handled.IsError {
+					resultMarkedError = true
+				}
+				return handled, nil
+			}
+		}
+		outcome = ToolLifecycleOutcomeUnhandledError
+		jsonrpcCode = CodeInternalError
+		return nil, lifecycleInternalError()
+	}
+	if runCtx.Err() == context.DeadlineExceeded {
+		outcome = ToolLifecycleOutcomeTimeout
+		jsonrpcCode = CodeServerError
+		return nil, context.DeadlineExceeded
+	}
+	if result != nil && result.IsError {
+		resultMarkedError = true
+	}
+	return result, nil
+}
+
+func bindToolLifecycleArgs[Args any](ctx context.Context, raw json.RawMessage, options ToolLifecycleOptions[Args]) (Args, error) {
+	var args Args
+
+	if options.NoArgs {
+		if !emptyToolLifecycleArgs(raw) {
+			return args, errToolLifecycleNoArgs
+		}
+		if options.Validate != nil {
+			if err := options.Validate(ctx, args); err != nil {
+				return args, errToolLifecycleValidation
+			}
+		}
+		return args, nil
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return args, errToolLifecycleMissingArguments
+	}
+	if trimmed[0] != '{' {
+		return args, errToolLifecycleInvalidArguments
+	}
+
+	if options.StrictJSON {
+		dec := json.NewDecoder(bytes.NewReader(trimmed))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&args); err != nil {
+			return args, errToolLifecycleInvalidArguments
+		}
+		var extra any
+		if err := dec.Decode(&extra); err != io.EOF {
+			return args, errToolLifecycleInvalidArguments
+		}
+	} else if err := json.Unmarshal(trimmed, &args); err != nil {
+		return args, errToolLifecycleInvalidArguments
+	}
+
+	if options.Validate != nil {
+		if err := options.Validate(ctx, args); err != nil {
+			return args, errToolLifecycleValidation
+		}
+	}
+
+	return args, nil
+}
+
+func callToolLifecycleStart(ctx context.Context, hook func(context.Context, ToolLifecycleStart), event ToolLifecycleStart) {
+	defer func() {
+		_ = recover()
+	}()
+	hook(ctx, event)
+}
+
+func callToolLifecycleFinish(ctx context.Context, hook func(context.Context, ToolLifecycleFinish), event ToolLifecycleFinish) {
+	defer func() {
+		_ = recover()
+	}()
+	hook(ctx, event)
+}
+
+func emptyToolLifecycleArgs(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return true
+	}
+
+	var args map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &args); err != nil {
+		return false
+	}
+	return len(args) == 0
+}
+
+func lifecycleInternalError() error {
+	return errToolLifecycleInternal
+}
+
+func toolLifecycleRPCError(err error) (*RPCError, bool) {
+	switch {
+	case errors.Is(err, errToolLifecycleInvalidArguments):
+		return &RPCError{Code: CodeInvalidParams, Message: lifecycleInvalidToolArgumentsMessage}, true
+	case errors.Is(err, errToolLifecycleMissingArguments):
+		return &RPCError{Code: CodeInvalidParams, Message: lifecycleMissingToolArgumentsMessage}, true
+	case errors.Is(err, errToolLifecycleNoArgs):
+		return &RPCError{Code: CodeInvalidParams, Message: lifecycleNoArgsMessage}, true
+	case errors.Is(err, errToolLifecycleValidation):
+		return &RPCError{Code: CodeInvalidParams, Message: lifecycleValidationMessage}, true
+	case errors.Is(err, errToolLifecycleInternal):
+		return &RPCError{Code: CodeInternalError, Message: lifecycleInternalMessage}, true
+	default:
+		return nil, false
+	}
+}
+
+func toolLifecycleErrorResponse(reqID any, err error) (*Response, bool) {
+	rpcErr, ok := toolLifecycleRPCError(err)
+	if !ok {
+		return nil, false
+	}
+	return &Response{
+		JSONRPC: jsonrpcVersion,
+		ID:      reqID,
+		Error:   rpcErr,
+	}, true
+}
+
+func formatToolTimeoutMessage(toolName string) string {
+	return fmt.Sprintf("tool %q timed out", toolName)
+}

--- a/runtime/mcp/lifecycle.go
+++ b/runtime/mcp/lifecycle.go
@@ -21,11 +21,11 @@ const (
 )
 
 var (
-	errToolLifecycleInvalidArguments = errors.New(lifecycleInvalidToolArgumentsMessage)
-	errToolLifecycleMissingArguments = errors.New(lifecycleMissingToolArgumentsMessage)
-	errToolLifecycleNoArgs           = errors.New(lifecycleNoArgsMessage)
-	errToolLifecycleValidation       = errors.New(lifecycleValidationMessage)
-	errToolLifecycleInternal         = errors.New(lifecycleInternalMessage)
+	errToolLifecycleInvalidArguments = errors.New("invalid tool arguments")
+	errToolLifecycleMissingArguments = errors.New("missing tool arguments")
+	errToolLifecycleNoArgs           = errors.New("tool accepts no arguments")
+	errToolLifecycleValidation       = errors.New("validation failed")
+	errToolLifecycleInternal         = errors.New("internal tool lifecycle error")
 )
 
 // ToolLifecycleOutcome describes the sanitized result class for a wrapped MCP
@@ -176,31 +176,8 @@ func runToolLifecycle[Args any](
 
 	result, err = handler(runCtx, args)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || runCtx.Err() == context.DeadlineExceeded {
-			outcome = ToolLifecycleOutcomeTimeout
-			jsonrpcCode = CodeServerError
-			return nil, context.DeadlineExceeded
-		}
-		if errors.Is(err, context.Canceled) || runCtx.Err() == context.Canceled {
-			outcome = ToolLifecycleOutcomeContextCanceled
-			jsonrpcCode = CodeServerError
-			return nil, context.Canceled
-		}
-		if options.HandleError != nil {
-			if handled, ok := options.HandleError(runCtx, err); ok {
-				outcome = ToolLifecycleOutcomeHandledError
-				if handled == nil {
-					handled = &ToolResult{IsError: true}
-				}
-				if handled.IsError {
-					resultMarkedError = true
-				}
-				return handled, nil
-			}
-		}
-		outcome = ToolLifecycleOutcomeUnhandledError
-		jsonrpcCode = CodeInternalError
-		return nil, lifecycleInternalError()
+		result, outcome, jsonrpcCode, resultMarkedError, err = handleToolLifecycleError(runCtx, err, options.HandleError)
+		return result, err
 	}
 	if runCtx.Err() == context.DeadlineExceeded {
 		outcome = ToolLifecycleOutcomeTimeout
@@ -211,6 +188,28 @@ func runToolLifecycle[Args any](
 		resultMarkedError = true
 	}
 	return result, nil
+}
+
+func handleToolLifecycleError(
+	ctx context.Context,
+	err error,
+	handle func(context.Context, error) (*ToolResult, bool),
+) (*ToolResult, ToolLifecycleOutcome, int, bool, error) {
+	if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
+		return nil, ToolLifecycleOutcomeTimeout, CodeServerError, false, context.DeadlineExceeded
+	}
+	if errors.Is(err, context.Canceled) || ctx.Err() == context.Canceled {
+		return nil, ToolLifecycleOutcomeContextCanceled, CodeServerError, false, context.Canceled
+	}
+	if handle != nil {
+		if handled, ok := handle(ctx, err); ok {
+			if handled == nil {
+				handled = &ToolResult{IsError: true}
+			}
+			return handled, ToolLifecycleOutcomeHandledError, 0, handled.IsError, nil
+		}
+	}
+	return nil, ToolLifecycleOutcomeUnhandledError, CodeInternalError, false, lifecycleInternalError()
 }
 
 func bindToolLifecycleArgs[Args any](ctx context.Context, raw json.RawMessage, options ToolLifecycleOptions[Args]) (Args, error) {
@@ -261,14 +260,18 @@ func bindToolLifecycleArgs[Args any](ctx context.Context, raw json.RawMessage, o
 
 func callToolLifecycleStart(ctx context.Context, hook func(context.Context, ToolLifecycleStart), event ToolLifecycleStart) {
 	defer func() {
-		_ = recover()
+		if recovered := recover(); recovered != nil {
+			return
+		}
 	}()
 	hook(ctx, event)
 }
 
 func callToolLifecycleFinish(ctx context.Context, hook func(context.Context, ToolLifecycleFinish), event ToolLifecycleFinish) {
 	defer func() {
-		_ = recover()
+		if recovered := recover(); recovered != nil {
+			return
+		}
 	}()
 	hook(ctx, event)
 }

--- a/runtime/mcp/lifecycle_test.go
+++ b/runtime/mcp/lifecycle_test.go
@@ -1,0 +1,472 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type lifecycleTelemetryRecorder struct {
+	mu       sync.Mutex
+	starts   []ToolLifecycleStart
+	finishes []ToolLifecycleFinish
+}
+
+func (r *lifecycleTelemetryRecorder) telemetry() ToolLifecycleTelemetry {
+	return ToolLifecycleTelemetry{
+		Start: func(_ context.Context, ev ToolLifecycleStart) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.starts = append(r.starts, ev)
+		},
+		Finish: func(_ context.Context, ev ToolLifecycleFinish) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.finishes = append(r.finishes, ev)
+		},
+	}
+}
+
+func (r *lifecycleTelemetryRecorder) finishOutcomes() []ToolLifecycleOutcome {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ToolLifecycleOutcome, len(r.finishes))
+	for i, ev := range r.finishes {
+		out[i] = ev.Outcome
+	}
+	return out
+}
+
+func (r *lifecycleTelemetryRecorder) marshalFinishes(t *testing.T) string {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	b, err := json.Marshal(r.finishes)
+	if err != nil {
+		t.Fatalf("marshal telemetry: %v", err)
+	}
+	return string(b)
+}
+
+func TestWrapToolLifecycle_BufferedPolicy(t *testing.T) {
+	type echoArgs struct {
+		Message string `json:"message"`
+	}
+	productErr := errors.New("product failure with bearer-secret-123")
+	rec := &lifecycleTelemetryRecorder{}
+	s := NewServer("test", "dev")
+
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "echo",
+		Description: "wrapped echo",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`),
+	}, WrapTool(ToolLifecycleOptions[echoArgs]{
+		Name:       "echo",
+		StrictJSON: true,
+		Validate: func(_ context.Context, args echoArgs) error {
+			if strings.TrimSpace(args.Message) == "" {
+				return errors.New("validation mentioned bearer-secret-123")
+			}
+			return nil
+		},
+		HandleError: func(_ context.Context, err error) (*ToolResult, bool) {
+			if errors.Is(err, productErr) {
+				return &ToolResult{
+					IsError: true,
+					Content: []ContentBlock{{Type: "text", Text: "safe product failure"}},
+				}, true
+			}
+			return nil, false
+		},
+		Telemetry: rec.telemetry(),
+	}, func(_ context.Context, args echoArgs) (*ToolResult, error) {
+		switch args.Message {
+		case "handled":
+			return nil, productErr
+		case "unhandled":
+			return nil, errors.New("unhandled bearer-secret-123")
+		case "panic":
+			panic("panic bearer-secret-123")
+		default:
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: args.Message}}}, nil
+		}
+	})); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	success := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(1, "echo", `{"message":"ok"}`, false), protocolVersion, "sess-1")
+	if success.Error != nil {
+		t.Fatalf("success error: %+v", success.Error)
+	}
+	successResult, ok := success.Result.(*ToolResult)
+	if !ok || len(successResult.Content) != 1 || successResult.Content[0].Text != "ok" {
+		t.Fatalf("unexpected success result: %#v", success.Result)
+	}
+
+	invalid := s.dispatchForProtocol(
+		context.Background(),
+		toolLifecycleCallRequest(2, "echo", `{"message":"ok","bearer-secret-123":"leak"}`, false),
+		protocolVersion,
+		"sess-1",
+	)
+	if invalid.Error == nil || invalid.Error.Code != CodeInvalidParams {
+		t.Fatalf("expected invalid params, got %+v", invalid.Error)
+	}
+	if strings.Contains(invalid.Error.Message, "bearer-secret-123") {
+		t.Fatalf("invalid params leaked raw argument data: %q", invalid.Error.Message)
+	}
+
+	handled := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(3, "echo", `{"message":"handled"}`, false), protocolVersion, "sess-1")
+	if handled.Error != nil {
+		t.Fatalf("handled product failure returned JSON-RPC error: %+v", handled.Error)
+	}
+	handledResult, ok := handled.Result.(*ToolResult)
+	if !ok || !handledResult.IsError || handledResult.Content[0].Text != "safe product failure" {
+		t.Fatalf("unexpected handled result: %#v", handled.Result)
+	}
+
+	unhandled := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(4, "echo", `{"message":"unhandled"}`, false), protocolVersion, "sess-1")
+	if unhandled.Error == nil || unhandled.Error.Code != CodeInternalError || unhandled.Error.Message != lifecycleInternalMessage {
+		t.Fatalf("expected sanitized internal error, got %+v", unhandled.Error)
+	}
+	if strings.Contains(unhandled.Error.Message, "bearer-secret-123") {
+		t.Fatalf("unhandled error leaked raw error text: %q", unhandled.Error.Message)
+	}
+
+	panicked := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(5, "echo", `{"message":"panic"}`, false), protocolVersion, "sess-1")
+	if panicked.Error == nil || panicked.Error.Code != CodeInternalError || panicked.Error.Message != lifecycleInternalMessage {
+		t.Fatalf("expected sanitized panic error, got %+v", panicked.Error)
+	}
+
+	assertLifecycleOutcomes(t, rec.finishOutcomes(),
+		ToolLifecycleOutcomeSuccess,
+		ToolLifecycleOutcomeInvalidParams,
+		ToolLifecycleOutcomeHandledError,
+		ToolLifecycleOutcomeUnhandledError,
+		ToolLifecycleOutcomePanic,
+	)
+	if telemetry := rec.marshalFinishes(t); strings.Contains(telemetry, "bearer-secret-123") {
+		t.Fatalf("telemetry leaked raw args/errors/panic values: %s", telemetry)
+	}
+}
+
+func TestWrapToolLifecycle_NoArgs(t *testing.T) {
+	rec := &lifecycleTelemetryRecorder{}
+	s := NewServer("test", "dev")
+
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "ping",
+		Description: "no-arg wrapped tool",
+		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false}`),
+	}, WrapTool(ToolLifecycleOptions[struct{}]{
+		Name:      "ping",
+		NoArgs:    true,
+		Telemetry: rec.telemetry(),
+	}, func(context.Context, struct{}) (*ToolResult, error) {
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "pong"}}}, nil
+	})); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	omitted := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(1, "ping", "", false), protocolVersion, "sess-1")
+	if omitted.Error != nil {
+		t.Fatalf("omitted args error: %+v", omitted.Error)
+	}
+	empty := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(2, "ping", `{}`, false), protocolVersion, "sess-1")
+	if empty.Error != nil {
+		t.Fatalf("empty args error: %+v", empty.Error)
+	}
+	extra := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(3, "ping", `{"secret":"bearer-secret-123"}`, false), protocolVersion, "sess-1")
+	if extra.Error == nil || extra.Error.Code != CodeInvalidParams {
+		t.Fatalf("expected extra args to fail closed, got %+v", extra.Error)
+	}
+	if strings.Contains(extra.Error.Message, "bearer-secret-123") {
+		t.Fatalf("no-arg error leaked raw args: %q", extra.Error.Message)
+	}
+
+	assertLifecycleOutcomes(t, rec.finishOutcomes(),
+		ToolLifecycleOutcomeSuccess,
+		ToolLifecycleOutcomeSuccess,
+		ToolLifecycleOutcomeInvalidParams,
+	)
+}
+
+func TestWrapStreamingToolLifecycle_StreamingPolicy(t *testing.T) {
+	type streamArgs struct {
+		Steps int `json:"steps"`
+	}
+	rec := &lifecycleTelemetryRecorder{}
+	s := NewServer("test", "dev")
+	sessionID := initializeSession(t, s)
+
+	if err := s.Registry().RegisterStreamingTool(ToolDef{
+		Name:        "stream_count",
+		Description: "wrapped streaming counter",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"steps":{"type":"integer","minimum":1}},"required":["steps"]}`),
+	}, WrapStreamingTool(ToolLifecycleOptions[streamArgs]{
+		Name:       "stream_count",
+		StrictJSON: true,
+		Validate: func(_ context.Context, args streamArgs) error {
+			if args.Steps <= 0 {
+				return errors.New("validation bearer-secret-123")
+			}
+			return nil
+		},
+		Telemetry: rec.telemetry(),
+	}, func(_ context.Context, args streamArgs, emit func(SSEEvent)) (*ToolResult, error) {
+		if args.Steps == 13 {
+			return nil, errors.New("stream bearer-secret-123")
+		}
+		emit(SSEEvent{Data: map[string]any{"progress": 1, "total": args.Steps, "message": "started"}})
+		return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "stream ok"}}}, nil
+	})); err != nil {
+		t.Fatalf("register streaming tool: %v", err)
+	}
+
+	successStream := invokeLifecycleStream(t, s, sessionID, toolLifecycleStreamingCallRequest(1, "stream_count", `{"steps":2}`))
+	if !strings.Contains(successStream, `"method":"notifications/progress"`) {
+		t.Fatalf("expected progress notification, got:\n%s", successStream)
+	}
+	if !strings.Contains(successStream, `"text":"stream ok"`) {
+		t.Fatalf("expected final result, got:\n%s", successStream)
+	}
+
+	invalidStream := invokeLifecycleStream(
+		t,
+		s,
+		sessionID,
+		toolLifecycleCallRequest(2, "stream_count", `{"steps":2,"bearer-secret-123":"leak"}`, false),
+	)
+	if !strings.Contains(invalidStream, `"code":-32602`) {
+		t.Fatalf("expected invalid params in stream, got:\n%s", invalidStream)
+	}
+	if strings.Contains(invalidStream, "bearer-secret-123") {
+		t.Fatalf("stream invalid params leaked raw args:\n%s", invalidStream)
+	}
+
+	unhandledStream := invokeLifecycleStream(t, s, sessionID, toolLifecycleCallRequest(3, "stream_count", `{"steps":13}`, false))
+	if !strings.Contains(unhandledStream, `"code":-32603`) || !strings.Contains(unhandledStream, `"message":"internal error"`) {
+		t.Fatalf("expected sanitized internal stream error, got:\n%s", unhandledStream)
+	}
+	if strings.Contains(unhandledStream, "bearer-secret-123") {
+		t.Fatalf("stream unhandled error leaked raw error text:\n%s", unhandledStream)
+	}
+
+	assertLifecycleOutcomes(t, rec.finishOutcomes(),
+		ToolLifecycleOutcomeSuccess,
+		ToolLifecycleOutcomeInvalidParams,
+		ToolLifecycleOutcomeUnhandledError,
+	)
+	if telemetry := rec.marshalFinishes(t); strings.Contains(telemetry, "bearer-secret-123") {
+		t.Fatalf("stream telemetry leaked raw args/errors: %s", telemetry)
+	}
+}
+
+func TestWrapToolLifecycle_TaskPolicy(t *testing.T) {
+	type taskArgs struct {
+		Mode string `json:"mode"`
+	}
+	productErr := errors.New("task product failure bearer-secret-123")
+
+	run := func(t *testing.T, args string) (*TaskRecord, *lifecycleTelemetryRecorder) {
+		t.Helper()
+		rec := &lifecycleTelemetryRecorder{}
+		store := NewMemoryTaskStore()
+		s := NewServer("test", "dev",
+			WithServerIDGenerator(staticIDGenerator{id: "task-lifecycle"}),
+			WithTaskRuntime(TaskRuntimeOptions{
+				Store:        store,
+				PollInterval: time.Millisecond,
+			}),
+		)
+		if err := s.Registry().RegisterTool(ToolDef{
+			Name:        "task_tool",
+			Description: "wrapped task tool",
+			Execution:   &ToolExecution{TaskSupport: TaskSupportOptional},
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"mode":{"type":"string"}},"required":["mode"]}`),
+		}, WrapTool(ToolLifecycleOptions[taskArgs]{
+			Name:       "task_tool",
+			StrictJSON: true,
+			Validate: func(_ context.Context, args taskArgs) error {
+				if args.Mode == "" {
+					return errors.New("validation bearer-secret-123")
+				}
+				return nil
+			},
+			HandleError: func(_ context.Context, err error) (*ToolResult, bool) {
+				if errors.Is(err, productErr) {
+					return &ToolResult{
+						IsError: true,
+						Content: []ContentBlock{{Type: "text", Text: "safe task product failure"}},
+					}, true
+				}
+				return nil, false
+			},
+			Telemetry: rec.telemetry(),
+		}, func(_ context.Context, args taskArgs) (*ToolResult, error) {
+			switch args.Mode {
+			case "handled":
+				return nil, productErr
+			case "unhandled":
+				return nil, errors.New("task bearer-secret-123")
+			default:
+				return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "task ok"}}}, nil
+			}
+		})); err != nil {
+			t.Fatalf("register task tool: %v", err)
+		}
+
+		createResp := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(1, "task_tool", args, true), protocolVersion, "sess-1")
+		if createResp.Error != nil {
+			t.Fatalf("create task: %+v", createResp.Error)
+		}
+		record := waitForTaskTerminal(t, store, "sess-1", "task-lifecycle")
+		return record, rec
+	}
+
+	success, successRec := run(t, `{"mode":"success"}`)
+	if success.Task.Status != TaskStatusCompleted || success.Error != nil || !strings.Contains(string(success.Result), "task ok") {
+		t.Fatalf("unexpected task success record: %+v result=%s", success, string(success.Result))
+	}
+	assertLifecycleOutcomes(t, successRec.finishOutcomes(), ToolLifecycleOutcomeSuccess)
+
+	invalid, invalidRec := run(t, `{"bearer-secret-123":"leak"}`)
+	if invalid.Task.Status != TaskStatusFailed || invalid.Error == nil || invalid.Error.Code != CodeInvalidParams {
+		t.Fatalf("expected invalid task failure, got %+v", invalid)
+	}
+	if strings.Contains(invalid.Error.Message, "bearer-secret-123") {
+		t.Fatalf("task invalid params leaked raw args: %q", invalid.Error.Message)
+	}
+	assertLifecycleOutcomes(t, invalidRec.finishOutcomes(), ToolLifecycleOutcomeInvalidParams)
+
+	handled, handledRec := run(t, `{"mode":"handled"}`)
+	if handled.Task.Status != TaskStatusFailed || handled.Error != nil || !strings.Contains(string(handled.Result), "safe task product failure") {
+		t.Fatalf("unexpected handled task record: %+v result=%s", handled, string(handled.Result))
+	}
+	assertLifecycleOutcomes(t, handledRec.finishOutcomes(), ToolLifecycleOutcomeHandledError)
+
+	unhandled, unhandledRec := run(t, `{"mode":"unhandled"}`)
+	if unhandled.Task.Status != TaskStatusFailed || unhandled.Error == nil || unhandled.Error.Code != CodeInternalError || unhandled.Error.Message != lifecycleInternalMessage {
+		t.Fatalf("expected sanitized unhandled task failure, got %+v", unhandled)
+	}
+	if strings.Contains(unhandled.Error.Message, "bearer-secret-123") {
+		t.Fatalf("task unhandled error leaked raw error text: %q", unhandled.Error.Message)
+	}
+	assertLifecycleOutcomes(t, unhandledRec.finishOutcomes(), ToolLifecycleOutcomeUnhandledError)
+	if telemetry := unhandledRec.marshalFinishes(t); strings.Contains(telemetry, "bearer-secret-123") {
+		t.Fatalf("task telemetry leaked raw args/errors: %s", telemetry)
+	}
+}
+
+func TestWrapToolLifecycle_TimeoutMapsToSafeTimeout(t *testing.T) {
+	type args struct {
+		Message string `json:"message"`
+	}
+	rec := &lifecycleTelemetryRecorder{}
+	s := NewServer("test", "dev")
+
+	if err := s.Registry().RegisterTool(ToolDef{
+		Name:        "timeout_tool",
+		Description: "wrapped timeout tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}}}`),
+	}, WrapTool(ToolLifecycleOptions[args]{
+		Name:      "timeout_tool",
+		Timeout:   time.Nanosecond,
+		Telemetry: rec.telemetry(),
+	}, func(ctx context.Context, _ args) (*ToolResult, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	resp := s.dispatchForProtocol(context.Background(), toolLifecycleCallRequest(1, "timeout_tool", `{"message":"ok"}`, false), protocolVersion, "sess-1")
+	if resp.Error == nil || resp.Error.Code != CodeServerError || resp.Error.Message != `tool "timeout_tool" timed out` {
+		t.Fatalf("expected safe timeout error, got %+v", resp.Error)
+	}
+	assertLifecycleOutcomes(t, rec.finishOutcomes(), ToolLifecycleOutcomeTimeout)
+}
+
+func toolLifecycleCallRequest(id int, name, args string, task bool) *Request {
+	params := map[string]any{"name": name}
+	if args != "" {
+		params["arguments"] = json.RawMessage(args)
+	}
+	if task {
+		params["task"] = map[string]any{}
+	}
+	return &Request{
+		JSONRPC: jsonrpcVersion,
+		ID:      id,
+		Method:  methodToolsCall,
+		Params:  mustMarshalJSON(params),
+	}
+}
+
+func toolLifecycleStreamingCallRequest(id int, name, args string) *Request {
+	req := toolLifecycleCallRequest(id, name, args, false)
+	var params map[string]any
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		panic(err)
+	}
+	params["_meta"] = map[string]any{"progressToken": "progress-token"}
+	req.Params = mustMarshalJSON(params)
+	return req
+}
+
+func invokeLifecycleStream(t *testing.T, s *Server, sessionID string, req *Request) string {
+	t.Helper()
+	body := mustMarshal(t, req)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", body, headers)
+	if err != nil {
+		t.Fatalf("invoke stream: %v", err)
+	}
+	if resp.BodyReader == nil {
+		t.Fatalf("expected streaming response BodyReader to be set")
+	}
+	b, err := io.ReadAll(resp.BodyReader)
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	return string(b)
+}
+
+func waitForTaskTerminal(t *testing.T, store TaskStore, sessionID, taskID string) *TaskRecord {
+	t.Helper()
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		record, err := store.Get(context.Background(), TaskLookup{SessionID: sessionID, TaskID: taskID})
+		if err == nil && (record.Task.Status == TaskStatusCompleted || record.Task.Status == TaskStatusFailed || record.Task.Status == TaskStatusCanceled) {
+			return record
+		}
+		select {
+		case <-deadline:
+			if err != nil {
+				t.Fatalf("task did not reach terminal status: %v", err)
+			}
+			t.Fatalf("task did not reach terminal status; latest status %s", record.Task.Status)
+		case <-ticker.C:
+		}
+	}
+}
+
+func assertLifecycleOutcomes(t *testing.T, got []ToolLifecycleOutcome, want ...ToolLifecycleOutcome) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("outcomes len: got %d (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("outcome[%d]: got %q in %v, want %q", i, got[i], got, want[i])
+		}
+	}
+}

--- a/runtime/mcp/lifecycle_test.go
+++ b/runtime/mcp/lifecycle_test.go
@@ -17,6 +17,22 @@ type lifecycleTelemetryRecorder struct {
 	finishes []ToolLifecycleFinish
 }
 
+type lifecycleSequenceClock struct {
+	mu     sync.Mutex
+	values []time.Time
+}
+
+func (c *lifecycleSequenceClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.values) == 0 {
+		return time.Unix(0, 0)
+	}
+	next := c.values[0]
+	c.values = c.values[1:]
+	return next
+}
+
 func (r *lifecycleTelemetryRecorder) telemetry() ToolLifecycleTelemetry {
 	return ToolLifecycleTelemetry{
 		Start: func(_ context.Context, ev ToolLifecycleStart) {
@@ -392,6 +408,208 @@ func TestWrapToolLifecycle_TimeoutMapsToSafeTimeout(t *testing.T) {
 	assertLifecycleOutcomes(t, rec.finishOutcomes(), ToolLifecycleOutcomeTimeout)
 }
 
+func TestWrapToolLifecycle_EdgeCasesStaySanitized(t *testing.T) {
+	type args struct {
+		Message string `json:"message"`
+	}
+
+	t.Run("missing arguments", func(t *testing.T) {
+		rec := &lifecycleTelemetryRecorder{}
+		handler := WrapTool(ToolLifecycleOptions[args]{Name: "edge", Telemetry: rec.telemetry()}, func(context.Context, args) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), nil)
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleMissingToolArgumentsMessage)
+		assertLifecycleOutcomes(t, rec.finishOutcomes(), ToolLifecycleOutcomeInvalidParams)
+	})
+
+	t.Run("non-object arguments", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[args]{Name: "edge"}, func(context.Context, args) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`["bearer-secret-123"]`))
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleInvalidToolArgumentsMessage)
+		if strings.Contains(err.Error(), "bearer-secret-123") {
+			t.Fatalf("non-object args leaked raw input: %v", err)
+		}
+	})
+
+	t.Run("strict trailing json", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[args]{Name: "edge", StrictJSON: true}, func(context.Context, args) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`{"message":"ok"} {}`))
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleInvalidToolArgumentsMessage)
+	})
+
+	t.Run("non-strict invalid json", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[map[string]any]{Name: "edge"}, func(context.Context, map[string]any) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`{"message":`))
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleInvalidToolArgumentsMessage)
+	})
+
+	t.Run("validation failure", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[args]{
+			Name: "edge",
+			Validate: func(context.Context, args) error {
+				return errors.New("validation bearer-secret-123")
+			},
+		}, func(context.Context, args) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`))
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleValidationMessage)
+		if strings.Contains(err.Error(), "bearer-secret-123") {
+			t.Fatalf("validation error leaked raw text: %v", err)
+		}
+	})
+
+	t.Run("no args validation failure", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[struct{}]{
+			Name:   "edge",
+			NoArgs: true,
+			Validate: func(context.Context, struct{}) error {
+				return errors.New("validation bearer-secret-123")
+			},
+		}, func(context.Context, struct{}) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`null`))
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleValidationMessage)
+	})
+
+	t.Run("no args invalid json", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[struct{}]{
+			Name:   "edge",
+			NoArgs: true,
+		}, func(context.Context, struct{}) (*ToolResult, error) {
+			t.Fatal("handler should not run")
+			return nil, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`{`))
+		assertLifecycleRPCError(t, err, CodeInvalidParams, lifecycleNoArgsMessage)
+	})
+
+	t.Run("successful isError result is reported", func(t *testing.T) {
+		rec := &lifecycleTelemetryRecorder{}
+		handler := WrapTool(ToolLifecycleOptions[args]{
+			Name:      "edge",
+			Telemetry: rec.telemetry(),
+		}, func(context.Context, args) (*ToolResult, error) {
+			return &ToolResult{IsError: true}, nil
+		})
+		result, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`))
+		if err != nil {
+			t.Fatalf("isError result returned error: %v", err)
+		}
+		if result == nil || !result.IsError {
+			t.Fatalf("expected isError result, got %#v", result)
+		}
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		if len(rec.finishes) != 1 || !rec.finishes[0].ResultMarkedError {
+			t.Fatalf("expected ResultMarkedError telemetry, got %+v", rec.finishes)
+		}
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		rec := &lifecycleTelemetryRecorder{}
+		handler := WrapTool(ToolLifecycleOptions[args]{Name: "edge", Telemetry: rec.telemetry()}, func(context.Context, args) (*ToolResult, error) {
+			return nil, context.Canceled
+		})
+		_, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`))
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled, got %v", err)
+		}
+		assertLifecycleOutcomes(t, rec.finishOutcomes(), ToolLifecycleOutcomeContextCanceled)
+	})
+
+	t.Run("handle error nil result", func(t *testing.T) {
+		rec := &lifecycleTelemetryRecorder{}
+		handler := WrapTool(ToolLifecycleOptions[args]{
+			Name:      "edge",
+			Telemetry: rec.telemetry(),
+			HandleError: func(context.Context, error) (*ToolResult, bool) {
+				return nil, true
+			},
+		}, func(context.Context, args) (*ToolResult, error) {
+			return nil, errors.New("handled bearer-secret-123")
+		})
+		result, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`))
+		if err != nil {
+			t.Fatalf("handled nil result error: %v", err)
+		}
+		if result == nil || !result.IsError {
+			t.Fatalf("expected synthesized isError result, got %#v", result)
+		}
+		assertLifecycleOutcomes(t, rec.finishOutcomes(), ToolLifecycleOutcomeHandledError)
+	})
+
+	t.Run("telemetry hook panics are contained", func(t *testing.T) {
+		handler := WrapTool(ToolLifecycleOptions[args]{
+			Name:  "edge",
+			Clock: fixedClock(time.Unix(100, 0)),
+			Telemetry: ToolLifecycleTelemetry{
+				Start: func(context.Context, ToolLifecycleStart) {
+					panic("start bearer-secret-123")
+				},
+				Finish: func(context.Context, ToolLifecycleFinish) {
+					panic("finish bearer-secret-123")
+				},
+			},
+		}, func(context.Context, args) (*ToolResult, error) {
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+		})
+		if _, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`)); err != nil {
+			t.Fatalf("telemetry panic should not fail tool: %v", err)
+		}
+	})
+
+	t.Run("negative clock duration clamps to zero", func(t *testing.T) {
+		rec := &lifecycleTelemetryRecorder{}
+		handler := WrapTool(ToolLifecycleOptions[args]{
+			Name:      "edge",
+			Clock:     &lifecycleSequenceClock{values: []time.Time{time.Unix(200, 0), time.Unix(100, 0)}},
+			Telemetry: rec.telemetry(),
+		}, func(context.Context, args) (*ToolResult, error) {
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "ok"}}}, nil
+		})
+		if _, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`)); err != nil {
+			t.Fatalf("negative clock case failed: %v", err)
+		}
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		if len(rec.finishes) != 1 || rec.finishes[0].Duration != 0 {
+			t.Fatalf("expected clamped zero duration, got %+v", rec.finishes)
+		}
+	})
+
+	t.Run("deadline after nil handler error", func(t *testing.T) {
+		rec := &lifecycleTelemetryRecorder{}
+		handler := WrapTool(ToolLifecycleOptions[args]{
+			Name:      "edge",
+			Timeout:   time.Nanosecond,
+			Telemetry: rec.telemetry(),
+		}, func(ctx context.Context, _ args) (*ToolResult, error) {
+			<-ctx.Done()
+			return &ToolResult{Content: []ContentBlock{{Type: "text", Text: "late"}}}, nil
+		})
+		_, err := handler(context.Background(), json.RawMessage(`{"message":"ok"}`))
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected deadline, got %v", err)
+		}
+		assertLifecycleOutcomes(t, rec.finishOutcomes(), ToolLifecycleOutcomeTimeout)
+	})
+}
+
 func toolLifecycleCallRequest(id int, name, args string, task bool) *Request {
 	params := map[string]any{"name": name}
 	if args != "" {
@@ -456,6 +674,17 @@ func waitForTaskTerminal(t *testing.T, store TaskStore, sessionID, taskID string
 			t.Fatalf("task did not reach terminal status; latest status %s", record.Task.Status)
 		case <-ticker.C:
 		}
+	}
+}
+
+func assertLifecycleRPCError(t *testing.T, err error, code int, message string) {
+	t.Helper()
+	rpcErr, ok := toolLifecycleRPCError(err)
+	if !ok {
+		t.Fatalf("expected lifecycle RPC error, got %v", err)
+	}
+	if rpcErr.Code != code || rpcErr.Message != message {
+		t.Fatalf("RPC error: got %+v, want code=%d message=%q", rpcErr, code, message)
 	}
 }
 

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -790,6 +790,9 @@ func (s *Server) toolCallError(ctx context.Context, reqID any, toolName string, 
 	if strings.HasPrefix(err.Error(), "tool not found:") {
 		return NewErrorResponse(reqID, CodeInvalidParams, err.Error())
 	}
+	if resp, ok := toolLifecycleErrorResponse(reqID, err); ok {
+		return resp
+	}
 
 	// Check for context deadline exceeded (timeout).
 	if ctx.Err() == context.DeadlineExceeded || errors.Is(err, context.DeadlineExceeded) {
@@ -797,7 +800,7 @@ func (s *Server) toolCallError(ctx context.Context, reqID any, toolName string, 
 			"tool", toolName,
 			"error", err,
 		)
-		return NewErrorResponse(reqID, CodeServerError, fmt.Sprintf("tool %q timed out", toolName))
+		return NewErrorResponse(reqID, CodeServerError, formatToolTimeoutMessage(toolName))
 	}
 
 	s.logger.ErrorContext(ctx, "tool error",

--- a/runtime/mcp/task.go
+++ b/runtime/mcp/task.go
@@ -298,6 +298,14 @@ func (s *Server) runTaskTool(ctx context.Context, record TaskRecord, args json.R
 		if ctx.Err() != nil {
 			return
 		}
+		if rpcErr, ok := toolLifecycleRPCError(err); ok {
+			s.finishTask(ctx, record, nil, rpcErr)
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			s.finishTask(ctx, record, nil, &RPCError{Code: CodeServerError, Message: formatToolTimeoutMessage(record.ToolName)})
+			return
+		}
 		s.finishTask(ctx, record, nil, &RPCError{Code: CodeServerError, Message: err.Error()})
 		return
 	}


### PR DESCRIPTION
## Milestone
APP-M1 — AppTheory MCP tool lifecycle primitive

## Linear
- Parent: THE-2034
- Subissues: THE-2047, THE-2048, THE-2049
- Project: 3d372b60e3b7

## What changed
- Added `mcp.WrapTool[Args]` and `mcp.WrapStreamingTool[Args]` as registration-time lifecycle adapters over the existing MCP registry.
- Added `ToolLifecycleOptions`, sanitized start/finish telemetry payloads, lifecycle outcomes, strict JSON/no-args validation, handled product-error mapping, per-tool timeout, and panic/unhandled-error sanitization.
- Kept all buffered, SSE streaming, and task execution on `ToolRegistry.Call` / `ToolRegistry.CallStreaming`; no second registration or dispatch path was added.
- Updated MCP examples and docs to show lifecycle-wrapped tools as the production path.
- Updated Go API snapshot for the additive public API.

## Tasks
- [x] THE-2047 — define MCP lifecycle wrapper API
- [x] THE-2048 — prove behavior across buffered/streaming/task
- [x] THE-2049 — document wrapper + blessed examples + API snapshots

## Contract / security notes
- Telemetry types intentionally exclude raw args, bearer tokens, raw unhandled errors, and panic values.
- Validation and no-arg failures map to JSON-RPC `CodeInvalidParams` with sanitized messages.
- Unhandled errors and panics map to sanitized internal JSON-RPC errors.
- Expected product failures can be mapped to safe `ToolResult{IsError:true}` via `HandleError`.

## Validation
- `go test ./runtime/mcp ./runtime/oauth ./testkit/mcp` — PASS
  - runtime/mcp: ok
  - runtime/oauth: ok
  - testkit/mcp: ok
- `go test ./examples/mcp/tools-only ./examples/mcp/tools-resources-prompts ./examples/mcp/resumable-sse` — PASS
  - tools-only: ok
  - tools-resources-prompts: ok
  - resumable-sse: ok
- `./scripts/update-api-snapshots.sh && ./scripts/verify-api-snapshots.sh` — PASS (`api-snapshots: PASS`)
- `make test` — PASS (`version-alignment: PASS (1.12.2)`)
- `make rubric` — PASS (`Status: PASS`, `Pass: 29`, `Fail: 0`, `Blocked: 0`, `rubric: PASS`)

## Cross-repo notes
- No TheoryMCP-side edits in this PR.
- Object-store helper and bearer→AuthPrincipal hook are intentionally out of scope.
