### PR TITLE
feat(objectstore): add helper and MCP spill adoption

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -685,6 +685,20 @@ func NormalizeStage(string) string
 
 func ResourceName(string, string, string, string) string
 
+## github.com/theory-cloud/apptheory/pkg/objectstore
+
+var ErrInvalidObjectRef = errors.New("objectstore: invalid object ref")
+
+type ObjectRef struct {
+	Bucket    string
+	Key       string
+	VersionID string
+}
+
+func ParseObjectRef(string) (ObjectRef, error)
+
+func (ObjectRef) Validate() error
+
 ## github.com/theory-cloud/apptheory/pkg/observability
 
 const LoggingProfileCloudWatchJSON = "cloudwatch-json"

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -691,6 +691,8 @@ var ErrInvalidGetLimit = errors.New("objectstore: max bytes must be positive")
 
 var ErrInvalidObjectRef = errors.New("objectstore: invalid object ref")
 
+var ErrInvalidStoreConfig = errors.New("objectstore: invalid store config")
+
 var ErrObjectNotFound = errors.New("objectstore: object not found")
 
 var ErrObjectTooLarge = errors.New("objectstore: object exceeds max bytes")
@@ -724,13 +726,23 @@ type PutInput struct {
 	Metadata    map[string]string
 }
 
+type S3StoreConfig struct{}
+
 type Store interface {
 	Put(context.Context, PutInput) (ObjectRef, error)
 	Get(context.Context, GetInput) (*GetOutput, error)
 	Delete(context.Context, DeleteInput) error
 }
 
+func NewS3Store(context.Context, S3StoreConfig) (Store, error)
+
 func ParseObjectRef(string) (ObjectRef, error)
+
+func (*s3Store) Delete(context.Context, DeleteInput) error
+
+func (*s3Store) Get(context.Context, GetInput) (*GetOutput, error)
+
+func (*s3Store) Put(context.Context, PutInput) (ObjectRef, error)
 
 func (ObjectRef) Validate() error
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -687,12 +687,47 @@ func ResourceName(string, string, string, string) string
 
 ## github.com/theory-cloud/apptheory/pkg/objectstore
 
+var ErrInvalidGetLimit = errors.New("objectstore: max bytes must be positive")
+
 var ErrInvalidObjectRef = errors.New("objectstore: invalid object ref")
+
+var ErrObjectNotFound = errors.New("objectstore: object not found")
+
+var ErrObjectTooLarge = errors.New("objectstore: object exceeds max bytes")
+
+type DeleteInput struct {
+	Ref ObjectRef
+}
+
+type GetInput struct {
+	Ref      ObjectRef
+	MaxBytes int64
+}
+
+type GetOutput struct {
+	Ref         ObjectRef
+	Payload     []byte
+	ContentType string
+	Metadata    map[string]string
+}
 
 type ObjectRef struct {
 	Bucket    string
 	Key       string
 	VersionID string
+}
+
+type PutInput struct {
+	Ref         ObjectRef
+	Payload     []byte
+	ContentType string
+	Metadata    map[string]string
+}
+
+type Store interface {
+	Put(context.Context, PutInput) (ObjectRef, error)
+	Get(context.Context, GetInput) (*GetOutput, error)
+	Delete(context.Context, DeleteInput) error
 }
 
 func ParseObjectRef(string) (ObjectRef, error)

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -3474,3 +3474,43 @@ type TokenResponse struct {
 func NewClaudePublicClient(*http.Client) *ClaudePublicClient
 
 func (*ClaudePublicClient) Authorize(context.Context, AuthorizeOptions) (*Discovery, *DCRResult, *TokenResponse, *TokenResponse, error)
+
+## github.com/theory-cloud/apptheory/testkit/objectstore
+
+const OperationDelete Operation = "Delete"
+
+const OperationGet Operation = "Get"
+
+const OperationPut Operation = "Put"
+
+type Call struct {
+	Operation   Operation
+	Ref         store.ObjectRef
+	MaxBytes    int64
+	ContentType string
+	Metadata    map[string]string
+	Payload     []byte
+}
+
+type FakeStore struct {
+	mu       sync.Mutex
+	seq      int64
+	latest   map[objectName]string
+	objects  map[objectVersion]storedObject
+	calls    []Call
+	failures map[Operation]error
+}
+
+type Operation string
+
+func NewStore() *FakeStore
+
+func (*FakeStore) Calls() []Call
+
+func (*FakeStore) Delete(context.Context, store.DeleteInput) error
+
+func (*FakeStore) Get(context.Context, store.GetInput) (*store.GetOutput, error)
+
+func (*FakeStore) Put(context.Context, store.PutInput) (store.ObjectRef, error)
+
+func (*FakeStore) SetError(Operation, error)

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -687,6 +687,14 @@ func ResourceName(string, string, string, string) string
 
 ## github.com/theory-cloud/apptheory/pkg/objectstore
 
+const S3EncryptionBucketDefault S3EncryptionMode = "bucket-default"
+
+const S3EncryptionKMS S3EncryptionMode = "kms"
+
+const S3EncryptionS3Managed S3EncryptionMode = "s3-managed"
+
+var ErrInvalidEncryptionConfig = errors.New("objectstore: invalid encryption config")
+
 var ErrInvalidGetLimit = errors.New("objectstore: max bytes must be positive")
 
 var ErrInvalidObjectRef = errors.New("objectstore: invalid object ref")
@@ -726,7 +734,16 @@ type PutInput struct {
 	Metadata    map[string]string
 }
 
-type S3StoreConfig struct{}
+type S3EncryptionConfig struct {
+	Mode     S3EncryptionMode
+	KMSKeyID string
+}
+
+type S3EncryptionMode string
+
+type S3StoreConfig struct {
+	Encryption S3EncryptionConfig
+}
 
 type Store interface {
 	Put(context.Context, PutInput) (ObjectRef, error)

--- a/cdk/docs/mcp-server-remote-mcp.md
+++ b/cdk/docs/mcp-server-remote-mcp.md
@@ -29,7 +29,7 @@ Claude Remote MCP requires real incremental streaming for tool calls (SSE). On A
   - session table (matches `runtime/mcp` Dynamo session store schema)
   - stream/event table (used by durable resumable SSE once the app wires a persistent `StreamStore`)
   - task table (used by the MCP task runtime once the app wires a persistent `TaskStore`)
-  - encrypted private S3 spill bucket for large logical stream event payloads when stream storage is enabled
+  - S3-managed encrypted private S3 spill bucket for large logical stream event payloads when stream storage is enabled
 
 If you are using OAuth for Claude connectors on the default `/mcp` route, also add:
 
@@ -138,12 +138,13 @@ in-flight tool context when still running; terminal task state is not rewritten.
 
 Large tool responses stay inside the same logical stream contract. `AppTheoryRemoteMcpServer` injects
 `MCP_STREAM_SPILL_BUCKET` and related threshold variables so `mcp.NewDynamoStreamStore(db)` stores small events inline
-and spills larger payloads to private S3 objects. The inline threshold defaults to `32768` and is bounded to the
+and spills larger payloads to private S3 objects through AppTheory's object-store helper. The inline threshold defaults to
+`32768` and is bounded to the
 DynamoDB-safe inline ceiling of `358400`. `MCP_STREAM_TTL_MINUTES` remains the runtime replay window: expired event
 records are not resolved or emitted even if DynamoDB TTL or S3 lifecycle cleanup has not run yet. Clients still resume
-with `Last-Event-ID`; do not add tool-specific chunking or object-link workarounds. Replay reads for spilled events are
-bounded by the recorded event byte count and `MCP_STREAM_MAX_EVENT_BYTES` before AppTheory verifies the byte count and
-SHA-256 hash.
+with `Last-Event-ID`; do not add tool-specific chunking, presigned URLs, or object-link workarounds. Replay reads for
+spilled events are bounded by the recorded event byte count and `MCP_STREAM_MAX_EVENT_BYTES` before AppTheory verifies
+the byte count and SHA-256 hash.
 
 Tool execution is hardened the same way in local and deployed Remote MCP: buffered and streaming tool panics become
 sanitized JSON-RPC internal errors. Panic text is server-log material, not part of the client contract.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -315,6 +315,22 @@ idempotency, and leases.
 Guide: [Jobs Ledger](./features/jobs-ledger.md)
 Reference stack: `examples/cdk/import-pipeline/`
 
+### Object store helper (Go)
+
+AppTheory includes a narrow Go object-store helper for framework-owned byte payload storage. It is not a general storage
+SDK.
+
+- Go: `pkg/objectstore`
+- Testkit: `testkit/objectstore`
+- Object refs: strict `s3://bucket/key` parsing into `ObjectRef{Bucket, Key, VersionID}` with no default bucket/key and
+  no query or fragment support.
+- Store contract: `Put`, bounded `Get` with required `MaxBytes`, and `Delete` only.
+- S3 implementation: `NewS3Store(ctx, S3StoreConfig{...})` uses AWS SDK v2 config loading while keeping the S3 client
+  seam private/test-only.
+- Encryption: bucket-default, S3-managed, and KMS modes fail closed on contradictory or missing KMS configuration.
+
+Guide: [Object Store Helper](./features/object-store.md)
+
 ## Migration and configuration notes
 
 Confirmed migration surface:

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -135,12 +135,12 @@ Important caveat:
   support is what gives `DynamoStreamStore` the strongest `DeleteSession`/`Append` race protection after spill writes
 - `MCP_STREAM_TTL_MINUTES` is the runtime replay window; expired event records are unreplayable before inline or spilled
   data is read, even if DynamoDB TTL and S3 lifecycle have not physically cleaned up yet
-- the construct also provisions a private, encrypted S3 spill bucket for large logical stream event payloads; DynamoDB
-  remains the replay index and stores the object pointer, byte count, and hash
+- the construct also provisions a private, S3-managed encrypted S3 spill bucket for large logical stream event payloads;
+  DynamoDB remains the replay index and stores the object pointer, byte count, and hash
 - `streamSpillInlineMaxBytes` defaults to `32768` and must not exceed the DynamoDB-safe inline ceiling of `358400`;
   larger logical events spill to S3 instead of risking DynamoDB item-size failures
-- MCP clients still receive normal JSON-RPC SSE messages. The spill bucket is never exposed through presigned URLs or a
-  client-visible chunking protocol.
+- MCP clients still receive normal JSON-RPC SSE messages. The spill bucket is accessed only through AppTheory's
+  private object-store helper and is never exposed through presigned URLs or a client-visible chunking protocol.
 
 Task table behavior:
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -16,6 +16,7 @@ contract.
 - [Logging Profiles](./logging-profiles.md)
 - [Jobs Ledger](./jobs-ledger.md)
 - [Event Workload Contracts](./event-workloads.md)
+- [Object Store Helper](./object-store.md)
 
 ## Boundary
 

--- a/docs/features/object-store.md
+++ b/docs/features/object-store.md
@@ -1,0 +1,92 @@
+---
+title: Object Store Helper
+---
+
+# Object Store Helper
+
+AppTheory exposes a narrow Go object-store helper in `pkg/objectstore` for framework-owned byte payload storage. It is
+intentionally small: one strict object reference type, one bounded `Store` interface, one S3-backed implementation, and a
+deterministic testkit fake.
+
+This helper exists so AppTheory-owned code paths can share one fail-closed S3 access pattern instead of reimplementing
+S3 get/put/delete, URL parsing, encryption headers, and bounded reads in each package. It is **not** a general storage
+SDK.
+
+## Surface
+
+- `ObjectRef{Bucket, Key, VersionID}` identifies exactly one object.
+- `ParseObjectRef("s3://bucket/key")` accepts only strict `s3://bucket/key` references.
+  - Bucket and key are required.
+  - No default bucket or default key is inferred.
+  - Query strings and fragments are rejected.
+  - Valid bucket and key values are preserved exactly; the parser does not normalize or URL-decode them.
+- `Store` supports only:
+  - `Put(ctx, PutInput) (ObjectRef, error)`
+  - `Get(ctx, GetInput) (*GetOutput, error)` with a required positive `MaxBytes`
+  - `Delete(ctx, DeleteInput) error`
+- `testkit/objectstore.NewStore()` provides an in-memory fake with call recording, failure injection, and copy-on-write
+  safety.
+
+## S3 implementation
+
+Create the S3 implementation through AppTheory, not by injecting an AWS client:
+
+```go
+store, err := objectstore.NewS3Store(ctx, objectstore.S3StoreConfig{
+  Encryption: objectstore.S3EncryptionConfig{Mode: objectstore.S3EncryptionS3Managed},
+})
+if err != nil {
+  return err
+}
+```
+
+`NewS3Store` loads AWS SDK v2 configuration and keeps the S3 client seam private to AppTheory tests. Public callers get
+only the `Store` contract.
+
+## Bounded reads
+
+Every `Get` call must provide a positive byte cap:
+
+```go
+out, err := store.Get(ctx, objectstore.GetInput{
+  Ref:      ref,
+  MaxBytes: 1 << 20,
+})
+```
+
+If the object body would exceed `MaxBytes`, the helper returns `objectstore.ErrObjectTooLarge`. There is no unbounded
+read method.
+
+## Fail-closed encryption
+
+S3 encryption configuration is validated before any S3 operation can be built:
+
+- `S3EncryptionBucketDefault` emits no SSE header and relies on the bucket's default encryption policy.
+- `S3EncryptionS3Managed` emits the S3-managed AES256 SSE header.
+- `S3EncryptionKMS` emits the AWS KMS SSE header and requires `KMSKeyID`.
+
+Invalid combinations fail closed with `objectstore.ErrInvalidEncryptionConfig`:
+
+- KMS mode without a key.
+- A blank or whitespace-padded KMS key.
+- A KMS key supplied for bucket-default or S3-managed mode.
+- Any unknown encryption mode.
+
+There is no silent fallback from KMS to bucket-default or S3-managed encryption.
+
+## Non-goals
+
+The helper deliberately does **not** provide:
+
+- listing
+- presigning
+- public URLs
+- multipart upload
+- copy or head operations
+- raw `*s3.Client` injection or exposure
+- client-side encryption
+- TypeScript or Python SDKs
+- product-specific schemas such as TheoryMCP records
+
+If an AppTheory-owned code path needs a new object-store behavior, grow this contract with tests instead of bypassing it
+with package-local S3 calls.

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -143,8 +143,9 @@ The MCP runtime fails closed around tool execution and durable replay:
   server-side and are not returned to clients
 - `DynamoSessionStore.Put` is an upsert, so sliding-session refreshes update the existing session data and TTL instead
   of failing when a session row already exists
-- S3-spilled stream events are read through bounded readers before replay validation; the read cap uses the recorded
-  event byte count and the configured maximum event size before size/hash validation
+- S3-spilled stream events are read through AppTheory's private object-store helper with bounded reads before replay
+  validation; the read cap uses the recorded event byte count and the configured maximum event size before size/hash
+  validation
 
 ### Capabilities advertisement (`initialize`)
 
@@ -608,8 +609,9 @@ Stream persistence note:
   `expiresAt <= now` as unreplayable even if DynamoDB TTL has not physically removed the item yet.
 - large logical stream events use the same MCP client contract: when `MCP_STREAM_SPILL_BUCKET` is set, events larger
   than `MCP_STREAM_SPILL_INLINE_MAX_BYTES` (default `32768`, clamped to the DynamoDB-safe inline ceiling of `358400`)
-  are stored as encrypted private S3 objects while DynamoDB keeps the logical event id, stream id, object pointer, byte
-  count, and SHA-256 hash; replay rehydrates the payload before emitting the same JSON-RPC SSE message
+  are stored as S3-managed encrypted private S3 objects through AppTheory's object-store helper while DynamoDB keeps the
+  logical event id, stream id, object pointer, byte count, and SHA-256 hash; replay rehydrates the payload before
+  emitting the same JSON-RPC SSE message
 - S3 lifecycle expiration is a best-effort cleanup backstop for spilled payload objects, not minute-level replay access
   enforcement; the runtime enforces replay access from the DynamoDB `expiresAt` value before reading inline or spilled
   event data.

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -173,14 +173,17 @@ in-flight tool context when that task is still running. If the work has already 
 rewritten.
 
 `AppTheoryRemoteMcpServer` also provisions the canonical private S3 spill bucket whenever `enableStreamTable` is true.
-The Dynamo stream store keeps small logical events inline in DynamoDB and spills larger events to S3 using the injected
-`MCP_STREAM_SPILL_BUCKET` configuration. The inline spill threshold is bounded to AppTheory's DynamoDB-safe ceiling so
+The Dynamo stream store keeps small logical events inline in DynamoDB and spills larger events to private S3 objects
+through AppTheory's internal object-store helper using the injected `MCP_STREAM_SPILL_BUCKET` and
+`MCP_STREAM_SPILL_PREFIX` configuration. Spill writes use S3-managed server-side encryption; there are no Remote MCP KMS
+construct props in this contract. The inline spill threshold is bounded to AppTheory's DynamoDB-safe ceiling so
 oversized inline writes fail closed into S3 spill instead of DynamoDB item-size errors. Clients still see one JSON-RPC
 SSE message per logical event, and resume/replay continues to use `Last-Event-ID`; there is no client-visible chunk or
 presigned URL protocol.
 
-Replay reads for S3-spilled events are bounded before validation: AppTheory caps the S3 body read by the recorded event
-byte count and `MCP_STREAM_MAX_EVENT_BYTES`, then verifies the recorded byte count and SHA-256 hash. Oversized,
+Replay reads for S3-spilled events go through the same private object-store helper and are bounded before validation:
+AppTheory caps the S3 body read by the recorded event byte count and `MCP_STREAM_MAX_EVENT_BYTES`, then verifies the
+recorded byte count and SHA-256 hash. Oversized,
 truncated, or tampered spill objects fail closed instead of being streamed to the client.
 
 `MCP_STREAM_TTL_MINUTES` is the runtime replay window. `DynamoStreamStore` rejects expired event records before

--- a/pkg/objectstore/objectref.go
+++ b/pkg/objectstore/objectref.go
@@ -1,0 +1,87 @@
+// Package objectstore provides AppTheory's narrow object-store helper surface.
+package objectstore
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+// ErrInvalidObjectRef is returned when an object reference is incomplete or unsupported.
+var ErrInvalidObjectRef = errors.New("objectstore: invalid object ref")
+
+// ObjectRef identifies one object in an S3-compatible object store.
+//
+// Bucket and Key are always required. VersionID is optional and is used only by
+// version-aware operations such as Get and Delete.
+type ObjectRef struct {
+	Bucket    string
+	Key       string
+	VersionID string
+}
+
+// ParseObjectRef parses a strict s3://bucket/key reference.
+//
+// The parser does not normalize, decode, or default any component: valid bucket
+// and key values are preserved exactly as they appear in the input reference.
+func ParseObjectRef(raw string) (ObjectRef, error) {
+	if raw == "" || raw != strings.TrimSpace(raw) {
+		return ObjectRef{}, ErrInvalidObjectRef
+	}
+	if strings.ContainsAny(raw, "?#") {
+		return ObjectRef{}, ErrInvalidObjectRef
+	}
+
+	const scheme = "s3://"
+	rest, ok := strings.CutPrefix(raw, scheme)
+	if !ok {
+		return ObjectRef{}, ErrInvalidObjectRef
+	}
+
+	bucket, key, ok := strings.Cut(rest, "/")
+	if !ok {
+		return ObjectRef{}, ErrInvalidObjectRef
+	}
+
+	ref := ObjectRef{Bucket: bucket, Key: key}
+	if err := ref.Validate(); err != nil {
+		return ObjectRef{}, err
+	}
+	return ref, nil
+}
+
+// Validate verifies that the reference has the components required for an
+// AppTheory object-store operation.
+func (r ObjectRef) Validate() error {
+	if r.Bucket == "" || r.Key == "" {
+		return ErrInvalidObjectRef
+	}
+	if strings.Contains(r.Bucket, "/") || strings.ContainsAny(r.Bucket, "?#") {
+		return ErrInvalidObjectRef
+	}
+	if strings.ContainsAny(r.Key, "?#") || strings.ContainsAny(r.VersionID, "?#") {
+		return ErrInvalidObjectRef
+	}
+	if containsControlOrSpace(r.Bucket) || containsControl(r.Key) || containsControl(r.VersionID) {
+		return ErrInvalidObjectRef
+	}
+	return nil
+}
+
+func containsControl(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsControlOrSpace(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/objectstore/objectref_test.go
+++ b/pkg/objectstore/objectref_test.go
@@ -1,0 +1,114 @@
+package objectstore
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseObjectRef(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want ObjectRef
+	}{
+		{
+			name: "simple",
+			raw:  "s3://bucket-a/path/to/object.json",
+			want: ObjectRef{Bucket: "bucket-a", Key: "path/to/object.json"},
+		},
+		{
+			name: "preserves bucket and key exactly",
+			raw:  "s3://bucket.with.dots/Prefix/Case%2Fkept.json",
+			want: ObjectRef{Bucket: "bucket.with.dots", Key: "Prefix/Case%2Fkept.json"},
+		},
+		{
+			name: "key can start with slash",
+			raw:  "s3://bucket-a//leading/slash.json",
+			want: ObjectRef{Bucket: "bucket-a", Key: "/leading/slash.json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseObjectRef(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseObjectRef() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseObjectRef() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseObjectRefInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "trimmed ref rejected", raw: " s3://bucket-a/key"},
+		{name: "wrong scheme", raw: "https://bucket-a/key"},
+		{name: "uppercase scheme", raw: "S3://bucket-a/key"},
+		{name: "missing bucket", raw: "s3:///key"},
+		{name: "missing key", raw: "s3://bucket-a/"},
+		{name: "missing slash", raw: "s3://bucket-a"},
+		{name: "query rejected", raw: "s3://bucket-a/key?versionId=1"},
+		{name: "fragment rejected", raw: "s3://bucket-a/key#frag"},
+		{name: "bucket space rejected", raw: "s3://bucket a/key"},
+		{name: "bucket control rejected", raw: "s3://bucket\na/key"},
+		{name: "key control rejected", raw: "s3://bucket-a/key\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseObjectRef(tt.raw)
+			if !errors.Is(err, ErrInvalidObjectRef) {
+				t.Fatalf("ParseObjectRef() error = %v, want ErrInvalidObjectRef", err)
+			}
+		})
+	}
+}
+
+func TestObjectRefValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  ObjectRef
+	}{
+		{name: "basic", ref: ObjectRef{Bucket: "bucket-a", Key: "key"}},
+		{name: "versioned", ref: ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "version-1"}},
+		{name: "space in key preserved", ref: ObjectRef{Bucket: "bucket-a", Key: "key with spaces"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.ref.Validate(); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestObjectRefValidateInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  ObjectRef
+	}{
+		{name: "missing bucket", ref: ObjectRef{Key: "key"}},
+		{name: "missing key", ref: ObjectRef{Bucket: "bucket-a"}},
+		{name: "bucket slash", ref: ObjectRef{Bucket: "bucket/a", Key: "key"}},
+		{name: "bucket query", ref: ObjectRef{Bucket: "bucket-a?x", Key: "key"}},
+		{name: "key query", ref: ObjectRef{Bucket: "bucket-a", Key: "key?x"}},
+		{name: "version query", ref: ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "v?1"}},
+		{name: "bucket space", ref: ObjectRef{Bucket: "bucket a", Key: "key"}},
+		{name: "key control", ref: ObjectRef{Bucket: "bucket-a", Key: "key\n"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.ref.Validate(); !errors.Is(err, ErrInvalidObjectRef) {
+				t.Fatalf("Validate() error = %v, want ErrInvalidObjectRef", err)
+			}
+		})
+	}
+}

--- a/pkg/objectstore/s3.go
+++ b/pkg/objectstore/s3.go
@@ -1,0 +1,160 @@
+package objectstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// ErrInvalidStoreConfig is returned when an object-store implementation is misconfigured.
+var ErrInvalidStoreConfig = errors.New("objectstore: invalid store config")
+
+// S3StoreConfig configures the narrow S3-backed Store implementation.
+type S3StoreConfig struct{}
+
+// NewS3Store loads AWS SDK v2 configuration and returns the S3-backed Store.
+func NewS3Store(ctx context.Context, storeConfig S3StoreConfig) (Store, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return newS3StoreWithClient(s3.NewFromConfig(cfg), storeConfig)
+}
+
+type s3Store struct {
+	client s3StoreClient
+}
+
+type s3StoreClient interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+func newS3StoreWithClient(client s3StoreClient, _ S3StoreConfig) (*s3Store, error) {
+	if client == nil {
+		return nil, ErrInvalidStoreConfig
+	}
+	return &s3Store{client: client}, nil
+}
+
+func (s *s3Store) Put(ctx context.Context, input PutInput) (ObjectRef, error) {
+	if err := s.requireClient(); err != nil {
+		return ObjectRef{}, err
+	}
+	if err := validatePutInput(input); err != nil {
+		return ObjectRef{}, err
+	}
+
+	params := &s3.PutObjectInput{
+		Bucket: aws.String(input.Ref.Bucket),
+		Key:    aws.String(input.Ref.Key),
+		Body:   bytes.NewReader(input.Payload),
+	}
+	if input.ContentType != "" {
+		params.ContentType = aws.String(input.ContentType)
+	}
+	if len(input.Metadata) > 0 {
+		params.Metadata = cloneMetadata(input.Metadata)
+	}
+
+	out, err := s.client.PutObject(ctx, params)
+	if err != nil {
+		return ObjectRef{}, err
+	}
+	ref := input.Ref
+	if out != nil && out.VersionId != nil {
+		ref.VersionID = aws.ToString(out.VersionId)
+	}
+	return ref, nil
+}
+
+func (s *s3Store) Get(ctx context.Context, input GetInput) (*GetOutput, error) {
+	if err := s.requireClient(); err != nil {
+		return nil, err
+	}
+	if err := validateGetInput(input); err != nil {
+		return nil, err
+	}
+
+	params := &s3.GetObjectInput{
+		Bucket: aws.String(input.Ref.Bucket),
+		Key:    aws.String(input.Ref.Key),
+	}
+	if input.Ref.VersionID != "" {
+		params.VersionId = aws.String(input.Ref.VersionID)
+	}
+
+	out, err := s.client.GetObject(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if out == nil || out.Body == nil {
+		return nil, ErrInvalidStoreConfig
+	}
+
+	payload, readErr := readBounded(out.Body, input.MaxBytes)
+	closeErr := out.Body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	ref := input.Ref
+	if out.VersionId != nil {
+		ref.VersionID = aws.ToString(out.VersionId)
+	}
+	return &GetOutput{
+		Ref:         ref,
+		Payload:     payload,
+		ContentType: aws.ToString(out.ContentType),
+		Metadata:    cloneMetadata(out.Metadata),
+	}, nil
+}
+
+func (s *s3Store) Delete(ctx context.Context, input DeleteInput) error {
+	if err := s.requireClient(); err != nil {
+		return err
+	}
+	if err := validateDeleteInput(input); err != nil {
+		return err
+	}
+
+	params := &s3.DeleteObjectInput{
+		Bucket: aws.String(input.Ref.Bucket),
+		Key:    aws.String(input.Ref.Key),
+	}
+	if input.Ref.VersionID != "" {
+		params.VersionId = aws.String(input.Ref.VersionID)
+	}
+	_, err := s.client.DeleteObject(ctx, params)
+	return err
+}
+
+func (s *s3Store) requireClient() error {
+	if s == nil || s.client == nil {
+		return ErrInvalidStoreConfig
+	}
+	return nil
+}
+
+func readBounded(body io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, ErrInvalidGetLimit
+	}
+	payload, err := io.ReadAll(io.LimitReader(body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(payload)) > maxBytes {
+		return nil, ErrObjectTooLarge
+	}
+	return payload, nil
+}

--- a/pkg/objectstore/s3.go
+++ b/pkg/objectstore/s3.go
@@ -5,20 +5,48 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // ErrInvalidStoreConfig is returned when an object-store implementation is misconfigured.
 var ErrInvalidStoreConfig = errors.New("objectstore: invalid store config")
 
+// ErrInvalidEncryptionConfig is returned when S3 encryption options are contradictory or incomplete.
+var ErrInvalidEncryptionConfig = errors.New("objectstore: invalid encryption config")
+
+// S3EncryptionMode selects the server-side encryption headers emitted for S3 PutObject.
+type S3EncryptionMode string
+
+const (
+	// S3EncryptionBucketDefault emits no server-side encryption headers and relies on bucket policy/defaults.
+	S3EncryptionBucketDefault S3EncryptionMode = "bucket-default"
+	// S3EncryptionS3Managed emits the S3-managed AES256 server-side encryption header.
+	S3EncryptionS3Managed S3EncryptionMode = "s3-managed"
+	// S3EncryptionKMS emits AWS KMS server-side encryption headers with a required key ID.
+	S3EncryptionKMS S3EncryptionMode = "kms"
+)
+
+// S3EncryptionConfig configures fail-closed S3 server-side encryption headers.
+type S3EncryptionConfig struct {
+	Mode     S3EncryptionMode
+	KMSKeyID string
+}
+
 // S3StoreConfig configures the narrow S3-backed Store implementation.
-type S3StoreConfig struct{}
+type S3StoreConfig struct {
+	Encryption S3EncryptionConfig
+}
 
 // NewS3Store loads AWS SDK v2 configuration and returns the S3-backed Store.
 func NewS3Store(ctx context.Context, storeConfig S3StoreConfig) (Store, error) {
+	if _, err := normalizeS3StoreConfig(storeConfig); err != nil {
+		return nil, err
+	}
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -27,7 +55,8 @@ func NewS3Store(ctx context.Context, storeConfig S3StoreConfig) (Store, error) {
 }
 
 type s3Store struct {
-	client s3StoreClient
+	client     s3StoreClient
+	encryption S3EncryptionConfig
 }
 
 type s3StoreClient interface {
@@ -36,11 +65,15 @@ type s3StoreClient interface {
 	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
-func newS3StoreWithClient(client s3StoreClient, _ S3StoreConfig) (*s3Store, error) {
+func newS3StoreWithClient(client s3StoreClient, storeConfig S3StoreConfig) (*s3Store, error) {
+	normalized, err := normalizeS3StoreConfig(storeConfig)
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return nil, ErrInvalidStoreConfig
 	}
-	return &s3Store{client: client}, nil
+	return &s3Store{client: client, encryption: normalized.Encryption}, nil
 }
 
 func (s *s3Store) Put(ctx context.Context, input PutInput) (ObjectRef, error) {
@@ -62,6 +95,7 @@ func (s *s3Store) Put(ctx context.Context, input PutInput) (ObjectRef, error) {
 	if len(input.Metadata) > 0 {
 		params.Metadata = cloneMetadata(input.Metadata)
 	}
+	applyS3Encryption(params, s.encryption)
 
 	out, err := s.client.PutObject(ctx, params)
 	if err != nil {
@@ -143,6 +177,44 @@ func (s *s3Store) requireClient() error {
 		return ErrInvalidStoreConfig
 	}
 	return nil
+}
+
+func normalizeS3StoreConfig(storeConfig S3StoreConfig) (S3StoreConfig, error) {
+	mode := storeConfig.Encryption.Mode
+	if mode == "" {
+		mode = S3EncryptionBucketDefault
+	}
+	kmsKeyID := storeConfig.Encryption.KMSKeyID
+	if kmsKeyID != strings.TrimSpace(kmsKeyID) {
+		return S3StoreConfig{}, ErrInvalidEncryptionConfig
+	}
+
+	switch mode {
+	case S3EncryptionBucketDefault, S3EncryptionS3Managed:
+		if kmsKeyID != "" {
+			return S3StoreConfig{}, ErrInvalidEncryptionConfig
+		}
+	case S3EncryptionKMS:
+		if kmsKeyID == "" {
+			return S3StoreConfig{}, ErrInvalidEncryptionConfig
+		}
+	default:
+		return S3StoreConfig{}, ErrInvalidEncryptionConfig
+	}
+
+	storeConfig.Encryption.Mode = mode
+	storeConfig.Encryption.KMSKeyID = kmsKeyID
+	return storeConfig, nil
+}
+
+func applyS3Encryption(params *s3.PutObjectInput, encryption S3EncryptionConfig) {
+	switch encryption.Mode {
+	case S3EncryptionS3Managed:
+		params.ServerSideEncryption = types.ServerSideEncryptionAes256
+	case S3EncryptionKMS:
+		params.ServerSideEncryption = types.ServerSideEncryptionAwsKms
+		params.SSEKMSKeyId = aws.String(encryption.KMSKeyID)
+	}
 }
 
 func readBounded(body io.Reader, maxBytes int64) ([]byte, error) {

--- a/pkg/objectstore/s3_test.go
+++ b/pkg/objectstore/s3_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 func TestS3StorePutGetDelete(t *testing.T) {
@@ -182,4 +183,102 @@ type trackingReadCloser struct {
 func (r *trackingReadCloser) Close() error {
 	*r.closed = true
 	return nil
+}
+
+func TestS3StoreEncryption(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    S3StoreConfig
+		wantSSE   types.ServerSideEncryption
+		wantKMSID string
+	}{
+		{name: "bucket default", config: S3StoreConfig{}, wantSSE: ""},
+		{
+			name:    "s3 managed",
+			config:  S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionS3Managed}},
+			wantSSE: types.ServerSideEncryptionAes256,
+		},
+		{
+			name:      "kms",
+			config:    S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionKMS, KMSKeyID: "arn:aws:kms:us-east-1:123456789012:key/abc"}},
+			wantSSE:   types.ServerSideEncryptionAwsKms,
+			wantKMSID: "arn:aws:kms:us-east-1:123456789012:key/abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &recordingS3Client{}
+			store, err := newS3StoreWithClient(client, tt.config)
+			if err != nil {
+				t.Fatalf("newS3StoreWithClient() error = %v", err)
+			}
+			_, err = store.Put(context.Background(), PutInput{
+				Ref:     ObjectRef{Bucket: "bucket-a", Key: "key"},
+				Payload: []byte("payload"),
+			})
+			if err != nil {
+				t.Fatalf("Put() error = %v", err)
+			}
+			if client.putInput.ServerSideEncryption != tt.wantSSE {
+				t.Fatalf("ServerSideEncryption = %q, want %q", client.putInput.ServerSideEncryption, tt.wantSSE)
+			}
+			if aws.ToString(client.putInput.SSEKMSKeyId) != tt.wantKMSID {
+				t.Fatalf("SSEKMSKeyId = %q, want %q", aws.ToString(client.putInput.SSEKMSKeyId), tt.wantKMSID)
+			}
+		})
+	}
+}
+
+func TestS3StoreEncryptionFailClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		config S3StoreConfig
+	}{
+		{
+			name:   "kms mode without key",
+			config: S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionKMS}},
+		},
+		{
+			name:   "kms mode with blank key",
+			config: S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionKMS, KMSKeyID: " "}},
+		},
+		{
+			name:   "s3 managed with kms key",
+			config: S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionS3Managed, KMSKeyID: "key"}},
+		},
+		{
+			name:   "bucket default with kms key",
+			config: S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionBucketDefault, KMSKeyID: "key"}},
+		},
+		{
+			name:   "unknown mode",
+			config: S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionMode("custom")}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &recordingS3Client{}
+			store, err := newS3StoreWithClient(client, tt.config)
+			if !errors.Is(err, ErrInvalidEncryptionConfig) {
+				t.Fatalf("newS3StoreWithClient() error = %v, want ErrInvalidEncryptionConfig", err)
+			}
+			if store != nil {
+				t.Fatalf("newS3StoreWithClient() returned store for invalid config")
+			}
+			if len(client.operations) != 0 {
+				t.Fatalf("invalid encryption config reached S3 client: %#v", client.operations)
+			}
+		})
+	}
+}
+
+func TestNewS3StoreEncryptionValidationPrecedesAWSConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := NewS3Store(ctx, S3StoreConfig{Encryption: S3EncryptionConfig{Mode: S3EncryptionKMS}})
+	if !errors.Is(err, ErrInvalidEncryptionConfig) {
+		t.Fatalf("NewS3Store() error = %v, want ErrInvalidEncryptionConfig", err)
+	}
 }

--- a/pkg/objectstore/s3_test.go
+++ b/pkg/objectstore/s3_test.go
@@ -1,0 +1,185 @@
+package objectstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestS3StorePutGetDelete(t *testing.T) {
+	client := &recordingS3Client{
+		putVersionID: "put-v1",
+		getVersionID: "get-v1",
+		getBody:      []byte("payload"),
+		contentType:  "application/json",
+		metadata:     map[string]string{"sha256": "abc"},
+	}
+	store, err := newS3StoreWithClient(client, S3StoreConfig{})
+	if err != nil {
+		t.Fatalf("newS3StoreWithClient() error = %v", err)
+	}
+
+	putRef, err := store.Put(context.Background(), PutInput{
+		Ref:         ObjectRef{Bucket: "bucket-a", Key: "objects/1.json"},
+		Payload:     []byte("payload"),
+		ContentType: "application/json",
+		Metadata:    map[string]string{"sha256": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if putRef != (ObjectRef{Bucket: "bucket-a", Key: "objects/1.json", VersionID: "put-v1"}) {
+		t.Fatalf("Put() ref = %#v", putRef)
+	}
+	if aws.ToString(client.putInput.Bucket) != "bucket-a" || aws.ToString(client.putInput.Key) != "objects/1.json" {
+		t.Fatalf("PutObject bucket/key mismatch: %#v", client.putInput)
+	}
+	if client.putInput.Metadata["sha256"] != "abc" || aws.ToString(client.putInput.ContentType) != "application/json" {
+		t.Fatalf("PutObject metadata/content type mismatch: %#v", client.putInput)
+	}
+
+	got, err := store.Get(context.Background(), GetInput{
+		Ref:      ObjectRef{Bucket: "bucket-a", Key: "objects/1.json", VersionID: "get-v1"},
+		MaxBytes: 7,
+	})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if string(got.Payload) != "payload" || got.Ref.VersionID != "get-v1" {
+		t.Fatalf("Get() output mismatch: %#v", got)
+	}
+	if got.ContentType != "application/json" || got.Metadata["sha256"] != "abc" {
+		t.Fatalf("Get() metadata/content type mismatch: %#v", got)
+	}
+	if !client.bodyClosed {
+		t.Fatalf("Get() did not close body")
+	}
+	if aws.ToString(client.getInput.VersionId) != "get-v1" {
+		t.Fatalf("GetObject VersionId = %q", aws.ToString(client.getInput.VersionId))
+	}
+
+	if err := store.Delete(context.Background(), DeleteInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "objects/1.json", VersionID: "del-v1"}}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if aws.ToString(client.deleteInput.VersionId) != "del-v1" {
+		t.Fatalf("DeleteObject VersionId = %q", aws.ToString(client.deleteInput.VersionId))
+	}
+	if !reflect.DeepEqual(client.operations, []string{"PutObject", "GetObject", "DeleteObject"}) {
+		t.Fatalf("operations = %#v", client.operations)
+	}
+}
+
+func TestS3StoreGetBoundsAndClosesBody(t *testing.T) {
+	client := &recordingS3Client{getBody: []byte("too-large")}
+	store, err := newS3StoreWithClient(client, S3StoreConfig{})
+	if err != nil {
+		t.Fatalf("newS3StoreWithClient() error = %v", err)
+	}
+
+	_, err = store.Get(context.Background(), GetInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key"}, MaxBytes: 3})
+	if !errors.Is(err, ErrObjectTooLarge) {
+		t.Fatalf("Get() error = %v, want ErrObjectTooLarge", err)
+	}
+	if !client.bodyClosed {
+		t.Fatalf("Get() did not close body after bounded read failure")
+	}
+}
+
+func TestS3StoreFailClosedValidation(t *testing.T) {
+	client := &recordingS3Client{}
+	store, err := newS3StoreWithClient(client, S3StoreConfig{})
+	if err != nil {
+		t.Fatalf("newS3StoreWithClient() error = %v", err)
+	}
+
+	_, err = store.Put(context.Background(), PutInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "v1"}})
+	if !errors.Is(err, ErrInvalidObjectRef) {
+		t.Fatalf("Put() with VersionID error = %v, want ErrInvalidObjectRef", err)
+	}
+	_, err = store.Get(context.Background(), GetInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key"}})
+	if !errors.Is(err, ErrInvalidGetLimit) {
+		t.Fatalf("Get() without cap error = %v, want ErrInvalidGetLimit", err)
+	}
+	if err := store.Delete(context.Background(), DeleteInput{Ref: ObjectRef{Bucket: "bucket-a"}}); !errors.Is(err, ErrInvalidObjectRef) {
+		t.Fatalf("Delete() invalid ref error = %v, want ErrInvalidObjectRef", err)
+	}
+	if len(client.operations) != 0 {
+		t.Fatalf("invalid requests reached S3 client: %#v", client.operations)
+	}
+}
+
+func TestS3StoreConfigValidation(t *testing.T) {
+	_, err := newS3StoreWithClient(nil, S3StoreConfig{})
+	if !errors.Is(err, ErrInvalidStoreConfig) {
+		t.Fatalf("newS3StoreWithClient(nil) error = %v, want ErrInvalidStoreConfig", err)
+	}
+	var nilStore *s3Store
+	_, err = nilStore.Get(context.Background(), GetInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key"}, MaxBytes: 1})
+	if !errors.Is(err, ErrInvalidStoreConfig) {
+		t.Fatalf("nilStore.Get() error = %v, want ErrInvalidStoreConfig", err)
+	}
+}
+
+func TestNewS3StoreLoadsAWSConfig(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	store, err := NewS3Store(context.Background(), S3StoreConfig{})
+	if err != nil {
+		t.Fatalf("NewS3Store() error = %v", err)
+	}
+	if store == nil {
+		t.Fatalf("NewS3Store() returned nil store")
+	}
+}
+
+type recordingS3Client struct {
+	operations   []string
+	putInput     *s3.PutObjectInput
+	getInput     *s3.GetObjectInput
+	deleteInput  *s3.DeleteObjectInput
+	putVersionID string
+	getVersionID string
+	getBody      []byte
+	contentType  string
+	metadata     map[string]string
+	bodyClosed   bool
+}
+
+func (c *recordingS3Client) PutObject(_ context.Context, params *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	c.operations = append(c.operations, "PutObject")
+	c.putInput = params
+	return &s3.PutObjectOutput{VersionId: aws.String(c.putVersionID)}, nil
+}
+
+func (c *recordingS3Client) GetObject(_ context.Context, params *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	c.operations = append(c.operations, "GetObject")
+	c.getInput = params
+	return &s3.GetObjectOutput{
+		Body:        &trackingReadCloser{Reader: bytes.NewReader(c.getBody), closed: &c.bodyClosed},
+		VersionId:   aws.String(c.getVersionID),
+		ContentType: aws.String(c.contentType),
+		Metadata:    cloneMetadata(c.metadata),
+	}, nil
+}
+
+func (c *recordingS3Client) DeleteObject(_ context.Context, params *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	c.operations = append(c.operations, "DeleteObject")
+	c.deleteInput = params
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed *bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	*r.closed = true
+	return nil
+}

--- a/pkg/objectstore/store.go
+++ b/pkg/objectstore/store.go
@@ -1,0 +1,93 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+)
+
+// Stable object-store operation errors.
+var (
+	// ErrInvalidGetLimit is returned when a Get request does not set a positive byte cap.
+	ErrInvalidGetLimit = errors.New("objectstore: max bytes must be positive")
+	// ErrObjectTooLarge is returned when a bounded Get would exceed its byte cap.
+	ErrObjectTooLarge = errors.New("objectstore: object exceeds max bytes")
+	// ErrObjectNotFound is returned by deterministic stores when the requested object is absent.
+	ErrObjectNotFound = errors.New("objectstore: object not found")
+)
+
+// Store is AppTheory's narrow object-store contract.
+//
+// It intentionally supports only byte Put, bounded Get, and Delete. There is no
+// unbounded read method and no listing, presigning, public URL, multipart, copy,
+// head, or raw client escape hatch.
+type Store interface {
+	Put(context.Context, PutInput) (ObjectRef, error)
+	Get(context.Context, GetInput) (*GetOutput, error)
+	Delete(context.Context, DeleteInput) error
+}
+
+// PutInput writes a byte payload to one object reference.
+type PutInput struct {
+	Ref         ObjectRef
+	Payload     []byte
+	ContentType string
+	Metadata    map[string]string
+}
+
+// GetInput reads one object reference with a required maximum byte cap.
+type GetInput struct {
+	Ref      ObjectRef
+	MaxBytes int64
+}
+
+// GetOutput is the bounded byte payload returned by Store.Get.
+type GetOutput struct {
+	Ref         ObjectRef
+	Payload     []byte
+	ContentType string
+	Metadata    map[string]string
+}
+
+// DeleteInput removes one object reference. Ref.VersionID is honored by stores
+// that support versioned objects.
+type DeleteInput struct {
+	Ref ObjectRef
+}
+
+func validatePutInput(input PutInput) error {
+	return input.Ref.Validate()
+}
+
+func validateGetInput(input GetInput) error {
+	if err := input.Ref.Validate(); err != nil {
+		return err
+	}
+	if input.MaxBytes <= 0 {
+		return ErrInvalidGetLimit
+	}
+	return nil
+}
+
+func validateDeleteInput(input DeleteInput) error {
+	return input.Ref.Validate()
+}
+
+func cloneBytes(in []byte) []byte {
+	if in == nil {
+		return nil
+	}
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneMetadata(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/objectstore/store.go
+++ b/pkg/objectstore/store.go
@@ -55,7 +55,13 @@ type DeleteInput struct {
 }
 
 func validatePutInput(input PutInput) error {
-	return input.Ref.Validate()
+	if err := input.Ref.Validate(); err != nil {
+		return err
+	}
+	if input.Ref.VersionID != "" {
+		return ErrInvalidObjectRef
+	}
+	return nil
 }
 
 func validateGetInput(input GetInput) error {

--- a/pkg/objectstore/store_test.go
+++ b/pkg/objectstore/store_test.go
@@ -16,7 +16,8 @@ func (*contractStore) Delete(context.Context, DeleteInput) error         { retur
 
 func TestValidateStoreInputs(t *testing.T) {
 	ref := ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "version-1"}
-	if err := validatePutInput(PutInput{Ref: ref, Payload: []byte("payload")}); err != nil {
+	putRef := ObjectRef{Bucket: "bucket-a", Key: "key"}
+	if err := validatePutInput(PutInput{Ref: putRef, Payload: []byte("payload")}); err != nil {
 		t.Fatalf("validatePutInput() error = %v", err)
 	}
 	if err := validateGetInput(GetInput{Ref: ref, MaxBytes: 1}); err != nil {
@@ -30,6 +31,9 @@ func TestValidateStoreInputs(t *testing.T) {
 func TestValidateStoreInputsFailClosed(t *testing.T) {
 	if err := validatePutInput(PutInput{Ref: ObjectRef{Bucket: "bucket-a"}}); !errors.Is(err, ErrInvalidObjectRef) {
 		t.Fatalf("validatePutInput() error = %v, want ErrInvalidObjectRef", err)
+	}
+	if err := validatePutInput(PutInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "v1"}}); !errors.Is(err, ErrInvalidObjectRef) {
+		t.Fatalf("validatePutInput() version error = %v, want ErrInvalidObjectRef", err)
 	}
 	if err := validateGetInput(GetInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key"}}); !errors.Is(err, ErrInvalidGetLimit) {
 		t.Fatalf("validateGetInput() error = %v, want ErrInvalidGetLimit", err)

--- a/pkg/objectstore/store_test.go
+++ b/pkg/objectstore/store_test.go
@@ -1,0 +1,59 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+var _ Store = (*contractStore)(nil)
+
+type contractStore struct{}
+
+func (*contractStore) Put(context.Context, PutInput) (ObjectRef, error)  { return ObjectRef{}, nil }
+func (*contractStore) Get(context.Context, GetInput) (*GetOutput, error) { return nil, nil }
+func (*contractStore) Delete(context.Context, DeleteInput) error         { return nil }
+
+func TestValidateStoreInputs(t *testing.T) {
+	ref := ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "version-1"}
+	if err := validatePutInput(PutInput{Ref: ref, Payload: []byte("payload")}); err != nil {
+		t.Fatalf("validatePutInput() error = %v", err)
+	}
+	if err := validateGetInput(GetInput{Ref: ref, MaxBytes: 1}); err != nil {
+		t.Fatalf("validateGetInput() error = %v", err)
+	}
+	if err := validateDeleteInput(DeleteInput{Ref: ref}); err != nil {
+		t.Fatalf("validateDeleteInput() error = %v", err)
+	}
+}
+
+func TestValidateStoreInputsFailClosed(t *testing.T) {
+	if err := validatePutInput(PutInput{Ref: ObjectRef{Bucket: "bucket-a"}}); !errors.Is(err, ErrInvalidObjectRef) {
+		t.Fatalf("validatePutInput() error = %v, want ErrInvalidObjectRef", err)
+	}
+	if err := validateGetInput(GetInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key"}}); !errors.Is(err, ErrInvalidGetLimit) {
+		t.Fatalf("validateGetInput() error = %v, want ErrInvalidGetLimit", err)
+	}
+	if err := validateGetInput(GetInput{Ref: ObjectRef{Bucket: "bucket-a", Key: "key"}, MaxBytes: -1}); !errors.Is(err, ErrInvalidGetLimit) {
+		t.Fatalf("validateGetInput() negative cap error = %v, want ErrInvalidGetLimit", err)
+	}
+	if err := validateDeleteInput(DeleteInput{Ref: ObjectRef{Bucket: "bucket-a"}}); !errors.Is(err, ErrInvalidObjectRef) {
+		t.Fatalf("validateDeleteInput() error = %v, want ErrInvalidObjectRef", err)
+	}
+}
+
+func TestCloneHelpersCopyOnWrite(t *testing.T) {
+	payload := []byte("payload")
+	payloadCopy := cloneBytes(payload)
+	payload[0] = 'P'
+	if string(payloadCopy) != "payload" {
+		t.Fatalf("cloneBytes() = %q, want payload", payloadCopy)
+	}
+
+	metadata := map[string]string{"a": "b"}
+	metadataCopy := cloneMetadata(metadata)
+	metadata["a"] = "changed"
+	if metadataCopy["a"] != "b" {
+		t.Fatalf("cloneMetadata() = %#v, want original value", metadataCopy)
+	}
+}

--- a/runtime/mcp/stream_store_dynamo.go
+++ b/runtime/mcp/stream_store_dynamo.go
@@ -777,9 +777,9 @@ func (d *DynamoStreamStore) spillStreamData(
 	expiresAt int64,
 	sha256Hex string,
 ) (string, error) {
-	if s3Store, ok := d.spillStore.(*dynamoStreamS3SpillStore); ok {
-		key := s3Store.objectKey(sessionID, eventID)
-		if err := s3Store.put(ctx, key, payload, expiresAt, sha256Hex); err != nil {
+	if keyer, ok := d.spillStore.(interface{ objectKey(string, string) string }); ok {
+		key := keyer.objectKey(sessionID, eventID)
+		if err := d.spillStore.put(ctx, key, payload, expiresAt, sha256Hex); err != nil {
 			return "", err
 		}
 		return key, nil

--- a/runtime/mcp/stream_store_dynamo_spill.go
+++ b/runtime/mcp/stream_store_dynamo_spill.go
@@ -1,21 +1,17 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/theory-cloud/apptheory/pkg/objectstore"
 )
 
 const (
@@ -36,19 +32,13 @@ type dynamoStreamSpillStore interface {
 	delete(ctx context.Context, key string) error
 }
 
-type dynamoStreamS3SpillStore struct {
+type dynamoStreamObjectSpillStore struct {
 	bucket string
 	prefix string
 
-	mu         sync.Mutex
-	client     dynamoStreamS3Client
-	loadClient func(context.Context) (dynamoStreamS3Client, error)
-}
-
-type dynamoStreamS3Client interface {
-	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
-	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
-	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	mu        sync.Mutex
+	store     objectstore.Store
+	loadStore func(context.Context) (objectstore.Store, error)
 }
 
 func newDynamoStreamSpillStoreFromEnv() dynamoStreamSpillStore {
@@ -62,26 +52,25 @@ func newDynamoStreamSpillStoreFromEnv() dynamoStreamSpillStore {
 		prefix = defaultDynamoStreamSpillPrefix
 	}
 
-	return &dynamoStreamS3SpillStore{
+	return &dynamoStreamObjectSpillStore{
 		bucket: bucket,
 		prefix: prefix,
 	}
 }
 
-func (s *dynamoStreamS3SpillStore) put(ctx context.Context, key string, data []byte, expiresAt int64, sha256Hex string) error {
+func (s *dynamoStreamObjectSpillStore) put(ctx context.Context, key string, data []byte, expiresAt int64, sha256Hex string) error {
 	if s == nil {
 		return errors.New("stream spill store not configured")
 	}
-	client, err := s.s3Client(ctx)
+	store, err := s.objectStore(ctx)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:      aws.String(s.bucket),
-		Key:         aws.String(key),
-		Body:        bytes.NewReader(data),
-		ContentType: aws.String("application/json"),
+	_, err = store.Put(ctx, objectstore.PutInput{
+		Ref:         objectstore.ObjectRef{Bucket: s.bucket, Key: key},
+		Payload:     data,
+		ContentType: "application/json",
 		Metadata: map[string]string{
 			"expires-at": strconv.FormatInt(expiresAt, 10),
 			"sha256":     sha256Hex,
@@ -90,90 +79,73 @@ func (s *dynamoStreamS3SpillStore) put(ctx context.Context, key string, data []b
 	return err
 }
 
-func (s *dynamoStreamS3SpillStore) get(ctx context.Context, key string, maxBytes int) ([]byte, error) {
+func (s *dynamoStreamObjectSpillStore) get(ctx context.Context, key string, maxBytes int) ([]byte, error) {
 	if s == nil {
 		return nil, errors.New("stream spill store not configured")
 	}
-	client, err := s.s3Client(ctx)
+	store, err := s.objectStore(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	out, err := client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if closeErr := out.Body.Close(); closeErr != nil {
-			// The payload has already been read or the read path will return its own
-			// error. Close failures do not alter the stream event contract.
-			return
-		}
-	}()
 
 	if maxBytes <= 0 {
 		maxBytes = dynamoStreamMaxEventBytes()
 	}
-	payload, err := io.ReadAll(io.LimitReader(out.Body, int64(maxBytes)+1))
+	out, err := store.Get(ctx, objectstore.GetInput{
+		Ref:      objectstore.ObjectRef{Bucket: s.bucket, Key: key},
+		MaxBytes: int64(maxBytes),
+	})
 	if err != nil {
+		if errors.Is(err, objectstore.ErrObjectTooLarge) {
+			return nil, fmt.Errorf("stream spill object exceeds max event bytes")
+		}
 		return nil, err
 	}
-	if len(payload) > maxBytes {
-		return nil, fmt.Errorf("stream spill object exceeds max event bytes")
-	}
-
+	payload := make([]byte, len(out.Payload))
+	copy(payload, out.Payload)
 	return payload, nil
 }
 
-func (s *dynamoStreamS3SpillStore) delete(ctx context.Context, key string) error {
+func (s *dynamoStreamObjectSpillStore) delete(ctx context.Context, key string) error {
 	if s == nil {
 		return errors.New("stream spill store not configured")
 	}
-	client, err := s.s3Client(ctx)
+	store, err := s.objectStore(ctx)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
-	})
-	return err
+	return store.Delete(ctx, objectstore.DeleteInput{Ref: objectstore.ObjectRef{Bucket: s.bucket, Key: key}})
 }
 
-func (s *dynamoStreamS3SpillStore) s3Client(ctx context.Context) (dynamoStreamS3Client, error) {
+func (s *dynamoStreamObjectSpillStore) objectStore(ctx context.Context) (objectstore.Store, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.client != nil {
-		return s.client, nil
+	if s.store != nil {
+		return s.store, nil
 	}
 
-	loadClient := s.loadClient
-	if loadClient == nil {
-		loadClient = newDynamoStreamS3Client
+	loadStore := s.loadStore
+	if loadStore == nil {
+		loadStore = newDynamoStreamObjectStore
 	}
-	client, err := loadClient(ctx)
+	store, err := loadStore(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	s.client = client
-	return s.client, nil
+	s.store = store
+	return s.store, nil
 }
 
-func newDynamoStreamS3Client(ctx context.Context) (dynamoStreamS3Client, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s3.NewFromConfig(cfg), nil
+func newDynamoStreamObjectStore(ctx context.Context) (objectstore.Store, error) {
+	return objectstore.NewS3Store(ctx, objectstore.S3StoreConfig{
+		Encryption: objectstore.S3EncryptionConfig{Mode: objectstore.S3EncryptionS3Managed},
+	})
 }
 
-func (s *dynamoStreamS3SpillStore) objectKey(sessionID, eventID string) string {
+func (s *dynamoStreamObjectSpillStore) objectKey(sessionID, eventID string) string {
 	sessionHash := dynamoStreamPayloadSHA256([]byte(sessionID))
 	name := fmt.Sprintf("sessions/%s/events/%s.json", sessionHash, eventID)
 	prefix := strings.Trim(s.prefix, "/")

--- a/runtime/mcp/stream_store_dynamo_spill_test.go
+++ b/runtime/mcp/stream_store_dynamo_spill_test.go
@@ -1,17 +1,15 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"strings"
-	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/apptheory/pkg/objectstore"
+	objectstoretest "github.com/theory-cloud/apptheory/testkit/objectstore"
 )
 
 func TestDynamoStreamSpillStoreFromEnvAndObjectKey(t *testing.T) {
@@ -20,7 +18,7 @@ func TestDynamoStreamSpillStoreFromEnvAndObjectKey(t *testing.T) {
 
 	t.Setenv(envStreamSpillBucket, " spill-bucket ")
 	t.Setenv(envStreamSpillPrefix, " /custom/prefix/ ")
-	store, ok := newDynamoStreamSpillStoreFromEnv().(*dynamoStreamS3SpillStore)
+	store, ok := newDynamoStreamSpillStoreFromEnv().(*dynamoStreamObjectSpillStore)
 	require.True(t, ok)
 	require.Equal(t, "spill-bucket", store.bucket)
 	require.Equal(t, "custom/prefix", store.prefix)
@@ -30,60 +28,68 @@ func TestDynamoStreamSpillStoreFromEnvAndObjectKey(t *testing.T) {
 	require.True(t, strings.HasSuffix(key, "/events/event-1.json"))
 
 	t.Setenv(envStreamSpillPrefix, " ")
-	store, ok = newDynamoStreamSpillStoreFromEnv().(*dynamoStreamS3SpillStore)
+	store, ok = newDynamoStreamSpillStoreFromEnv().(*dynamoStreamObjectSpillStore)
 	require.True(t, ok)
 	require.Equal(t, defaultDynamoStreamSpillPrefix, store.prefix)
 }
 
 func TestDynamoStreamS3SpillStorePutGetDelete(t *testing.T) {
-	client := &recordingDynamoStreamS3Client{
-		getBody: []byte(`{"ok":true}`),
-	}
+	backend := objectstoretest.NewStore()
 	loads := 0
-	store := &dynamoStreamS3SpillStore{
+	store := &dynamoStreamObjectSpillStore{
 		bucket: "bucket-a",
 		prefix: "prefix-a",
-		loadClient: func(context.Context) (dynamoStreamS3Client, error) {
+		loadStore: func(context.Context) (objectstore.Store, error) {
 			loads++
-			return client, nil
+			return backend, nil
 		},
 	}
 
 	err := store.put(context.Background(), "key-1", []byte(`{"seq":1}`), 123, dynamoStreamPayloadSHA256([]byte(`{"seq":1}`)))
 	require.NoError(t, err)
 	require.Equal(t, 1, loads)
-	require.Equal(t, "bucket-a", aws.ToString(client.putInput.Bucket))
-	require.Equal(t, "key-1", aws.ToString(client.putInput.Key))
-	require.Equal(t, "123", client.putInput.Metadata["expires-at"])
-	require.NotEmpty(t, client.putInput.Metadata["sha256"])
+
+	calls := backend.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, objectstoretest.OperationPut, calls[0].Operation)
+	require.Equal(t, objectstore.ObjectRef{Bucket: "bucket-a", Key: "key-1"}, calls[0].Ref)
+	require.Equal(t, []byte(`{"seq":1}`), calls[0].Payload)
+	require.Equal(t, "application/json", calls[0].ContentType)
+	require.Equal(t, "123", calls[0].Metadata["expires-at"])
+	require.NotEmpty(t, calls[0].Metadata["sha256"])
 
 	got, err := store.get(context.Background(), "key-1", 0)
 	require.NoError(t, err)
-	require.Equal(t, []byte(`{"ok":true}`), got)
-	require.True(t, client.bodyClosed)
-	require.Equal(t, "bucket-a", aws.ToString(client.getInput.Bucket))
-	require.Equal(t, "key-1", aws.ToString(client.getInput.Key))
-	require.Equal(t, 1, loads, "cached S3 client should be reused")
+	require.Equal(t, []byte(`{"seq":1}`), got)
+	require.Equal(t, 1, loads, "cached object store should be reused")
 
 	require.NoError(t, store.delete(context.Background(), "key-1"))
-	require.Equal(t, "bucket-a", aws.ToString(client.deleteInput.Bucket))
-	require.Equal(t, "key-1", aws.ToString(client.deleteInput.Key))
+	calls = backend.Calls()
+	require.Len(t, calls, 3)
+	require.Equal(t, objectstoretest.OperationGet, calls[1].Operation)
+	require.Equal(t, int64(defaultDynamoStreamMaxEventBytes), calls[1].MaxBytes)
+	require.Equal(t, objectstoretest.OperationDelete, calls[2].Operation)
+	require.Equal(t, objectstore.ObjectRef{Bucket: "bucket-a", Key: "key-1"}, calls[2].Ref)
 }
 
 func TestDynamoStreamS3SpillStoreGetBoundsPayload(t *testing.T) {
 	t.Setenv(envStreamMaxEventBytes, "4")
-	client := &recordingDynamoStreamS3Client{getBody: []byte("12345")}
-	store := &dynamoStreamS3SpillStore{
+	backend := objectstoretest.NewStore()
+	_, err := backend.Put(context.Background(), objectstore.PutInput{
+		Ref:     objectstore.ObjectRef{Bucket: "bucket-a", Key: "key-1"},
+		Payload: []byte("12345"),
+	})
+	require.NoError(t, err)
+	store := &dynamoStreamObjectSpillStore{
 		bucket: "bucket-a",
-		loadClient: func(context.Context) (dynamoStreamS3Client, error) {
-			return client, nil
+		loadStore: func(context.Context) (objectstore.Store, error) {
+			return backend, nil
 		},
 	}
 
 	got, err := store.get(context.Background(), "key-1", 4)
 	require.Nil(t, got)
 	require.ErrorContains(t, err, "exceeds max event bytes")
-	require.True(t, client.bodyClosed)
 }
 
 func TestDynamoStreamStoreSpillReadLimitUsesRecordMetadata(t *testing.T) {
@@ -96,16 +102,16 @@ func TestDynamoStreamStoreSpillReadLimitUsesRecordMetadata(t *testing.T) {
 }
 
 func TestDynamoStreamS3SpillStoreNilAndLoadErrors(t *testing.T) {
-	var nilStore *dynamoStreamS3SpillStore
+	var nilStore *dynamoStreamObjectSpillStore
 	_, err := nilStore.get(context.Background(), "key", 0)
 	require.ErrorContains(t, err, "not configured")
 	require.ErrorContains(t, nilStore.put(context.Background(), "key", []byte("{}"), 0, ""), "not configured")
 	require.ErrorContains(t, nilStore.delete(context.Background(), "key"), "not configured")
 
 	loadErr := errors.New("load failed")
-	store := &dynamoStreamS3SpillStore{
+	store := &dynamoStreamObjectSpillStore{
 		bucket: "bucket-a",
-		loadClient: func(context.Context) (dynamoStreamS3Client, error) {
+		loadStore: func(context.Context) (objectstore.Store, error) {
 			return nil, loadErr
 		},
 	}
@@ -113,56 +119,4 @@ func TestDynamoStreamS3SpillStoreNilAndLoadErrors(t *testing.T) {
 	require.ErrorIs(t, err, loadErr)
 	require.ErrorIs(t, store.put(context.Background(), "key", []byte("{}"), 0, ""), loadErr)
 	require.ErrorIs(t, store.delete(context.Background(), "key"), loadErr)
-}
-
-type recordingDynamoStreamS3Client struct {
-	mu          sync.Mutex
-	putInput    *s3.PutObjectInput
-	getInput    *s3.GetObjectInput
-	deleteInput *s3.DeleteObjectInput
-	getBody     []byte
-	bodyClosed  bool
-}
-
-func (c *recordingDynamoStreamS3Client) PutObject(
-	_ context.Context,
-	params *s3.PutObjectInput,
-	_ ...func(*s3.Options),
-) (*s3.PutObjectOutput, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.putInput = params
-	return &s3.PutObjectOutput{}, nil
-}
-
-func (c *recordingDynamoStreamS3Client) GetObject(
-	_ context.Context,
-	params *s3.GetObjectInput,
-	_ ...func(*s3.Options),
-) (*s3.GetObjectOutput, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.getInput = params
-	return &s3.GetObjectOutput{Body: &trackingReadCloser{Reader: bytes.NewReader(c.getBody), closed: &c.bodyClosed}}, nil
-}
-
-func (c *recordingDynamoStreamS3Client) DeleteObject(
-	_ context.Context,
-	params *s3.DeleteObjectInput,
-	_ ...func(*s3.Options),
-) (*s3.DeleteObjectOutput, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.deleteInput = params
-	return &s3.DeleteObjectOutput{}, nil
-}
-
-type trackingReadCloser struct {
-	io.Reader
-	closed *bool
-}
-
-func (r *trackingReadCloser) Close() error {
-	*r.closed = true
-	return nil
 }

--- a/runtime/mcp/stream_store_dynamo_test.go
+++ b/runtime/mcp/stream_store_dynamo_test.go
@@ -463,6 +463,121 @@ func TestDynamoStreamStore_SpillsLargeEventsToS3AndRehydrates(t *testing.T) {
 	requireStreamClosed(t, ch)
 }
 
+func TestDynamoStreamStore_TamperedSpillObjectsFailClosedOnReplay(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+	}{
+		{
+			name: "oversized",
+			mutate: func(payload []byte) []byte {
+				return append(append([]byte(nil), payload...), 'x')
+			},
+		},
+		{
+			name: "truncated",
+			mutate: func(payload []byte) []byte {
+				return append([]byte(nil), payload[:len(payload)-1]...)
+			},
+		},
+		{
+			name: "tampered same length",
+			mutate: func(payload []byte) []byte {
+				out := append([]byte(nil), payload...)
+				out[len(out)-2] = '0'
+				return out
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newFakeMCPTableDB()
+			spill := newFakeDynamoStreamSpillStore()
+			store, ok := NewDynamoStreamStore(db).(*DynamoStreamStore)
+			require.True(t, ok)
+			store.spillStore = spill
+			store.inlineMaxBytes = 1
+			store.pollInterval = time.Millisecond
+			store.idGen = staticIDGenerator{id: "stream-1"}
+
+			payload := json.RawMessage(`{"seq":123}`)
+			streamID, err := store.Create(context.Background(), "sess-1")
+			require.NoError(t, err)
+			eventID, err := store.Append(context.Background(), "sess-1", streamID, payload)
+			require.NoError(t, err)
+			require.NoError(t, store.Close(context.Background(), "sess-1", streamID))
+
+			record, ok := db.getStreamRecord("sess-1", eventID)
+			require.True(t, ok)
+			require.Equal(t, int64(len(payload)), record.DataBytes)
+			require.Equal(t, dynamoStreamPayloadSHA256(payload), record.DataSHA256)
+			spill.set(record.DataRef, tt.mutate(payload))
+
+			ch, err := store.Subscribe(context.Background(), "sess-1", streamID, "")
+			require.NoError(t, err)
+			requireStreamClosed(t, ch)
+		})
+	}
+}
+
+func TestDynamoStreamStore_ValidSpillReplayPreservesEventBytesAndHash(t *testing.T) {
+	db := newFakeMCPTableDB()
+	spill := newFakeDynamoStreamSpillStore()
+	writer, ok := NewDynamoStreamStore(db).(*DynamoStreamStore)
+	require.True(t, ok)
+	replayer, ok := NewDynamoStreamStore(db).(*DynamoStreamStore)
+	require.True(t, ok)
+	writer.spillStore = spill
+	replayer.spillStore = spill
+	writer.inlineMaxBytes = 1
+	replayer.inlineMaxBytes = 1
+	writer.idGen = staticIDGenerator{id: "stream-1"}
+
+	payload := json.RawMessage(`{"kind":"progress","seq":123}`)
+	streamID, err := writer.Create(context.Background(), "sess-1")
+	require.NoError(t, err)
+	eventID, err := writer.Append(context.Background(), "sess-1", streamID, payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close(context.Background(), "sess-1", streamID))
+
+	record, ok := db.getStreamRecord("sess-1", eventID)
+	require.True(t, ok)
+	require.Equal(t, dynamoStreamDataStorageS3, record.DataStorage)
+	require.Equal(t, int64(len(payload)), record.DataBytes)
+	require.Equal(t, dynamoStreamPayloadSHA256(payload), record.DataSHA256)
+
+	ch, err := replayer.Subscribe(context.Background(), "sess-1", streamID, "")
+	require.NoError(t, err)
+	ev := requireStreamEvent(t, ch)
+	require.Equal(t, eventID, ev.ID)
+	require.Equal(t, []byte(payload), []byte(ev.Data))
+	require.JSONEq(t, string(payload), string(ev.Data))
+	requireStreamClosed(t, ch)
+}
+
+func TestDynamoStreamStore_FailedSpilledAppendCleansObject(t *testing.T) {
+	db := newFakeMCPTableDB()
+	spill := newFakeDynamoStreamSpillStore()
+	store, ok := NewDynamoStreamStore(db).(*DynamoStreamStore)
+	require.True(t, ok)
+	store.spillStore = spill
+	store.inlineMaxBytes = 1
+	store.idGen = staticIDGenerator{id: "stream-1"}
+
+	streamID, err := store.Create(context.Background(), "sess-1")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	spill.beforePut = func(_ string) { cancel() }
+
+	_, err = store.Append(ctx, "sess-1", streamID, json.RawMessage(`{"seq":1}`))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, spill.count())
+	require.Equal(t, 1, db.countNonSessionStreamRecords("sess-1"))
+}
+
 func TestDynamoStreamStore_SubscribeSkipsExpiredInlineEvents(t *testing.T) {
 	db := newFakeMCPTableDB()
 	store, ok := NewDynamoStreamStore(db).(*DynamoStreamStore)

--- a/runtime/mcp/stream_store_dynamo_test.go
+++ b/runtime/mcp/stream_store_dynamo_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/apptheory/pkg/objectstore"
+	objectstoretest "github.com/theory-cloud/apptheory/testkit/objectstore"
 )
 
 func TestDynamoStreamStore_CreateSubscribeReplayAndDeleteSession(t *testing.T) {
@@ -656,28 +658,28 @@ func TestDynamoStreamStore_InlineSpillThresholdClampsToSafeDynamoSize(t *testing
 
 func TestDynamoStreamS3SpillStore_RetriesClientInitAfterCanceledContext(t *testing.T) {
 	attempts := 0
-	store := &dynamoStreamS3SpillStore{
+	store := &dynamoStreamObjectSpillStore{
 		bucket: "bucket",
-		loadClient: func(ctx context.Context) (dynamoStreamS3Client, error) {
+		loadStore: func(ctx context.Context) (objectstore.Store, error) {
 			attempts++
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			return fakeDynamoStreamS3Client{}, nil
+			return objectstoretest.NewStore(), nil
 		},
 	}
 
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := store.s3Client(canceled)
+	_, err := store.objectStore(canceled)
 	require.ErrorIs(t, err, context.Canceled)
-	require.Nil(t, store.client)
+	require.Nil(t, store.store)
 
-	client, err := store.s3Client(context.Background())
+	backend, err := store.objectStore(context.Background())
 	require.NoError(t, err)
-	require.NotNil(t, client)
-	require.NotNil(t, store.client)
+	require.NotNil(t, backend)
+	require.NotNil(t, store.store)
 	require.Equal(t, 2, attempts)
 }
 
@@ -880,21 +882,26 @@ func TestDynamoStreamStore_StreamRecordDataValidationBranches(t *testing.T) {
 }
 
 func TestDynamoStreamStore_SpillStreamDataS3BranchAndWaitCancel(t *testing.T) {
-	client := &recordingDynamoStreamS3Client{}
+	backend := objectstoretest.NewStore()
 	store, ok := NewDynamoStreamStore(newFakeMCPTableDB()).(*DynamoStreamStore)
 	require.True(t, ok)
-	store.spillStore = &dynamoStreamS3SpillStore{
+	store.spillStore = &dynamoStreamObjectSpillStore{
 		bucket: "bucket-a",
 		prefix: "prefix-a",
-		loadClient: func(context.Context) (dynamoStreamS3Client, error) {
-			return client, nil
+		loadStore: func(context.Context) (objectstore.Store, error) {
+			return backend, nil
 		},
 	}
 
 	ref, err := store.spillStreamData(context.Background(), "sess-1", "event-1", []byte(`{"ok":true}`), 123, dynamoStreamPayloadSHA256([]byte(`{"ok":true}`)))
 	require.NoError(t, err)
 	require.Contains(t, ref, "prefix-a/sessions/")
-	require.Equal(t, ref, aws.ToString(client.putInput.Key))
+
+	calls := backend.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, objectstoretest.OperationPut, calls[0].Operation)
+	require.Equal(t, ref, calls[0].Ref.Key)
+	require.Equal(t, "bucket-a", calls[0].Ref.Bucket)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/runtime/mcp/stream_store_dynamo_test_helpers_test.go
+++ b/runtime/mcp/stream_store_dynamo_test_helpers_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/require"
 
 	tablecore "github.com/theory-cloud/tabletheory/pkg/core"
@@ -96,32 +95,6 @@ func (s *fakeDynamoStreamSpillStore) mustGet(t *testing.T, key string) []byte {
 	payload, err := s.get(context.Background(), key, 0)
 	require.NoError(t, err)
 	return payload
-}
-
-type fakeDynamoStreamS3Client struct{}
-
-func (fakeDynamoStreamS3Client) PutObject(
-	context.Context,
-	*s3.PutObjectInput,
-	...func(*s3.Options),
-) (*s3.PutObjectOutput, error) {
-	return &s3.PutObjectOutput{}, nil
-}
-
-func (fakeDynamoStreamS3Client) GetObject(
-	context.Context,
-	*s3.GetObjectInput,
-	...func(*s3.Options),
-) (*s3.GetObjectOutput, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (fakeDynamoStreamS3Client) DeleteObject(
-	context.Context,
-	*s3.DeleteObjectInput,
-	...func(*s3.Options),
-) (*s3.DeleteObjectOutput, error) {
-	return &s3.DeleteObjectOutput{}, nil
 }
 
 type fakeMCPTableDB struct {

--- a/runtime/mcp/stream_store_dynamo_test_helpers_test.go
+++ b/runtime/mcp/stream_store_dynamo_test_helpers_test.go
@@ -67,6 +67,15 @@ func (s *fakeDynamoStreamSpillStore) delete(_ context.Context, key string) error
 	return nil
 }
 
+func (s *fakeDynamoStreamSpillStore) set(key string, data []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	payload := make([]byte, len(data))
+	copy(payload, data)
+	s.objects[key] = payload
+}
+
 func (s *fakeDynamoStreamSpillStore) exists(key string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/testkit/objectstore/store.go
+++ b/testkit/objectstore/store.go
@@ -1,0 +1,263 @@
+// Package objectstore provides deterministic test doubles for AppTheory object-store code.
+package objectstore
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	store "github.com/theory-cloud/apptheory/pkg/objectstore"
+)
+
+// Operation names a Store operation recorded by FakeStore.
+type Operation string
+
+const (
+	// OperationPut records a Store.Put call.
+	OperationPut Operation = "Put"
+	// OperationGet records a Store.Get call.
+	OperationGet Operation = "Get"
+	// OperationDelete records a Store.Delete call.
+	OperationDelete Operation = "Delete"
+)
+
+// Call is one recorded FakeStore operation.
+type Call struct {
+	Operation   Operation
+	Ref         store.ObjectRef
+	MaxBytes    int64
+	ContentType string
+	Metadata    map[string]string
+	Payload     []byte
+}
+
+// FakeStore is an in-memory Store for tests.
+//
+// FakeStore records calls in order, injects per-operation failures, and copies
+// all byte slices and metadata maps at its boundary.
+type FakeStore struct {
+	mu       sync.Mutex
+	seq      int64
+	latest   map[objectName]string
+	objects  map[objectVersion]storedObject
+	calls    []Call
+	failures map[Operation]error
+}
+
+var _ store.Store = (*FakeStore)(nil)
+
+type objectName struct {
+	bucket string
+	key    string
+}
+
+type objectVersion struct {
+	name    objectName
+	version string
+}
+
+type storedObject struct {
+	ref         store.ObjectRef
+	payload     []byte
+	contentType string
+	metadata    map[string]string
+}
+
+// NewStore creates an empty FakeStore.
+func NewStore() *FakeStore {
+	return &FakeStore{
+		latest:   make(map[objectName]string),
+		objects:  make(map[objectVersion]storedObject),
+		failures: make(map[Operation]error),
+	}
+}
+
+// SetError injects err for subsequent calls to operation. Passing nil clears the injection.
+func (s *FakeStore) SetError(operation Operation, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	if err == nil {
+		delete(s.failures, operation)
+		return
+	}
+	s.failures[operation] = err
+}
+
+// Calls returns the recorded operations in call order.
+func (s *FakeStore) Calls() []Call {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]Call, len(s.calls))
+	for i, call := range s.calls {
+		out[i] = cloneCall(call)
+	}
+	return out
+}
+
+// Put stores a payload copy and returns a version-aware reference.
+func (s *FakeStore) Put(_ context.Context, input store.PutInput) (store.ObjectRef, error) {
+	if err := input.Ref.Validate(); err != nil {
+		return store.ObjectRef{}, err
+	}
+	if input.Ref.VersionID != "" {
+		return store.ObjectRef{}, store.ErrInvalidObjectRef
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	s.recordLocked(Call{
+		Operation:   OperationPut,
+		Ref:         input.Ref,
+		Payload:     cloneBytes(input.Payload),
+		ContentType: input.ContentType,
+		Metadata:    cloneMetadata(input.Metadata),
+	})
+	if err := s.failureLocked(OperationPut); err != nil {
+		return store.ObjectRef{}, err
+	}
+
+	s.seq++
+	ref := input.Ref
+	ref.VersionID = fmt.Sprintf("v%020d", s.seq)
+	name := objectName{bucket: ref.Bucket, key: ref.Key}
+	s.latest[name] = ref.VersionID
+	s.objects[objectVersion{name: name, version: ref.VersionID}] = storedObject{
+		ref:         ref,
+		payload:     cloneBytes(input.Payload),
+		contentType: input.ContentType,
+		metadata:    cloneMetadata(input.Metadata),
+	}
+	return ref, nil
+}
+
+// Get returns a bounded payload copy. MaxBytes must be positive.
+func (s *FakeStore) Get(_ context.Context, input store.GetInput) (*store.GetOutput, error) {
+	if err := input.Ref.Validate(); err != nil {
+		return nil, err
+	}
+	if input.MaxBytes <= 0 {
+		return nil, store.ErrInvalidGetLimit
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	s.recordLocked(Call{Operation: OperationGet, Ref: input.Ref, MaxBytes: input.MaxBytes})
+	if err := s.failureLocked(OperationGet); err != nil {
+		return nil, err
+	}
+
+	obj, ok := s.objectLocked(input.Ref)
+	if !ok {
+		return nil, store.ErrObjectNotFound
+	}
+	if int64(len(obj.payload)) > input.MaxBytes {
+		return nil, store.ErrObjectTooLarge
+	}
+	return &store.GetOutput{
+		Ref:         obj.ref,
+		Payload:     cloneBytes(obj.payload),
+		ContentType: obj.contentType,
+		Metadata:    cloneMetadata(obj.metadata),
+	}, nil
+}
+
+// Delete removes the referenced object. An unversioned ref removes all versions for the bucket/key.
+func (s *FakeStore) Delete(_ context.Context, input store.DeleteInput) error {
+	if err := input.Ref.Validate(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	s.recordLocked(Call{Operation: OperationDelete, Ref: input.Ref})
+	if err := s.failureLocked(OperationDelete); err != nil {
+		return err
+	}
+
+	name := objectName{bucket: input.Ref.Bucket, key: input.Ref.Key}
+	if input.Ref.VersionID == "" {
+		delete(s.latest, name)
+		for key := range s.objects {
+			if key.name == name {
+				delete(s.objects, key)
+			}
+		}
+		return nil
+	}
+
+	delete(s.objects, objectVersion{name: name, version: input.Ref.VersionID})
+	if s.latest[name] == input.Ref.VersionID {
+		delete(s.latest, name)
+	}
+	return nil
+}
+
+func (s *FakeStore) ensureLocked() {
+	if s.latest == nil {
+		s.latest = make(map[objectName]string)
+	}
+	if s.objects == nil {
+		s.objects = make(map[objectVersion]storedObject)
+	}
+	if s.failures == nil {
+		s.failures = make(map[Operation]error)
+	}
+}
+
+func (s *FakeStore) objectLocked(ref store.ObjectRef) (storedObject, bool) {
+	name := objectName{bucket: ref.Bucket, key: ref.Key}
+	version := ref.VersionID
+	if version == "" {
+		version = s.latest[name]
+	}
+	if version == "" {
+		return storedObject{}, false
+	}
+	obj, ok := s.objects[objectVersion{name: name, version: version}]
+	return obj, ok
+}
+
+func (s *FakeStore) recordLocked(call Call) {
+	s.calls = append(s.calls, cloneCall(call))
+}
+
+func (s *FakeStore) failureLocked(operation Operation) error {
+	return s.failures[operation]
+}
+
+func cloneCall(call Call) Call {
+	call.Payload = cloneBytes(call.Payload)
+	call.Metadata = cloneMetadata(call.Metadata)
+	return call
+}
+
+func cloneBytes(in []byte) []byte {
+	if in == nil {
+		return nil
+	}
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneMetadata(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out[k] = in[k]
+	}
+	return out
+}

--- a/testkit/objectstore/store_test.go
+++ b/testkit/objectstore/store_test.go
@@ -1,0 +1,144 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	store "github.com/theory-cloud/apptheory/pkg/objectstore"
+)
+
+func TestFakeStorePutGetDeleteAndCallOrder(t *testing.T) {
+	fake := NewStore()
+	ref := store.ObjectRef{Bucket: "bucket-a", Key: "objects/1.json"}
+
+	storedRef, err := fake.Put(context.Background(), store.PutInput{
+		Ref:         ref,
+		Payload:     []byte(`{"ok":true}`),
+		ContentType: "application/json",
+		Metadata:    map[string]string{"sha256": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if storedRef.VersionID == "" {
+		t.Fatalf("Put() VersionID is empty")
+	}
+
+	_, err = fake.Get(context.Background(), store.GetInput{Ref: ref, MaxBytes: 4})
+	if !errors.Is(err, store.ErrObjectTooLarge) {
+		t.Fatalf("bounded Get() error = %v, want ErrObjectTooLarge", err)
+	}
+
+	got, err := fake.Get(context.Background(), store.GetInput{Ref: storedRef, MaxBytes: 64})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if string(got.Payload) != `{"ok":true}` {
+		t.Fatalf("Get() payload = %q", got.Payload)
+	}
+	if got.Ref != storedRef {
+		t.Fatalf("Get() ref = %#v, want %#v", got.Ref, storedRef)
+	}
+	if got.ContentType != "application/json" || got.Metadata["sha256"] != "abc" {
+		t.Fatalf("Get() metadata/content type mismatch: %#v", got)
+	}
+
+	if deleteErr := fake.Delete(context.Background(), store.DeleteInput{Ref: ref}); deleteErr != nil {
+		t.Fatalf("Delete() error = %v", deleteErr)
+	}
+	_, err = fake.Get(context.Background(), store.GetInput{Ref: storedRef, MaxBytes: 64})
+	if !errors.Is(err, store.ErrObjectNotFound) {
+		t.Fatalf("Get() after delete error = %v, want ErrObjectNotFound", err)
+	}
+
+	calls := fake.Calls()
+	if got, want := len(calls), 5; got != want {
+		t.Fatalf("len(Calls()) = %d, want %d", got, want)
+	}
+	wantOps := []Operation{OperationPut, OperationGet, OperationGet, OperationDelete, OperationGet}
+	for i, want := range wantOps {
+		if calls[i].Operation != want {
+			t.Fatalf("Calls()[%d].Operation = %s, want %s", i, calls[i].Operation, want)
+		}
+	}
+	if calls[1].MaxBytes != 4 || calls[2].Ref.VersionID != storedRef.VersionID {
+		t.Fatalf("Get call details not recorded: %#v", calls)
+	}
+}
+
+func TestFakeStoreCopyOnWriteSafety(t *testing.T) {
+	fake := NewStore()
+	payload := []byte("payload")
+	metadata := map[string]string{"a": "b"}
+	ref, err := fake.Put(context.Background(), store.PutInput{
+		Ref:      store.ObjectRef{Bucket: "bucket-a", Key: "key"},
+		Payload:  payload,
+		Metadata: metadata,
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	payload[0] = 'P'
+	metadata["a"] = "changed"
+
+	got, err := fake.Get(context.Background(), store.GetInput{Ref: ref, MaxBytes: 64})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	got.Payload[0] = 'G'
+	got.Metadata["a"] = "changed again"
+
+	gotAgain, err := fake.Get(context.Background(), store.GetInput{Ref: ref, MaxBytes: 64})
+	if err != nil {
+		t.Fatalf("Get() again error = %v", err)
+	}
+	if string(gotAgain.Payload) != "payload" || gotAgain.Metadata["a"] != "b" {
+		t.Fatalf("FakeStore did not preserve stored copies: %#v", gotAgain)
+	}
+
+	calls := fake.Calls()
+	calls[0].Payload[0] = 'C'
+	calls[0].Metadata["a"] = "mutated call"
+	callsAgain := fake.Calls()
+	if string(callsAgain[0].Payload) != "payload" || callsAgain[0].Metadata["a"] != "b" {
+		t.Fatalf("Calls() did not return copies: %#v", callsAgain[0])
+	}
+}
+
+func TestFakeStoreFailureInjection(t *testing.T) {
+	fake := NewStore()
+	boom := errors.New("boom")
+	fake.SetError(OperationPut, boom)
+	_, err := fake.Put(context.Background(), store.PutInput{
+		Ref:     store.ObjectRef{Bucket: "bucket-a", Key: "key"},
+		Payload: []byte("payload"),
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Put() error = %v, want injected error", err)
+	}
+	if got, want := len(fake.Calls()), 1; got != want {
+		t.Fatalf("len(Calls()) = %d, want %d", got, want)
+	}
+
+	fake.SetError(OperationPut, nil)
+	if _, err := fake.Put(context.Background(), store.PutInput{
+		Ref:     store.ObjectRef{Bucket: "bucket-a", Key: "key"},
+		Payload: []byte("payload"),
+	}); err != nil {
+		t.Fatalf("Put() after clearing error = %v", err)
+	}
+}
+
+func TestFakeStoreFailClosedValidation(t *testing.T) {
+	fake := NewStore()
+	if _, err := fake.Get(context.Background(), store.GetInput{Ref: store.ObjectRef{Bucket: "bucket-a", Key: "key"}}); !errors.Is(err, store.ErrInvalidGetLimit) {
+		t.Fatalf("Get() without cap error = %v, want ErrInvalidGetLimit", err)
+	}
+	if _, err := fake.Put(context.Background(), store.PutInput{Ref: store.ObjectRef{Bucket: "bucket-a", Key: "key", VersionID: "v1"}}); !errors.Is(err, store.ErrInvalidObjectRef) {
+		t.Fatalf("Put() with VersionID error = %v, want ErrInvalidObjectRef", err)
+	}
+	if err := fake.Delete(context.Background(), store.DeleteInput{Ref: store.ObjectRef{Bucket: "bucket-a"}}); !errors.Is(err, store.ErrInvalidObjectRef) {
+		t.Fatalf("Delete() invalid ref error = %v, want ErrInvalidObjectRef", err)
+	}
+}


### PR DESCRIPTION
## Milestone
TheoryMCP Architecture Review — Framework Coverage / OBJ-M1→OBJ-M2→OBJ-M3 — AppTheory object-store helper + MCP stream-spill adoption.

## Linear
Project `3d372b60e3b7`.

References:
- OBJ-M1 / THE-2010: THE-2015, THE-2016, THE-2017
- OBJ-M2 / THE-2011: THE-2018, THE-2019, THE-2020
- OBJ-M3 / THE-2012: THE-2021, THE-2022, THE-2023

## Tasks
- [x] M1.1 THE-2015 — strict `objectstore.ObjectRef` + `s3://bucket/key` parsing/validation.
- [x] M1.2 THE-2016 — narrow bounded `objectstore.Store` contract.
- [x] M1.3 THE-2017 — deterministic `testkit/objectstore` fake/recorder.
- [x] M2.1 THE-2018 — minimal AWS SDK v2 S3 `Store` implementation.
- [x] M2.2 THE-2019 — fail-closed S3 encryption modes.
- [x] M2.3 THE-2020 — object-store helper docs/API evidence.
- [x] M3.1 THE-2021 — MCP stream-spill rewire to `objectstore.Store`.
- [x] M3.2 THE-2022 — spill replay/hash/TTL/cleanup invariant tests.
- [x] M3.3 THE-2023 — Remote MCP docs/CDK evidence alignment.

## Contract impact
Go-only additive helper surface. No TS/Python SDK surface. No listing, presigning, public URLs, multipart, copy/head, client-side encryption, product schemas, or public raw `*s3.Client` seam. MCP client protocol remains unchanged: no client-visible object refs, chunks, or presigned URLs.

## Validation
Commands run on the final branch tip:
- `go test ./pkg/objectstore -run 'ObjectRef|Parse'` — PASS
- `go test ./pkg/objectstore` — PASS
- `go test ./pkg/objectstore ./testkit/objectstore` — PASS
- `go test ./pkg/objectstore -run S3Store` — PASS
- `go test ./pkg/objectstore -run Encryption` — PASS
- `./scripts/update-api-snapshots.sh` — PASS / snapshots regenerated intentionally
- `./scripts/verify-api-snapshots.sh` — PASS
- `go test ./runtime/mcp -run 'DynamoStream.*Spill|S3Spill|StreamRecordData'` — PASS
- `go test ./runtime/mcp ./testkit/mcp` — PASS
- `cd cdk && npm test` — PASS, 131 pass / 0 fail
- `make test` — PASS, version-alignment PASS (1.12.2)
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS, 29 pass / 0 fail / 0 blocked
- `make rubric` — PASS, 29 pass / 0 fail / 0 blocked

## Evidence notes
- `runtime/mcp` no longer imports the AWS S3 SDK or owns direct `PutObject` / `GetObject` / `DeleteObject` code in the stream-spill path.
- Spill replay remains bounded by recorded byte count and `MCP_STREAM_MAX_EVENT_BYTES`, then validates byte count + SHA-256 before emitting.
- Expired spill records are not rehydrated or emitted.
- Failed spilled appends and session deletes clean up private spill objects.
- Remote MCP remains on private S3-managed spill storage; no CDK KMS props were added.

## Cross-repo notes
No TheoryMCP product-plane edits in this PR. OBJ-M4/M5 should wait for an AppTheory release containing this helper.
