### PR TITLE
fix: remediate AppTheory stream batch IDs and release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,22 @@ jobs:
             --github-head-repository "${PR_HEAD_REPOSITORY}" \
             "${pr_title_args[@]}"
 
+  release-security-gates:
+    name: Release/security gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify release/security invariants
+        run: |
+          bash scripts/verify-branch-release-supply-chain.sh
+          bash scripts/verify-release-train-promotion.sh --self-test
+          bash scripts/verify-ci-rubric-enforced.sh
+          bash scripts/verify-release-workflows.sh
+          bash scripts/verify-release-cycle.sh
+
   prerelease-readiness:
     name: Prerelease readiness (staging → premain)
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'premain' && github.event.pull_request.head.ref == 'staging'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Keep PRs focused. One logical change per PR is easier to review than a bundle of
 
 ### Authoring documentation
 
-The documentation site under `docs/` is published to <https://theory-cloud.github.io/apptheory/> on every push to `main` by `.github/workflows/pages.yml`. The site is built with Jekyll; the layouts, includes, CSS, and JS are portable across all Theory Cloud frameworks.
+The documentation site under `docs/` is published to <https://apptheory.theorycloud.ai/> on every push to `staging` by `.github/workflows/pages.yml`. The deployed site represents the staging integration documentation line; stable release authority remains the versioned packages, release notes, and API snapshots. The site is built with Jekyll; the layouts, includes, CSS, and JS are portable across all Theory Cloud frameworks.
 
 When adding or modifying a documentation page:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- AI Training: Root README for the AppTheory multi-language monorepo -->
 
 <p align="center">
-  <a href="https://theory-cloud.github.io/apptheory/">
+  <a href="https://apptheory.theorycloud.ai/">
     <img src="docs/assets/svg/icon.svg" width="84" alt="AppTheory">
   </a>
 </p>
@@ -16,7 +16,7 @@
 <p align="center">
   <a href="https://github.com/theory-cloud/AppTheory/releases"><img alt="Release" src="https://img.shields.io/github/v/release/theory-cloud/AppTheory?style=flat-square&label=release&color=2EA7FF"></a>
   <a href="https://github.com/theory-cloud/AppTheory/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-7A5CFF?style=flat-square"></a>
-  <a href="https://theory-cloud.github.io/apptheory/"><img alt="Docs" src="https://img.shields.io/badge/docs-theory--cloud.github.io%2Fapptheory-2EA7FF?style=flat-square"></a>
+  <a href="https://apptheory.theorycloud.ai/"><img alt="Docs" src="https://img.shields.io/badge/docs-apptheory.theorycloud.ai-2EA7FF?style=flat-square"></a>
   <a href="https://github.com/theory-cloud/AppTheory/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/theory-cloud/AppTheory/ci.yml?branch=main&style=flat-square&label=rubric&color=46D397"></a>
 </p>
 
@@ -27,10 +27,10 @@
 </p>
 
 <p align="center">
-  <a href="https://theory-cloud.github.io/apptheory/getting-started/"><strong>Get started →</strong></a> ·
-  <a href="https://theory-cloud.github.io/apptheory/api-reference/">API reference</a> ·
-  <a href="https://theory-cloud.github.io/apptheory/reference/contract-fixtures/">Contract fixtures</a> ·
-  <a href="https://theory-cloud.github.io/apptheory/integrations/mcp/">MCP runtime</a>
+  <a href="https://apptheory.theorycloud.ai/getting-started/"><strong>Get started →</strong></a> ·
+  <a href="https://apptheory.theorycloud.ai/api-reference/">API reference</a> ·
+  <a href="https://apptheory.theorycloud.ai/reference/contract-fixtures/">Contract fixtures</a> ·
+  <a href="https://apptheory.theorycloud.ai/integrations/mcp/">MCP runtime</a>
 </p>
 
 ---
@@ -56,8 +56,8 @@ AppTheory is distributed exclusively through immutable **[GitHub Releases](https
 | Runtime | Install |
 |---|---|
 | **Go** | `go get github.com/theory-cloud/apptheory@vX.Y.Z` |
-| **TypeScript** | install the `.tgz` release asset — see [TypeScript getting started](https://theory-cloud.github.io/apptheory/runtimes/typescript/) |
-| **Python** | install the `.whl` release asset — see [Python getting started](https://theory-cloud.github.io/apptheory/runtimes/python/) |
+| **TypeScript** | install the `.tgz` release asset — see [TypeScript getting started](https://apptheory.theorycloud.ai/runtimes/typescript/) |
+| **Python** | install the `.whl` release asset — see [Python getting started](https://apptheory.theorycloud.ai/runtimes/python/) |
 
 ## At a glance
 
@@ -76,7 +76,7 @@ AppTheory is distributed exclusively through immutable **[GitHub Releases](https
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [128 contract fixtures](https://theory-cloud.github.io/apptheory/reference/contract-fixtures/).
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [128 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/).
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -86,53 +86,53 @@ Use AppTheory when you want AWS-Lambda-backed services that are:
 
 AppTheory includes a complete [Model Context Protocol](https://modelcontextprotocol.io) production stack: Streamable HTTP transport, session management, OAuth protected resources, resumable SSE streaming, and CDK deployment constructs. The MCP runtime is a **first-class part of the contract**, not an experimental add-on — `theory-mcp-server` itself runs on it.
 
-- [MCP integration guide](https://theory-cloud.github.io/apptheory/integrations/mcp/) — transport, JSON-RPC surface, registries, sessions, streaming
-- [Remote MCP deployment](https://theory-cloud.github.io/apptheory/integrations/remote-mcp/) — OAuth, protected resource metadata, Autheory integration
+- [MCP integration guide](https://apptheory.theorycloud.ai/integrations/mcp/) — transport, JSON-RPC surface, registries, sessions, streaming
+- [Remote MCP deployment](https://apptheory.theorycloud.ai/integrations/remote-mcp/) — OAuth, protected resource metadata, Autheory integration
 - [MCP examples](examples/mcp/) — `tools-only`, `tools-resources-prompts`, `resumable-sse`
 - CDK constructs: `AppTheoryMcpServer`, `AppTheoryRemoteMcpServer`, `AppTheoryMcpProtectedResource`
 
 ## Documentation
 
-The full documentation site lives at **[theory-cloud.github.io/apptheory](https://theory-cloud.github.io/apptheory/)** — branded with the Theory Cloud design system, with a ⌘K search palette, runtime tabs, and surface-tinted pages.
+The full documentation site lives at **[apptheory.theorycloud.ai](https://apptheory.theorycloud.ai/)**. It is published from the `staging` integration branch; stable release authority remains the versioned packages, release notes, and API snapshots.
 
 **Most-used entry points:**
 
 | Section | Link |
 |---|---|
-| Getting started | [theory-cloud.github.io/apptheory/getting-started/](https://theory-cloud.github.io/apptheory/getting-started/) |
-| API reference | [theory-cloud.github.io/apptheory/api-reference/](https://theory-cloud.github.io/apptheory/api-reference/) |
-| HTTP runtime tiers | [theory-cloud.github.io/apptheory/features/http-runtime/](https://theory-cloud.github.io/apptheory/features/http-runtime/) |
-| Event workloads | [theory-cloud.github.io/apptheory/features/event-workloads/](https://theory-cloud.github.io/apptheory/features/event-workloads/) |
-| Logging profiles | [theory-cloud.github.io/apptheory/features/logging-profiles/](https://theory-cloud.github.io/apptheory/features/logging-profiles/) |
-| Source provenance | [theory-cloud.github.io/apptheory/features/source-provenance/](https://theory-cloud.github.io/apptheory/features/source-provenance/) |
-| Migration from Lift | [theory-cloud.github.io/apptheory/migration/from-lift/](https://theory-cloud.github.io/apptheory/migration/from-lift/) |
+| Getting started | [apptheory.theorycloud.ai/getting-started/](https://apptheory.theorycloud.ai/getting-started/) |
+| API reference | [apptheory.theorycloud.ai/api-reference/](https://apptheory.theorycloud.ai/api-reference/) |
+| HTTP runtime tiers | [apptheory.theorycloud.ai/features/http-runtime/](https://apptheory.theorycloud.ai/features/http-runtime/) |
+| Event workloads | [apptheory.theorycloud.ai/features/event-workloads/](https://apptheory.theorycloud.ai/features/event-workloads/) |
+| Logging profiles | [apptheory.theorycloud.ai/features/logging-profiles/](https://apptheory.theorycloud.ai/features/logging-profiles/) |
+| Source provenance | [apptheory.theorycloud.ai/features/source-provenance/](https://apptheory.theorycloud.ai/features/source-provenance/) |
+| Migration from Lift | [apptheory.theorycloud.ai/migration/from-lift/](https://apptheory.theorycloud.ai/migration/from-lift/) |
 
 **Per-runtime entry points:**
 
-- **Go** — [theory-cloud.github.io/apptheory/runtimes/go/](https://theory-cloud.github.io/apptheory/runtimes/go/)
-- **TypeScript** — [theory-cloud.github.io/apptheory/runtimes/typescript/](https://theory-cloud.github.io/apptheory/runtimes/typescript/)
-- **Python** — [theory-cloud.github.io/apptheory/runtimes/python/](https://theory-cloud.github.io/apptheory/runtimes/python/)
+- **Go** — [apptheory.theorycloud.ai/runtimes/go/](https://apptheory.theorycloud.ai/runtimes/go/)
+- **TypeScript** — [apptheory.theorycloud.ai/runtimes/typescript/](https://apptheory.theorycloud.ai/runtimes/typescript/)
+- **Python** — [apptheory.theorycloud.ai/runtimes/python/](https://apptheory.theorycloud.ai/runtimes/python/)
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://theory-cloud.github.io/apptheory/reference/contract-fixtures/) — the 128-fixture covenant every runtime is tested against
-- [Event Shape Dispatch](https://theory-cloud.github.io/apptheory/reference/event-shapes/) — which Lambda event shapes route to which handler
-- [HTTP Runtime](https://theory-cloud.github.io/apptheory/features/http-runtime/) — P0/P1/P2 tier surface
-- [Jobs Ledger](https://theory-cloud.github.io/apptheory/features/jobs-ledger/)
-- [Sanitization](https://theory-cloud.github.io/apptheory/features/sanitization/)
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 128-fixture covenant every runtime is tested against
+- [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
+- [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
+- [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
+- [Sanitization](https://apptheory.theorycloud.ai/features/sanitization/)
 
 **Integrations** — how AppTheory connects to the rest of the stack:
 
-- [MCP Method Surface](https://theory-cloud.github.io/apptheory/integrations/mcp/)
-- [Remote MCP](https://theory-cloud.github.io/apptheory/integrations/remote-mcp/)
-- [Remote MCP + Autheory](https://theory-cloud.github.io/apptheory/integrations/remote-mcp-autheory/)
-- [Bedrock AgentCore MCP](https://theory-cloud.github.io/apptheory/integrations/agentcore-mcp/)
+- [MCP Method Surface](https://apptheory.theorycloud.ai/integrations/mcp/)
+- [Remote MCP](https://apptheory.theorycloud.ai/integrations/remote-mcp/)
+- [Remote MCP + Autheory](https://apptheory.theorycloud.ai/integrations/remote-mcp-autheory/)
+- [Bedrock AgentCore MCP](https://apptheory.theorycloud.ai/integrations/agentcore-mcp/)
 
 **CDK** — the blessed deployment surface:
 
-- [CDK Getting Started](https://theory-cloud.github.io/apptheory/cdk/getting-started/)
-- [CDK API Reference](https://theory-cloud.github.io/apptheory/cdk/api-reference/)
-- [SSR Site (FaceTheory-first)](https://theory-cloud.github.io/apptheory/cdk/ssr-site/)
+- [CDK Getting Started](https://apptheory.theorycloud.ai/cdk/getting-started/)
+- [CDK API Reference](https://apptheory.theorycloud.ai/cdk/api-reference/)
+- [SSR Site (FaceTheory-first)](https://apptheory.theorycloud.ai/cdk/ssr-site/)
 
 ## Repository layout
 
@@ -155,7 +155,7 @@ The CDK multilang demo deploys one HTTP entry + three Lambda runtimes (Go, Node.
 
 → [`examples/cdk/multilang/`](examples/cdk/multilang/)
 
-For infrastructure patterns, see the [CDK integration guide](https://theory-cloud.github.io/apptheory/cdk/getting-started/).
+For infrastructure patterns, see the [CDK integration guide](https://apptheory.theorycloud.ai/cdk/getting-started/).
 
 ## Runtime tiers
 
@@ -167,7 +167,7 @@ AppTheory's middleware surface is tiered, not flag-based. Each tier is additive 
 | **P1** | P0 + request-id, tenant extraction, auth hooks, CORS, size/time guardrails, middleware ordering |
 | **P2** *(default)* | P1 + observability hooks, rate limiting / load-shedding policy hooks |
 
-Tiers are a **contract**, not a menu — see [HTTP Runtime](https://theory-cloud.github.io/apptheory/features/http-runtime/) for the exact slot list and per-tier behavior.
+Tiers are a **contract**, not a menu — see [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) for the exact slot list and per-tier behavior.
 
 ## Minimal app
 
@@ -264,4 +264,4 @@ The single-path philosophy applies here: one way to register a route, one way to
 - [CHANGELOG.md](CHANGELOG.md)
 - [THEORY_CLOUD.md](THEORY_CLOUD.md)
 
-<p align="center"><sub>Made with <a href="https://github.com/theory-cloud">Theory Cloud</a> · <a href="https://theory-cloud.github.io/apptheory/">docs</a></sub></p>
+<p align="center"><sub>Made with <a href="https://github.com/theory-cloud">Theory Cloud</a> · <a href="https://apptheory.theorycloud.ai/">docs</a></sub></p>

--- a/contract-tests/fixtures/m1/dynamodb-stream-normalized-summary-partial-failure.json
+++ b/contract-tests/fixtures/m1/dynamodb-stream-normalized-summary-partial-failure.json
@@ -99,7 +99,7 @@
     "output_json": {
       "batchItemFailures": [
         {
-          "itemIdentifier": "stream-evt-2"
+          "itemIdentifier": "000000000000000002"
         }
       ]
     }

--- a/contract-tests/fixtures/m1/dynamodb-stream-observability-partial-failure.json
+++ b/contract-tests/fixtures/m1/dynamodb-stream-observability-partial-failure.json
@@ -72,7 +72,7 @@
     "output_json": {
       "batchItemFailures": [
         {
-          "itemIdentifier": "stream-obs-2"
+          "itemIdentifier": "000000000000000102"
         }
       ]
     },

--- a/contract-tests/fixtures/m1/dynamodb-stream-partial-batch-failure.json
+++ b/contract-tests/fixtures/m1/dynamodb-stream-partial-batch-failure.json
@@ -36,7 +36,6 @@
     }
   },
   "expect": {
-    "output_json": { "batchItemFailures": [{ "itemIdentifier": "evt-2" }] }
+    "output_json": { "batchItemFailures": [{ "itemIdentifier": "2" }] }
   }
 }
-

--- a/contract-tests/fixtures/m1/dynamodb-stream-unrecognized-table-fails-closed.json
+++ b/contract-tests/fixtures/m1/dynamodb-stream-unrecognized-table-fails-closed.json
@@ -37,10 +37,9 @@
   "expect": {
     "output_json": {
       "batchItemFailures": [
-        { "itemIdentifier": "evt-1" },
-        { "itemIdentifier": "evt-2" }
+        { "itemIdentifier": "1" },
+        { "itemIdentifier": "2" }
       ]
     }
   }
 }
-

--- a/contract-tests/fixtures/m1/kinesis-cloudwatch-logs-subscription-malformed-partial-batch.json
+++ b/contract-tests/fixtures/m1/kinesis-cloudwatch-logs-subscription-malformed-partial-batch.json
@@ -139,7 +139,7 @@
     "output_json": {
       "batchItemFailures": [
         {
-          "itemIdentifier": "kin-cwl-malformed-1"
+          "itemIdentifier": "1002"
         }
       ]
     }

--- a/contract-tests/fixtures/m1/kinesis-partial-batch-failure.json
+++ b/contract-tests/fixtures/m1/kinesis-partial-batch-failure.json
@@ -46,7 +46,6 @@
     }
   },
   "expect": {
-    "output_json": { "batchItemFailures": [{ "itemIdentifier": "kin-2" }] }
+    "output_json": { "batchItemFailures": [{ "itemIdentifier": "2" }] }
   }
 }
-

--- a/contract-tests/fixtures/m1/kinesis-unrecognized-stream-fails-closed.json
+++ b/contract-tests/fixtures/m1/kinesis-unrecognized-stream-fails-closed.json
@@ -47,10 +47,9 @@
   "expect": {
     "output_json": {
       "batchItemFailures": [
-        { "itemIdentifier": "kin-1" },
-        { "itemIdentifier": "kin-2" }
+        { "itemIdentifier": "1" },
+        { "itemIdentifier": "2" }
       ]
     }
   }
 }
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,9 @@ This directory contains the OFFICIAL documentation for AppTheory.
 `docs/` is the canonical documentation root for AppTheory. Use the pages in this directory for user-facing guidance,
 AI ingestion, and migration-safe references.
 
+The hosted Pages site at <https://apptheory.theorycloud.ai/> is intentionally published from the `staging` integration
+branch. Treat it as the integration documentation line, not as proof that a stable release has completed.
+
 All public AppTheory functionality should be represented either in the fixed ingestible set below or in one of the
 sanctioned category roots. Avoid adding new root-level feature guides when a category root already exists.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -25,6 +25,8 @@ Release automation is driven by Conventional Commits. `feat:` and `fix:` entries
 
 The full rubric runs only for PRs targeting `staging` and optional manual `workflow_dispatch` CI runs. Manual CI dispatch defaults to running the rubric; generated release-PR artifact sync dispatches CI with the full rubric disabled and waits only for release hygiene/build checks. The standalone `Verify deterministic builds` CI job also runs only for PRs targeting `staging`; generated release PR sync must not require or wait for that skipped context. `premain` and `main` run release hygiene, branch version sync, release-branch provenance, package build, and publish postcondition checks; they must not run the full rubric or deterministic-build job on release publish paths.
 
+Skipped full-rubric and deterministic-build contexts are not release/security proof. The `Release/security gates` CI job is unconditional and branch-protection-compatible; it verifies release supply-chain wiring, Release Please provenance self-tests, CI rubric enforcement, workflow invariants, and deterministic release-cycle fixtures even when the full rubric is intentionally skipped.
+
 ## Full cycle checklist
 
 ### 1. Integrate on `staging`

--- a/examples/cdk/kinesis-cloudwatch-logs/handlers/go/main_test.go
+++ b/examples/cdk/kinesis-cloudwatch-logs/handlers/go/main_test.go
@@ -69,7 +69,7 @@ func TestBuildAppReportsDecodeFailuresByRecord(t *testing.T) {
 		}},
 	}))
 
-	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "bad-record" {
+	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "0" {
 		t.Fatalf("expected malformed record to be reported as a partial batch failure, got %#v", out.BatchItemFailures)
 	}
 }
@@ -88,7 +88,7 @@ func TestBuildAppFailsClosedWhenStreamNameIsMissing(t *testing.T) {
 		},
 	}))
 
-	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "unrouted-record" {
+	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "0" {
 		t.Fatalf("expected missing stream route to fail closed, got %#v", out.BatchItemFailures)
 	}
 }

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
-  "tabletheory-py @ https://github.com/theory-cloud/TableTheory/releases/download/v1.9.4/tabletheory_py-1.9.4-py3-none-any.whl#sha256=e2c7c4375536e88a82bfd2c1a408831e85a20913248db9b872a225db637db5a4",
+  "tabletheory-py @ https://github.com/theory-cloud/TableTheory/releases/download/v1.10.0/tabletheory_py-1.10.0-py3-none-any.whl#sha256=afd034517bd4b0c8bf76cfa18e91b191199f1efef14da02ee9a978ccb5d2b16e",
 ]
 
 [tool.setuptools]

--- a/py/src/apptheory/app.py
+++ b/py/src/apptheory/app.py
@@ -1078,9 +1078,9 @@ class App:
 
             observation = _dynamodb_stream_observation(evt_ctx, record)
             if record_error is not None:
-                event_id = str(record.get("eventID") or "").strip()
-                if event_id:
-                    failures.append({"itemIdentifier": event_id})
+                sequence_number = _dynamodb_stream_sequence_number(record)
+                if sequence_number:
+                    failures.append({"itemIdentifier": sequence_number})
                 _record_event_observability(self._observability, observation, "error", "app.internal")
                 continue
             _record_event_observability(self._observability, observation, "success", "")
@@ -1111,9 +1111,9 @@ class App:
             for record in records:
                 if not isinstance(record, dict):
                     continue
-                event_id = str(record.get("eventID") or "").strip()
-                if event_id:
-                    failures.append({"itemIdentifier": event_id})
+                sequence_number = _kinesis_sequence_number(record)
+                if sequence_number:
+                    failures.append({"itemIdentifier": sequence_number})
             return {"batchItemFailures": failures}
 
         evt_ctx = self._event_context(ctx)
@@ -1125,9 +1125,9 @@ class App:
             try:
                 _resolve(wrapped(evt_ctx, record))
             except Exception:  # noqa: BLE001
-                event_id = str(record.get("eventID") or "").strip()
-                if event_id:
-                    failures.append({"itemIdentifier": event_id})
+                sequence_number = _kinesis_sequence_number(record)
+                if sequence_number:
+                    failures.append({"itemIdentifier": sequence_number})
 
         return {"batchItemFailures": failures}
 
@@ -1788,6 +1788,16 @@ def _remaining_ms(ctx: Any | None) -> int:
 
 def _event_workload_failed_error() -> RuntimeError:
     return RuntimeError(_EVENT_WORKLOAD_FAILED_MESSAGE)
+
+
+def _kinesis_sequence_number(record: dict[str, Any]) -> str:
+    kinesis = record.get("kinesis") if isinstance(record.get("kinesis"), dict) else {}
+    return str(kinesis.get("sequenceNumber") or "").strip()
+
+
+def _dynamodb_stream_sequence_number(record: dict[str, Any]) -> str:
+    change = record.get("dynamodb") if isinstance(record.get("dynamodb"), dict) else {}
+    return str(change.get("SequenceNumber") or "").strip()
 
 
 def _is_safe_event_error(exc: Exception) -> bool:

--- a/py/tests/test_app.py
+++ b/py/tests/test_app.py
@@ -769,11 +769,12 @@ class TestApp(unittest.TestCase):
                     "eventSource": "aws:dynamodb",
                     "eventSourceARN": "arn:aws:dynamodb:us-east-1:000000000000:table/t/stream/1",
                     "eventID": "e1",
+                    "dynamodb": {"SequenceNumber": "seq-e1"},
                 },
             ]
         }
         out2 = app.handle_lambda(ddb)
-        self.assertEqual(out2, {"batchItemFailures": [{"itemIdentifier": "e1"}]})
+        self.assertEqual(out2, {"batchItemFailures": [{"itemIdentifier": "seq-e1"}]})
 
         kin = {
             "Records": [
@@ -781,11 +782,12 @@ class TestApp(unittest.TestCase):
                     "eventSource": "aws:kinesis",
                     "eventSourceARN": "arn:aws:kinesis:us-east-1:000000000000:stream/s",
                     "eventID": "k1",
+                    "kinesis": {"sequenceNumber": "seq-k1"},
                 },
             ]
         }
         out3 = app.handle_lambda(kin)
-        self.assertEqual(out3, {"batchItemFailures": [{"itemIdentifier": "k1"}]})
+        self.assertEqual(out3, {"batchItemFailures": [{"itemIdentifier": "seq-k1"}]})
 
         sns = {
             "Records": [

--- a/runtime/aws_eventsources.go
+++ b/runtime/aws_eventsources.go
@@ -370,7 +370,7 @@ func (a *App) kinesisHandlerForEvent(event events.KinesisEvent) KinesisHandler {
 
 var kinesisBatchSpec = newBatchEventSpec[events.KinesisEventRecord, events.KinesisBatchItemFailure, events.KinesisEventResponse](
 	"apptheory: invalid kinesis record type",
-	func(record events.KinesisEventRecord) string { return record.EventID },
+	func(record events.KinesisEventRecord) string { return record.Kinesis.SequenceNumber },
 )
 
 // ServeKinesis routes a Kinesis event to the registered stream handler and returns a partial batch failure response.
@@ -673,7 +673,7 @@ func (a *App) dynamoDBHandlerForEvent(event events.DynamoDBEvent) DynamoDBStream
 
 var dynamoDBBatchSpec = newBatchEventSpec[events.DynamoDBEventRecord, events.DynamoDBBatchItemFailure, events.DynamoDBEventResponse](
 	"apptheory: invalid dynamodb record type",
-	func(record events.DynamoDBEventRecord) string { return record.EventID },
+	func(record events.DynamoDBEventRecord) string { return record.Change.SequenceNumber },
 )
 
 // ServeDynamoDBStream routes a DynamoDB Streams event to the registered table handler and returns a partial batch failure response.

--- a/runtime/aws_eventsources_test.go
+++ b/runtime/aws_eventsources_test.go
@@ -99,7 +99,7 @@ func TestServeSQS_IsolatesEventContextValuesPerRecord(t *testing.T) {
 func TestServeKinesis_BatchFailures(t *testing.T) {
 	app := New()
 	app.Kinesis("stream1", func(_ *EventContext, record events.KinesisEventRecord) error {
-		if record.EventID == "bad" {
+		if record.EventID == "bad-event-id" {
 			return errors.New("fail")
 		}
 		return nil
@@ -107,11 +107,20 @@ func TestServeKinesis_BatchFailures(t *testing.T) {
 
 	out := app.ServeKinesis(context.Background(), events.KinesisEvent{
 		Records: []events.KinesisEventRecord{
-			{EventID: "ok", EventSourceArn: "arn:aws:kinesis:us-east-1:123:stream/stream1"},
-			{EventID: "bad", EventSourceArn: "arn:aws:kinesis:us-east-1:123:stream/stream1"},
+			{
+				EventID:        "ok-event-id",
+				EventSourceArn: "arn:aws:kinesis:us-east-1:123:stream/stream1",
+				Kinesis:        events.KinesisRecord{SequenceNumber: "49661350000000000000000000000000000000000000000000000001"},
+			},
+			{
+				EventID:        "bad-event-id",
+				EventSourceArn: "arn:aws:kinesis:us-east-1:123:stream/stream1",
+				Kinesis:        events.KinesisRecord{SequenceNumber: "49661350000000000000000000000000000000000000000000000002"},
+			},
 		},
 	})
-	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "bad" {
+	if len(out.BatchItemFailures) != 1 ||
+		out.BatchItemFailures[0].ItemIdentifier != "49661350000000000000000000000000000000000000000000000002" {
 		t.Fatalf("unexpected failures: %#v", out.BatchItemFailures)
 	}
 }
@@ -202,7 +211,7 @@ func TestServeEventBridge_SelectsByRuleAndPattern(t *testing.T) {
 func TestServeDynamoDBStream_BatchFailures(t *testing.T) {
 	app := New()
 	app.DynamoDB("tbl", func(_ *EventContext, record events.DynamoDBEventRecord) error {
-		if record.EventID == "bad" {
+		if record.EventID == "bad-event-id" {
 			return errors.New("fail")
 		}
 		return nil
@@ -210,11 +219,19 @@ func TestServeDynamoDBStream_BatchFailures(t *testing.T) {
 
 	out := app.ServeDynamoDBStream(context.Background(), events.DynamoDBEvent{
 		Records: []events.DynamoDBEventRecord{
-			{EventID: "ok", EventSourceArn: "arn:aws:dynamodb:us-east-1:123:table/tbl/stream/2020"},
-			{EventID: "bad", EventSourceArn: "arn:aws:dynamodb:us-east-1:123:table/tbl/stream/2020"},
+			{
+				EventID:        "ok-event-id",
+				EventSourceArn: "arn:aws:dynamodb:us-east-1:123:table/tbl/stream/2020",
+				Change:         events.DynamoDBStreamRecord{SequenceNumber: "100000000000000000001"},
+			},
+			{
+				EventID:        "bad-event-id",
+				EventSourceArn: "arn:aws:dynamodb:us-east-1:123:table/tbl/stream/2020",
+				Change:         events.DynamoDBStreamRecord{SequenceNumber: "100000000000000000002"},
+			},
 		},
 	})
-	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "bad" {
+	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "100000000000000000002" {
 		t.Fatalf("unexpected failures: %#v", out.BatchItemFailures)
 	}
 }

--- a/runtime/event_workloads_test.go
+++ b/runtime/event_workloads_test.go
@@ -216,7 +216,7 @@ func TestServeDynamoDBStream_RecordsPerRecordObservability(t *testing.T) {
 			Change:         events.DynamoDBStreamRecord{SequenceNumber: "2", StreamViewType: "NEW_AND_OLD_IMAGES"},
 		},
 	}})
-	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "stream-2" {
+	if len(out.BatchItemFailures) != 1 || out.BatchItemFailures[0].ItemIdentifier != "2" {
 		t.Fatalf("unexpected batch failures: %#v", out.BatchItemFailures)
 	}
 	if len(logs) != 2 {

--- a/scripts/verify-ci-rubric-enforced.sh
+++ b/scripts/verify-ci-rubric-enforced.sh
@@ -26,8 +26,39 @@ require_not_contains() {
   fi
 }
 
+require_job_without_if() {
+  local path="$1"
+  local job="$2"
+  local description="$3"
+
+  if awk -v job="  ${job}:" '
+    $0 == job { in_job = 1; next }
+    in_job && /^  [A-Za-z0-9_-]+:/ { in_job = 0 }
+    in_job && /^    if:/ { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "${path}"; then
+    fail "${description}; job-level if is not allowed"
+  fi
+}
+
 ci=".github/workflows/ci.yml"
 
+require_contains "${ci}" "  release-security-gates:" \
+  "CI must define non-skipped release/security gates independent of the full rubric"
+require_contains "${ci}" "name: Release/security gates" \
+  "CI must keep the release/security gate check name stable for branch protection visibility"
+require_job_without_if "${ci}" "release-security-gates" \
+  "release/security gates must not be skipped by branch or dispatch conditions"
+require_contains "${ci}" "bash scripts/verify-branch-release-supply-chain.sh" \
+  "release/security gates must verify release supply-chain workflow wiring"
+require_contains "${ci}" "bash scripts/verify-release-train-promotion.sh --self-test" \
+  "release/security gates must exercise release train provenance self-tests"
+require_contains "${ci}" "bash scripts/verify-ci-rubric-enforced.sh" \
+  "release/security gates must verify CI rubric enforcement invariants"
+require_contains "${ci}" "bash scripts/verify-release-workflows.sh" \
+  "release/security gates must verify release workflow invariants"
+require_contains "${ci}" "bash scripts/verify-release-cycle.sh" \
+  "release/security gates must verify deterministic release-cycle fixtures"
 require_contains "${ci}" "  rubric:" "CI must define the full rubric job"
 require_contains "${ci}" "run: make rubric" "CI rubric job must run make rubric"
 require_contains "${ci}" "run_full_rubric:" \

--- a/scripts/verify-release-gates.sh
+++ b/scripts/verify-release-gates.sh
@@ -26,6 +26,7 @@ bash ./scripts/verify-branch-version-sync.sh
 ./scripts/verify-contract-tests.sh
 ./scripts/verify-testkit-examples.sh
 bash ./scripts/verify-docs-standard.sh
+bash ./scripts/verify-release-train-promotion.sh --self-test
 bash ./scripts/verify-ci-rubric-enforced.sh
 bash ./scripts/verify-release-workflows.sh
 bash ./scripts/verify-release-cycle.sh

--- a/scripts/verify-release-train-promotion.sh
+++ b/scripts/verify-release-train-promotion.sh
@@ -24,6 +24,7 @@ from pathlib import Path
 RELEASE_BRANCHES = {"staging", "premain", "main"}
 PREMAIN_RELEASE_PLEASE_BRANCH = "release-please--branches--premain"
 MAIN_RELEASE_PLEASE_BRANCH = "release-please--branches--main"
+RELEASE_PLEASE_BRANCHES = {PREMAIN_RELEASE_PLEASE_BRANCH, MAIN_RELEASE_PLEASE_BRANCH}
 RC_VERSION_RE = re.compile(r"\bv?[0-9]+\.[0-9]+\.[0-9]+-rc(?:\.[0-9]+)?\b", re.IGNORECASE)
 VALID_PROMOTIONS = {
     ("staging", "premain"): "staging → premain prerelease promotion",
@@ -199,6 +200,52 @@ def github_compare_is_ancestor(repository: str, ancestor_sha: str, descendant_sh
     return compare_response_is_ancestor(payload, ancestor_sha)
 
 
+def trusted_release_please_head_ref(
+    head: str,
+    remote: str,
+    head_ref: str | None,
+    expected_head_sha: str | None,
+    github_repository: str | None,
+    github_head_repository: str | None,
+) -> str:
+    if head not in RELEASE_PLEASE_BRANCHES:
+        raise AssertionError(f"{head!r} is not a release-please branch")
+    if not github_repository:
+        fail("GitHub repository is required to verify generated release-please branch provenance")
+    if not github_head_repository:
+        fail("GitHub head repository is required to verify generated release-please branch provenance")
+    if expected_head_sha is None:
+        fail(f"event head SHA is required to verify generated release-please branch {head}")
+
+    repository = normalize_repository(github_repository)
+    head_repository = normalize_repository(github_head_repository)
+    if repository.lower() != head_repository.lower():
+        fail(
+            f"generated release-please PR head {head} must originate from trusted repository "
+            f"{repository}; got {head_repository}"
+        )
+
+    trusted_ref = trusted_release_ref(remote, head)
+    trusted_sha = commit_sha(trusted_ref).lower()
+    if expected_head_sha != trusted_sha:
+        fail(
+            f"event head SHA for generated release-please branch {head} "
+            f"does not match trusted {remote}/{head}"
+        )
+
+    if head_ref is not None:
+        if not ref_exists(head_ref):
+            fail(f"could not resolve explicit ref {head_ref!r} for generated release-please branch {head}")
+        explicit_sha = commit_sha(head_ref).lower()
+        if explicit_sha != trusted_sha:
+            fail(
+                f"explicit ref {head_ref!r} for generated release-please branch {head} "
+                f"does not match trusted {remote}/{head}"
+            )
+
+    return trusted_ref
+
+
 def expected_base_for_release_head(head: str) -> str:
     if head == "staging":
         return "premain"
@@ -291,6 +338,16 @@ def validate(
         fail("generated main release-please PR must be stable-shaped, not RC-shaped")
 
     expected_head_sha = normalize_sha(head_sha, "head SHA") if head_sha else None
+    trusted_release_please_ref = None
+    if head in RELEASE_PLEASE_BRANCHES:
+        trusted_release_please_ref = trusted_release_please_head_ref(
+            head,
+            remote,
+            head_ref,
+            expected_head_sha,
+            github_repository,
+            github_head_repository,
+        )
 
     if plan.non_release_pr:
         print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
@@ -318,6 +375,7 @@ def validate(
         and expected_head_sha is not None
         and head_ref is None
         and head not in RELEASE_BRANCHES
+        and trusted_release_please_ref is None
     ):
         compare_repository = github_head_repository or github_repository
         if not compare_repository:
@@ -337,11 +395,14 @@ def validate(
         print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
         return
 
-    descendant_ref = resolve_branch_ref(
-        remote,
-        plan.descendant_branch,
-        head_ref if plan.descendant_branch == head else None,
-    )
+    if trusted_release_please_ref is not None and plan.descendant_branch == head:
+        descendant_ref = trusted_release_please_ref
+    else:
+        descendant_ref = resolve_branch_ref(
+            remote,
+            plan.descendant_branch,
+            head_ref if plan.descendant_branch == head else None,
+        )
 
     if plan.descendant_branch == head and expected_head_sha is not None:
         actual_head_sha = commit_sha(descendant_ref).lower()
@@ -573,8 +634,45 @@ def self_test_git_topology() -> None:
                 0,
                 base_ref="premain",
                 head_ref=PREMAIN_RELEASE_PLEASE_BRANCH,
+                head_sha=commit_sha(PREMAIN_RELEASE_PLEASE_BRANCH),
+                github_repository="theory-cloud/AppTheory",
+                github_head_repository="theory-cloud/AppTheory",
                 pr_title="chore: release 1.0.1-rc.1",
                 contains="generated premain RC release-please PR",
+            )
+            assert_validation(
+                "premain",
+                PREMAIN_RELEASE_PLEASE_BRANCH,
+                1,
+                base_ref="premain",
+                head_sha=commit_sha(PREMAIN_RELEASE_PLEASE_BRANCH),
+                github_repository="theory-cloud/AppTheory",
+                github_head_repository="fork-owner/AppTheory",
+                pr_title="chore: release 1.0.1-rc.1",
+                contains="must originate from trusted repository",
+            )
+            assert_validation(
+                "premain",
+                PREMAIN_RELEASE_PLEASE_BRANCH,
+                1,
+                base_ref="premain",
+                head_sha=commit_sha("refs/remotes/origin/pr/1/head"),
+                github_repository="theory-cloud/AppTheory",
+                github_head_repository="theory-cloud/AppTheory",
+                pr_title="chore: release 1.0.1-rc.1",
+                contains="does not match trusted origin/release-please--branches--premain",
+            )
+            assert_validation(
+                "premain",
+                PREMAIN_RELEASE_PLEASE_BRANCH,
+                1,
+                base_ref="premain",
+                head_ref="refs/remotes/origin/pr/1/head",
+                head_sha=commit_sha(PREMAIN_RELEASE_PLEASE_BRANCH),
+                github_repository="theory-cloud/AppTheory",
+                github_head_repository="theory-cloud/AppTheory",
+                pr_title="chore: release 1.0.1-rc.1",
+                contains="explicit ref 'refs/remotes/origin/pr/1/head' for generated release-please branch",
             )
             assert_validation(
                 "main",
@@ -582,6 +680,9 @@ def self_test_git_topology() -> None:
                 0,
                 base_ref="main",
                 head_ref=MAIN_RELEASE_PLEASE_BRANCH,
+                head_sha=commit_sha(MAIN_RELEASE_PLEASE_BRANCH),
+                github_repository="theory-cloud/AppTheory",
+                github_head_repository="theory-cloud/AppTheory",
                 pr_title="chore: release 1.0.1",
                 contains="generated main stable release-please PR",
             )
@@ -591,6 +692,9 @@ def self_test_git_topology() -> None:
                 1,
                 base_ref="main",
                 head_ref=MAIN_RELEASE_PLEASE_BRANCH,
+                head_sha=commit_sha(MAIN_RELEASE_PLEASE_BRANCH),
+                github_repository="theory-cloud/AppTheory",
+                github_head_repository="theory-cloud/AppTheory",
                 pr_title="chore: release 1.0.1-rc.1",
                 contains="rejects RC-shaped",
             )

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -462,8 +462,43 @@ require_contains(
 )
 require_contains(
     "scripts/verify-release-train-promotion.sh",
+    "must originate from trusted repository",
+    "release train promotion verifier must reject forked generated release-please branch spoofing",
+)
+require_contains(
+    "scripts/verify-release-train-promotion.sh",
+    "event head SHA is required to verify generated release-please branch",
+    "release train promotion verifier must require exact release-please head SHA provenance",
+)
+require_contains(
+    "scripts/verify-release-train-promotion.sh",
+    "does not match trusted origin/release-please--branches--premain",
+    "release train promotion self-test must reject forged release-please head SHA",
+)
+require_contains(
+    "scripts/verify-release-train-promotion.sh",
     "main release gate rejects RC-shaped PR titles/versions",
     "main release promotion gate must reject RC-shaped main PR titles/versions",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "name: Release/security gates",
+    "CI must expose release/security gates as a stable non-skipped branch-protection context",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "bash scripts/verify-release-train-promotion.sh --self-test",
+    "CI release/security gates must exercise release train provenance self-tests",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "bash scripts/verify-ci-rubric-enforced.sh",
+    "CI release/security gates must verify rubric enforcement separately from the full rubric",
+)
+require_contains(
+    "scripts/verify-release-gates.sh",
+    "bash ./scripts/verify-release-train-promotion.sh --self-test",
+    "full release gates must include release train provenance self-tests",
 )
 require_contains(
     "scripts/verify-release-gates.sh",

--- a/ts/dist/app.js
+++ b/ts/dist/app.js
@@ -654,7 +654,7 @@ export class App {
         const handler = this._kinesisHandlerForEvent(event);
         if (!handler) {
             const failures = records
-                .map((r) => String(r?.eventID ?? "").trim())
+                .map(kinesisRecordSequenceNumber)
                 .filter(Boolean)
                 .map((id) => ({ itemIdentifier: id }));
             return { batchItemFailures: failures };
@@ -672,7 +672,7 @@ export class App {
             }
             if (recordError) {
                 failures.push({
-                    itemIdentifier: String(record?.eventID ?? ""),
+                    itemIdentifier: kinesisRecordSequenceNumber(record),
                 });
             }
         }
@@ -788,7 +788,7 @@ export class App {
             const observation = dynamoDBStreamObservation(eventCtx, record);
             if (recordError) {
                 failures.push({
-                    itemIdentifier: String(record?.eventID ?? ""),
+                    itemIdentifier: dynamoDBStreamSequenceNumber(record),
                 });
                 recordEventObservability(this._observability, observation, "error", "app.internal");
                 continue;
@@ -1161,6 +1161,15 @@ const EVENT_TRIGGER_EVENTBRIDGE = "eventbridge";
 const EVENT_TRIGGER_DYNAMODB_STREAM = "dynamodb_stream";
 function eventWorkloadFailedError() {
     return new Error(EVENT_WORKLOAD_FAILED_MESSAGE);
+}
+function kinesisRecordSequenceNumber(record) {
+    return String(record?.kinesis?.sequenceNumber ?? "").trim();
+}
+function dynamoDBStreamSequenceNumber(record) {
+    const change = record?.dynamodb;
+    if (!change || typeof change !== "object")
+        return "";
+    return String(change["SequenceNumber"] ?? "").trim();
 }
 function sanitizeEventWorkloadError(err) {
     if (isSafeEventError(err)) {

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -1183,7 +1183,7 @@ export class App {
     const handler = this._kinesisHandlerForEvent(event);
     if (!handler) {
       const failures = records
-        .map((r) => String(r?.eventID ?? "").trim())
+        .map(kinesisRecordSequenceNumber)
         .filter(Boolean)
         .map((id) => ({ itemIdentifier: id }));
       return { batchItemFailures: failures };
@@ -1202,7 +1202,7 @@ export class App {
       }
       if (recordError) {
         failures.push({
-          itemIdentifier: String(record?.eventID ?? ""),
+          itemIdentifier: kinesisRecordSequenceNumber(record),
         });
       }
     }
@@ -1343,7 +1343,7 @@ export class App {
       const observation = dynamoDBStreamObservation(eventCtx, record);
       if (recordError) {
         failures.push({
-          itemIdentifier: String(record?.eventID ?? ""),
+          itemIdentifier: dynamoDBStreamSequenceNumber(record),
         });
         recordEventObservability(
           this._observability,
@@ -1870,6 +1870,18 @@ const EVENT_TRIGGER_DYNAMODB_STREAM = "dynamodb_stream";
 
 function eventWorkloadFailedError(): Error {
   return new Error(EVENT_WORKLOAD_FAILED_MESSAGE);
+}
+
+function kinesisRecordSequenceNumber(record: KinesisEventRecord): string {
+  return String(record?.kinesis?.sequenceNumber ?? "").trim();
+}
+
+function dynamoDBStreamSequenceNumber(record: DynamoDBStreamRecord): string {
+  const change = record?.dynamodb;
+  if (!change || typeof change !== "object") return "";
+  return String(
+    (change as Record<string, unknown>)["SequenceNumber"] ?? "",
+  ).trim();
 }
 
 function sanitizeEventWorkloadError(err: unknown): Error {


### PR DESCRIPTION
## Summary

- Use AWS stream sequence numbers for Kinesis and DynamoDB Streams partial-batch failure item identifiers across Go, TypeScript, and Python runtimes, with updated contract fixtures and checked-in TypeScript dist output.
- Fail closed on generated Release Please PR provenance by requiring trusted repository ownership and exact trusted head SHA/ref matching for `release-please--branches--premain` and `release-please--branches--main`.
- Add a non-skipped `Release/security gates` CI context for release supply-chain, release-train self-test, CI rubric enforcement, workflow invariant, and release-cycle checks.
- Document the staging-only Pages deployment policy and align the Python TableTheory pin to the current `v1.10.0` framework input already used by Go/TypeScript.

References THE-2102
Fixes #690

## Validation

- `go test ./runtime -run 'TestServe(Kinesis|DynamoDBStream)_BatchFailures|TestServeDynamoDBStream_RecordsPerRecordObservability' -count=1 -v` PASS
- `make test` PASS
- `./scripts/verify-contract-tests.sh` PASS: Go/TS/Py 128 fixtures each
- `npm run check` PASS
- `./scripts/verify-ts-tests.sh` PASS
- `./scripts/verify-python-tests.sh` PASS
- `./scripts/verify-ts-pack.sh` PASS
- `./scripts/verify-python-build.sh` PASS
- `./scripts/verify-python-lint.sh` PASS
- `./scripts/fmt-check.sh` PASS
- `./scripts/verify-go-lint.sh` PASS
- `bash scripts/verify-release-train-promotion.sh --self-test` PASS
- `bash scripts/verify-ci-rubric-enforced.sh` PASS
- `bash scripts/verify-release-workflows.sh` PASS
- `bash scripts/verify-branch-release-supply-chain.sh` PASS
- `bash scripts/verify-release-cycle.sh` PASS
- `bash scripts/verify-docs-standard.sh` PASS
- `git diff --check` PASS

## Risk / release notes

- Full `make rubric` was not run; targeted runtime, contract, packaging, lint, docs, and release/security gates were run instead.
- No release, tag, package publish, or staging PR was performed.
- This does not claim AppTheory release-gate completion; THE-2105 remains the release blocker until TableTheory release consumption is complete.
- `npm ci` in `ts/` reported one existing moderate advisory in the dependency tree; no unrelated dependency range changes were made in this remediation.
