### PR TITLE
fix(release): harden graduation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
 
   version-alignment:
     name: Version alignment
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || (github.event.pull_request.head.ref != 'release-please--branches--premain' && github.event.pull_request.head.ref != 'release-please--branches--main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -135,6 +136,7 @@ jobs:
 
   go:
     name: Go (test + vet)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || (github.event.pull_request.head.ref != 'release-please--branches--premain' && github.event.pull_request.head.ref != 'release-please--branches--main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -146,6 +148,7 @@ jobs:
 
   ts:
     name: TypeScript (npm pack)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || (github.event.pull_request.head.ref != 'release-please--branches--premain' && github.event.pull_request.head.ref != 'release-please--branches--main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -157,6 +160,7 @@ jobs:
 
   py:
     name: Python (build wheel + sdist)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || (github.event.pull_request.head.ref != 'release-please--branches--premain' && github.event.pull_request.head.ref != 'release-please--branches--main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -188,6 +192,7 @@ jobs:
 
   contract-tests:
     name: Contract tests (fixtures)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || (github.event.pull_request.head.ref != 'release-please--branches--premain' && github.event.pull_request.head.ref != 'release-please--branches--main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -24,6 +24,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: release-pr-${{ github.repository }}-release-please--branches--premain
+  cancel-in-progress: false
+
 jobs:
   release-please:
     if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, 'release-please--branches--premain')

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,6 +24,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: release-pr-${{ github.repository }}-release-please--branches--main
+  cancel-in-progress: false
+
 jobs:
   release-please:
     if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, 'release-please--branches--main')

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -37,6 +37,41 @@ pr_state_line() {
     2>/dev/null || true
 }
 
+required_checks_passed=false
+synced_head=""
+
+exit_if_benign_merged_release_pr() {
+  local context="$1"
+  local current_pr_line="${2:-}"
+  if [[ -z "${current_pr_line}" ]]; then
+    current_pr_line="$(pr_state_line)"
+  fi
+  if [[ -z "${current_pr_line}" ]]; then
+    return 1
+  fi
+
+  local current_pr_state
+  local current_pr_head
+  current_pr_state="${current_pr_line%%$'\t'*}"
+  current_pr_head="${current_pr_line##*$'\t'}"
+
+  if [[ "${current_pr_state}" != "MERGED" ]]; then
+    return 1
+  fi
+
+  if [[ "${required_checks_passed}" != "true" || -z "${synced_head}" ]]; then
+    return 1
+  fi
+
+  if [[ "${current_pr_head}" != "${synced_head}" ]]; then
+    echo "sync-release-pr-generated: FAIL (PR #${pr_number} merged ${context}; expected head ${synced_head}, found ${current_pr_head})"
+    exit 1
+  fi
+
+  echo "sync-release-pr-generated: PASS (${release_branch} already merged after generated artifacts and required checks matched ${synced_head})"
+  exit 0
+}
+
 ensure_release_pr_is_draft() {
   local context="$1"
   local current_pr_line
@@ -53,6 +88,7 @@ ensure_release_pr_is_draft() {
   current_pr_is_draft="${current_pr_is_draft%%$'\t'*}"
 
   if [[ "${current_pr_state}" != "OPEN" ]]; then
+    exit_if_benign_merged_release_pr "${context}" "${current_pr_line}" || true
     echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} ${context})"
     exit 1
   fi
@@ -93,9 +129,12 @@ collect_check_records() {
   current_pr_state="${current_pr_line%%$'\t'*}"
   current_pr_head="${current_pr_line##*$'\t'}"
 
-  if [[ "${current_pr_state}" != "OPEN" ]]; then
+  if [[ "${current_pr_state}" != "OPEN" && "${current_pr_state}" != "MERGED" ]]; then
     echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} while reading checks)" >&2
     return 1
+  fi
+  if [[ "${current_pr_state}" == "MERGED" ]]; then
+    echo "sync-release-pr-generated: PR #${pr_number} merged while reading checks; verifying required checks on ${current_pr_head}" >&2
   fi
 
   local repo
@@ -353,6 +392,7 @@ wait_for_pr_head() {
     current_pr_head="${current_pr_line##*$'\t'}"
 
     if [[ "${current_pr_state}" != "OPEN" ]]; then
+      exit_if_benign_merged_release_pr "before head ${expected_head} was visible" "${current_pr_line}" || true
       echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} before head ${expected_head} was visible)"
       exit 1
     fi
@@ -388,6 +428,7 @@ require_pr_head() {
   current_pr_head="${current_pr_line##*$'\t'}"
 
   if [[ "${current_pr_state}" != "OPEN" ]]; then
+    exit_if_benign_merged_release_pr "${context}" "${current_pr_line}" || true
     echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} ${context})"
     exit 1
   fi
@@ -465,11 +506,16 @@ require_pr_head "${synced_head}" "before dispatching independent required checks
 dispatch_required_checks
 wait_for_required_checks_to_start
 wait_for_required_checks
+required_checks_passed=true
 
 require_pr_head "${synced_head}" "after required checks passed"
 ensure_release_pr_is_draft "before marking generated-artifact-synced PR ready"
 require_pr_head "${synced_head}" "before marking generated-artifact-synced PR ready"
-gh pr ready "${pr_number}"
+if ! gh pr ready "${pr_number}"; then
+  exit_if_benign_merged_release_pr "while marking generated-artifact-synced PR ready" || true
+  echo "sync-release-pr-generated: FAIL (PR #${pr_number} could not be marked ready after generated artifacts and required checks matched ${synced_head})"
+  exit 1
+fi
 
 current_pr_line="$(pr_state_line)"
 if [[ -z "${current_pr_line}" ]]; then
@@ -481,6 +527,7 @@ current_pr_is_draft="${current_pr_line#*$'\t'}"
 current_pr_is_draft="${current_pr_is_draft%%$'\t'*}"
 current_pr_head="${current_pr_line##*$'\t'}"
 if [[ "${current_pr_state}" != "OPEN" ]]; then
+  exit_if_benign_merged_release_pr "after marking ready" "${current_pr_line}" || true
   echo "sync-release-pr-generated: FAIL (PR #${pr_number} is ${current_pr_state} after marking ready)"
   exit 1
 fi

--- a/scripts/verify-branch-version-sync.sh
+++ b/scripts/verify-branch-version-sync.sh
@@ -10,6 +10,12 @@ set -euo pipefail
 # - `premain` receives that baseline only through `staging` -> `premain` promotions
 # If `staging` or `premain` drift from the latest stable baseline on `main`,
 # prereleases can get stuck on an old major/minor track.
+#
+# Pull requests are validated from the checked-out content. In particular, a
+# premain -> main PR is checked as the PR merge content, not by re-reading the
+# live origin/premain tip. The merge content is where the current main stable
+# manifest is preserved while the premain prerelease track is promoted; the
+# subsequent main -> staging -> premain edges reset the protected premain tip.
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   # `scripts/verify-builds.sh` runs rubric in git-less working copies; this verifier needs git metadata.
@@ -42,6 +48,95 @@ git_fetch_retry() {
     i=$((i + 1))
   done
 }
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  script_path="${BASH_SOURCE[0]}"
+  tmp_dir="$(mktemp -d)"
+  cleanup() {
+    rm -rf "${tmp_dir}"
+  }
+  trap cleanup EXIT
+
+  mkdir -p "${tmp_dir}/repo/scripts"
+  cp "${script_path}" "${tmp_dir}/repo/scripts/verify-branch-version-sync.sh"
+
+  cd "${tmp_dir}/repo"
+  git init --quiet --initial-branch=main
+  git config user.email "apptheory-branch-version-sync@example.invalid"
+  git config user.name "AppTheory Branch Version Sync Self Test"
+
+  write_manifests() {
+    local stable="$1"
+    local premain="$2"
+    printf '{\n  ".": "%s"\n}\n' "${stable}" >.release-please-manifest.json
+    printf '{\n  ".": "%s"\n}\n' "${premain}" >.release-please-manifest.premain.json
+  }
+
+  commit_manifests() {
+    local message="$1"
+    git add .release-please-manifest.json .release-please-manifest.premain.json
+    git commit --quiet -m "${message}"
+  }
+
+  write_manifests "1.13.0" "1.13.0"
+  commit_manifests "main stable baseline"
+
+  remote_path="${tmp_dir}/origin.git"
+  git init --quiet --bare "${remote_path}"
+  git remote add origin "${remote_path}"
+  git push --quiet origin main
+
+  git switch --quiet -c premain
+  write_manifests "1.12.2" "1.13.1-rc"
+  commit_manifests "stale premain stable manifest"
+  git push --quiet origin premain
+
+  git switch --quiet main
+
+  run_self_test_case() {
+    local label="$1"
+    local expected_exit="$2"
+    local expected_output="$3"
+    local output
+    set +e
+    output="$(
+      GITHUB_BASE_REF=main \
+      GITHUB_HEAD_REF=premain \
+      GIT_FETCH_RETRIES=1 \
+      GIT_FETCH_RETRY_SLEEP_SECS=0 \
+      bash scripts/verify-branch-version-sync.sh 2>&1
+    )"
+    local status=$?
+    set -e
+    if [[ "${status}" != "${expected_exit}" ]]; then
+      echo "branch-version-sync: self-test FAIL (${label}; expected exit ${expected_exit}, got ${status})"
+      echo "${output}"
+      exit 1
+    fi
+    if [[ "${output}" != *"${expected_output}"* ]]; then
+      echo "branch-version-sync: self-test FAIL (${label}; missing ${expected_output@Q})"
+      echo "${output}"
+      exit 1
+    fi
+    echo "branch-version-sync: self-test ${label} PASS"
+  }
+
+  # Valid premain -> main PR merge content keeps main's stable manifest while
+  # promoting premain's prerelease track. The live origin/premain stable
+  # manifest is intentionally stale in this fixture; the gate must not read it
+  # for main-promotion mode.
+  write_manifests "1.13.0" "1.13.1-rc"
+  run_self_test_case "main-promotion merge content" 0 "branch-version-sync: PASS"
+
+  write_manifests "1.12.2" "1.13.1-rc"
+  run_self_test_case "stale stable manifest rejected" 1 ".release-please-manifest.json 1.12.2 != origin/main 1.13.0"
+
+  write_manifests "1.13.0" "1.12.2-rc"
+  run_self_test_case "behind prerelease track rejected" 1 "prerelease track 1.12.2-rc is behind main 1.13.0"
+
+  echo "branch-version-sync: self-test PASS"
+  exit 0
+fi
 
 base_ref="${GITHUB_BASE_REF:-}"
 head_ref="${GITHUB_HEAD_REF:-}"
@@ -105,11 +200,13 @@ subject_label="premain"
 premain_stable=""
 premain_version=""
 
-if [[ "${mode}" == "premain" || "${mode}" == "staging-promotion" || "${mode}" == "staging" ]]; then
+if [[ "${mode}" == "premain" || "${mode}" == "staging-promotion" || "${mode}" == "staging" || "${mode}" == "main-promotion" ]]; then
   if [[ "${mode}" == "staging-promotion" ]]; then
     subject_label="staging->premain promotion"
   elif [[ "${mode}" == "staging" ]]; then
     subject_label="staging"
+  elif [[ "${mode}" == "main-promotion" ]]; then
+    subject_label="premain->main promotion"
   fi
   premain_stable="$(
     python3 - <<'PY'
@@ -129,31 +226,6 @@ data = json.loads(
     Path(".release-please-manifest.premain.json").read_text(encoding="utf-8")
 )
 print(data.get(".", ""))
-PY
-  )"
-else
-  git_fetch_retry origin premain
-
-  premain_stable="$(
-    python3 - <<'PY'
-import json
-import subprocess
-
-data = subprocess.check_output(
-    ["git", "show", "origin/premain:.release-please-manifest.json"], text=True
-)
-print(json.loads(data).get(".", ""))
-PY
-  )"
-  premain_version="$(
-    python3 - <<'PY'
-import json
-import subprocess
-
-data = subprocess.check_output(
-    ["git", "show", "origin/premain:.release-please-manifest.premain.json"], text=True
-)
-print(json.loads(data).get(".", ""))
 PY
   )"
 fi

--- a/scripts/verify-release-train-promotion.sh
+++ b/scripts/verify-release-train-promotion.sh
@@ -293,7 +293,13 @@ def classify(base: str, head: str) -> PromotionPlan:
                     "invalid release-train PR "
                     f"{head} → staging; staging only accepts main → staging release back-merges from release branches",
                 )
-            return PromotionPlan(True, VALID_PROMOTIONS[(head, base)], ancestor_branch="staging", descendant_branch=head)
+            # A stable back-merge is allowed to reconcile a current staging head
+            # that has moved ahead of main after the stable release was cut. The
+            # protected invariant is that main remains connected to the premain
+            # train line; requiring the transient staging tip itself to be an
+            # ancestor of main falsely rejects legitimate back-merges while not
+            # adding protection against merge-around-the-train paths.
+            return PromotionPlan(True, VALID_PROMOTIONS[(head, base)], ancestor_branch="premain", descendant_branch=head)
 
         return PromotionPlan(
             True,
@@ -364,6 +370,9 @@ def validate(
     assert plan.ancestor_branch is not None
     assert plan.descendant_branch is not None
 
+    if base_ref and base in RELEASE_BRANCHES and plan.ancestor_branch != base:
+        resolve_branch_ref(remote, base, base_ref)
+
     ancestor_ref = resolve_branch_ref(
         remote,
         plan.ancestor_branch,
@@ -416,6 +425,25 @@ def validate(
             fail(f"event head SHA does not match resolved PR head ref {descendant_ref!r}")
 
     if not is_ancestor(ancestor_ref, descendant_ref):
+        if (
+            base == "staging"
+            and head == "main"
+            and plan.ancestor_branch == "premain"
+            and plan.descendant_branch == "main"
+            and is_ancestor(descendant_ref, ancestor_ref)
+        ):
+            print(f"release-train-promotion: PASS ({plan.message}; {head} → {base})")
+            return
+        if (
+            base == "staging"
+            and head == "main"
+            and plan.ancestor_branch == "premain"
+            and plan.descendant_branch == "main"
+        ):
+            fail(
+                "premain and main have diverged; recreate the release-train PR from the current "
+                "branch heads and do not merge around staging → premain → main → staging"
+            )
         if base == "staging" and head not in RELEASE_BRANCHES:
             fail(
                 "staging PR branch does not contain the current main baseline; "
@@ -715,11 +743,63 @@ def self_test_git_topology() -> None:
                 contains="current main baseline",
             )
 
+            run(["git", "switch", "-q", "main"])
+            run(["git", "merge", "-q", "--ff-only", "premain"])
+            commit_marker("main-stable-release")
+            run(["git", "push", "-q", "--force", "origin", "main"])
+            if is_ancestor("staging", "main"):
+                raise AssertionError("self-test back-merge must allow staging to diverge from main")
+            if not is_ancestor("premain", "main"):
+                raise AssertionError("self-test stable main must descend from premain")
+            assert_validation(
+                "staging",
+                "main",
+                0,
+                base_ref="staging",
+                head_ref="main",
+                head_sha=commit_sha("main"),
+                contains="main → staging stable back-merge",
+            )
+            print("release-train-promotion: positive main → staging back-merge topology accepted")
+
+            run(["git", "switch", "-q", "premain"])
+            run(["git", "merge", "-q", "--ff-only", "main"])
+            commit_marker("premain-next-rc")
+            run(["git", "push", "-q", "--force", "origin", "premain"])
+            run(["git", "fetch", "-q", "origin", "premain"])
+            if not is_ancestor("main", "premain"):
+                raise AssertionError("self-test current premain should be allowed to advance after main")
+            assert_validation(
+                "staging",
+                "main",
+                0,
+                base_ref="staging",
+                head_ref="main",
+                head_sha=commit_sha("main"),
+                contains="main → staging stable back-merge",
+            )
+            print("release-train-promotion: positive main → staging back-merge with advanced premain accepted")
+
+            run(["git", "switch", "-q", "--detach", "main~2"])
+            run(["git", "switch", "-q", "-c", "main-around-premain"])
+            commit_marker("main-around-premain")
+            run(["git", "push", "-q", "--force", "origin", "main-around-premain:main"])
+            run(["git", "fetch", "-q", "origin", "main"])
+            assert_validation(
+                "staging",
+                "main",
+                1,
+                base_ref="staging",
+                head_sha=commit_sha("refs/remotes/origin/main"),
+                contains="premain and main have diverged",
+            )
+            print("release-train-promotion: negative main → staging merge-around topology rejected")
+
 
 def self_test() -> None:
     assert_plan("premain", "staging", True, "premain", "staging")
     assert_plan("main", "premain", True, "main", "premain")
-    assert_plan("staging", "main", True, "staging", "main")
+    assert_plan("staging", "main", True, "premain", "main")
     assert_plan("premain", PREMAIN_RELEASE_PLEASE_BRANCH, True, "premain", PREMAIN_RELEASE_PLEASE_BRANCH)
     assert_plan("main", MAIN_RELEASE_PLEASE_BRANCH, True, "main", MAIN_RELEASE_PLEASE_BRANCH)
     assert_plan("staging", "feature/release-fix", True, "main", "feature/release-fix")

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -5,6 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 python3 - <<'PY'
 import subprocess
+import re
 from pathlib import Path
 
 
@@ -65,6 +66,20 @@ def require_step_contains(path: str, step_name: str, needle: str, description: s
         )
 
 
+def require_job_contains(path: str, job_name: str, needle: str, description: str) -> None:
+    text = Path(path).read_text(encoding="utf-8")
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<block>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        text,
+    )
+    if not match:
+        raise SystemExit(f"release-workflows: FAIL ({description}; missing job {job_name!r} in {path})")
+    if needle not in match.group("block"):
+        raise SystemExit(
+            f"release-workflows: FAIL ({description}; missing {needle!r} in {job_name!r} job in {path})"
+        )
+
+
 require_order(
     ".github/workflows/prerelease.yml",
     "Verify branch version sync (release preflight)",
@@ -111,6 +126,53 @@ for workflow in (".github/workflows/prerelease.yml", ".github/workflows/release.
         "concurrency:",
         "permissions:",
         "release publisher concurrency must be declared before jobs so the whole publisher workflow is serialized",
+    )
+release_pr_concurrency = {
+    ".github/workflows/prerelease-pr.yml": (
+        "concurrency:\n"
+        "  group: release-pr-${{ github.repository }}-release-please--branches--premain\n"
+        "  cancel-in-progress: false"
+    ),
+    ".github/workflows/release-pr.yml": (
+        "concurrency:\n"
+        "  group: release-pr-${{ github.repository }}-release-please--branches--main\n"
+        "  cancel-in-progress: false"
+    ),
+}
+for workflow, snippet in release_pr_concurrency.items():
+    require_contains(
+        workflow,
+        snippet,
+        "generated release PR workflows must serialize per release PR without cancelling an active sync",
+    )
+    require_not_contains(
+        workflow,
+        "cancel-in-progress: true",
+        "generated release PR workflows must queue overlapping runs instead of cancelling an active sync",
+    )
+    require_order(
+        workflow,
+        "workflow_dispatch",
+        "concurrency:",
+        "generated release PR concurrency must apply at workflow scope, including workflow_dispatch reruns",
+    )
+    require_order(
+        workflow,
+        "concurrency:",
+        "jobs:",
+        "generated release PR concurrency must be declared before jobs so PR sync is serialized",
+    )
+release_please_draft_guard = (
+    "if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || "
+    "(github.event.pull_request.head.ref != 'release-please--branches--premain' && "
+    "github.event.pull_request.head.ref != 'release-please--branches--main')"
+)
+for job in ("version-alignment", "go", "ts", "py", "contract-tests"):
+    require_job_contains(
+        ".github/workflows/ci.yml",
+        job,
+        release_please_draft_guard,
+        "required CI checks must not evaluate draft release-please heads before generated artifacts are synced",
     )
 require_not_contains(
     ".github/workflows/release.yml",
@@ -713,8 +775,18 @@ require_order_after(
 require_order(
     "scripts/sync-release-pr-generated.sh",
     'require_pr_head "${synced_head}" "after required checks passed"',
-    'gh pr ready "${pr_number}"\n\n',
+    'if ! gh pr ready "${pr_number}"; then',
     "release PR must wait for required checks before becoming ready",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'current_pr_state}" != "OPEN" && "${current_pr_state}" != "MERGED"',
+    "release PR sync must keep checking required contexts if an externally merged release PR is already terminal",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "already merged after generated artifacts and required checks matched",
+    "release PR sync must treat an externally merged synced PR as a benign terminal state after checks pass",
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
@@ -733,6 +805,7 @@ for forbidden in (
         "release PR sync must not self-attest protected contexts",
     )
 
+subprocess.run(["bash", "scripts/verify-branch-version-sync.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/verify-release-pr-postcondition.sh", "--self-test"], check=True)
 
 print("release-workflows: PASS")


### PR DESCRIPTION
## Summary

Factory investigation 2026-06-18: staging-green CI fails on graduation.

Hardens the AppTheory release-train graduation gates without weakening their assertions:

- H1: accepts legitimate `main → staging` stable back-merges when staging has moved, while still rejecting diverged/merge-around topology.
- H2: prevents required CI jobs from evaluating draft release-please heads before generated CDK artifacts are synced.
- H3: serializes generated release PR workflows per release PR and treats an externally merged synced PR as a benign terminal state only after required checks pass.
- H4: validates `premain → main` version sync from checked-out PR merge content, while preserving stable equality and prerelease monotonicity checks.

## Validation

- `bash scripts/verify-release-train-promotion.sh --self-test`
- H1 old-vs-new topology fixture: old gate fails with `staging is not an ancestor of main`; new gate passes; synthetic merge-around still fails in self-test.
- H2 drift proof: `go test ./cdk-go/apptheorycdk/...` fails on pre-sync PR #696 commit `f22056c9` with the two generated-version assertions; current branch passes without generated artifact edits.
- H3 simulated MERGED PR while reading checks: synced/checked PR exits benign PASS; missing required check still exits 1.
- H4 old-vs-new fixture: old main-promotion mode fails on `1.12.2 != origin/main 1.13.0`; new merge-content mode passes; behind prerelease track still fails.
- `bash scripts/verify-branch-version-sync.sh --self-test`
- `bash scripts/verify-release-workflows.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-release-cycle.sh`
- `bash scripts/verify-ci-rubric-enforced.sh`
- `bash scripts/verify-version-alignment.sh`
- `go test ./cdk-go/apptheorycdk/...`
- `make test`
- `make rubric` (PASS: 29 pass / 0 fail / 0 blocked)

## Notes

No TableTheory dependency pins, generated artifacts, VERSION files, release manifests, tags, or package lockfiles were manually edited.
