### PR TITLE
fix(release): treat release-please no-op as legitimate

### DIFF
--- a/scripts/verify-release-pr-postcondition.sh
+++ b/scripts/verify-release-pr-postcondition.sh
@@ -6,6 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 version_line_re='^[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?)[[:space:]]*(#.*)?$'
 rc_version_re='^[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$'
 stable_version_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+releasable_subject_re='^(feat|fix|perf)(\([^)]+\))?(!)?: '
 
 parse_version_value() {
   local raw="$1"
@@ -26,6 +27,106 @@ is_rc_version() {
 
 is_stable_version() {
   [[ "$1" =~ ${stable_version_re} ]]
+}
+
+manifest_version() {
+  local manifest_path="$1"
+
+  python3 - "${manifest_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+version = json.loads(manifest_path.read_text(encoding="utf-8")).get(".", "")
+if not version:
+    raise SystemExit(f"missing release-please version in {manifest_path}")
+print(version)
+PY
+}
+
+baseline_tag_from_manifest() {
+  local manifest_path="$1"
+  local version
+
+  version="$(manifest_version "${manifest_path}")"
+  printf 'v%s\n' "${version#v}"
+}
+
+fetch_base_branch_and_tags() {
+  local base_branch="$1"
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --force --tags origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}" >/dev/null 2>&1
+  fi
+}
+
+resolve_base_ref() {
+  local base_branch="$1"
+
+  if git rev-parse --verify --quiet "origin/${base_branch}^{commit}" >/dev/null; then
+    printf 'origin/%s\n' "${base_branch}"
+    return 0
+  fi
+
+  if git rev-parse --verify --quiet "${base_branch}^{commit}" >/dev/null; then
+    printf '%s\n' "${base_branch}"
+    return 0
+  fi
+
+  return 1
+}
+
+has_releasable_commits_since() {
+  local baseline="$1"
+  local base_ref="$2"
+  local commit_subjects
+
+  # Same user-facing predicate as the prerelease readiness gate:
+  # git log --no-merges --format=%s <baseline>..<base_branch> |
+  #   grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '
+  #
+  # Keep the subjects in memory instead of piping directly into grep -q so
+  # pipefail cannot turn a matching early grep exit into a false negative.
+  commit_subjects="$(git log --no-merges --format=%s "${baseline}..${base_ref}")"
+  grep -Eq "${releasable_subject_re}" <<<"${commit_subjects}"
+}
+
+verify_no_open_release_pr_is_legitimate_noop() {
+  local base_branch="$1"
+  local release_branch="$2"
+  local expected_shape="$3"
+  local noop_message="$4"
+  local manifest_path="$5"
+  local baseline
+  local base_ref
+
+  if ! baseline="$(baseline_tag_from_manifest "${manifest_path}")"; then
+    echo "release-pr-postcondition: FAIL (could not read ${manifest_path} to derive the ${base_branch} release baseline)" >&2
+    return 1
+  fi
+
+  if ! fetch_base_branch_and_tags "${base_branch}"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; could not fetch ${base_branch} and tags to check commits since ${baseline})" >&2
+    return 1
+  fi
+
+  if ! git rev-parse --verify --quiet "${baseline}^{commit}" >/dev/null; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; recorded ${base_branch} manifest baseline tag ${baseline} is missing, so no-op cannot be proven)" >&2
+    return 1
+  fi
+
+  if ! base_ref="$(resolve_base_ref "${base_branch}")"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; could not resolve ${base_branch} to check commits since ${baseline})" >&2
+    return 1
+  fi
+
+  if has_releasable_commits_since "${baseline}" "${base_ref}"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; expected an open generated ${expected_shape} release-please PR ${release_branch} -> ${base_branch})" >&2
+    return 1
+  fi
+
+  echo "release-pr-postcondition: PASS (legitimate no-op; nothing user-facing to release on ${base_branch} since ${baseline})"
 }
 
 self_test_version_parser() {
@@ -77,8 +178,108 @@ self_test_version_parser() {
   echo "release-pr-postcondition: PASS (self-test VERSION parser; annotated RC accepted and stable/RC mismatches rejected)"
 }
 
-if [[ "${1:-}" == "--self-test" ]]; then
+commit_self_test_change() {
+  local subject="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${path}"
+  git add "${path}"
+  git \
+    -c user.name="AppTheory Release Self Test" \
+    -c user.email="apptheory-release-self-test@example.invalid" \
+    commit -q -m "${subject}"
+}
+
+self_test_no_open_release_pr_channel() {
+  local channel="$1"
+  local base_branch="$2"
+  local manifest_path="$3"
+  local expected_shape="$4"
+  local noop_message="$5"
+  local release_branch="$6"
+  local tmp
+  local output
+
+  tmp="$(mktemp -d)"
+  (
+    cd "${tmp}"
+    git init -q
+    git checkout -q -b "${base_branch}"
+    commit_self_test_change "chore: seed release baseline" "self-test.txt" "baseline"
+    git update-ref refs/tags/v1.0.0 HEAD
+
+    python3 - "${manifest_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(json.dumps({".": "1.0.0"}) + "\n", encoding="utf-8")
+PY
+
+    commit_self_test_change "docs: internal release note" "self-test.txt" "docs"
+    if ! output="$(
+      verify_no_open_release_pr_is_legitimate_noop \
+        "${base_branch}" \
+        "${release_branch}" \
+        "${expected_shape}" \
+        "${noop_message}" \
+        "${manifest_path}" 2>&1
+    )"; then
+      printf '%s\n' "${output}" >&2
+      echo "release-pr-postcondition: FAIL (self-test ${channel} legitimate no-op was rejected)" >&2
+      return 1
+    fi
+    grep -Fq "legitimate no-op" <<<"${output}" || {
+      printf '%s\n' "${output}" >&2
+      echo "release-pr-postcondition: FAIL (self-test ${channel} no-op did not report legitimate no-op)" >&2
+      return 1
+    }
+    echo "release-pr-postcondition: PASS (self-test ${channel} empty release-please PR with zero user-facing commits passed)"
+
+    commit_self_test_change "fix: self-test releasable change" "self-test.txt" "fix"
+    if output="$(
+      verify_no_open_release_pr_is_legitimate_noop \
+        "${base_branch}" \
+        "${release_branch}" \
+        "${expected_shape}" \
+        "${noop_message}" \
+        "${manifest_path}" 2>&1
+    )"; then
+      printf '%s\n' "${output}" >&2
+      echo "release-pr-postcondition: FAIL (self-test ${channel} genuine miss was accepted)" >&2
+      return 1
+    fi
+    grep -Fq "release-pr-postcondition: FAIL (${noop_message}; expected an open generated ${expected_shape} release-please PR ${release_branch} -> ${base_branch})" <<<"${output}" || {
+      printf '%s\n' "${output}" >&2
+      echo "release-pr-postcondition: FAIL (self-test ${channel} genuine miss did not preserve the fail-closed message)" >&2
+      return 1
+    }
+    echo "release-pr-postcondition: PASS (self-test ${channel} empty release-please PR with a user-facing commit failed closed)"
+  )
+  rm -rf "${tmp}"
+}
+
+run_self_tests() {
   self_test_version_parser
+  self_test_no_open_release_pr_channel \
+    "prerelease" \
+    "premain" \
+    ".release-please-manifest.premain.json" \
+    "RC" \
+    "release-please no-op is a failed RC gate" \
+    "release-please--branches--premain"
+  self_test_no_open_release_pr_channel \
+    "stable" \
+    "main" \
+    ".release-please-manifest.json" \
+    "stable" \
+    "release-please no-op is a failed stable gate" \
+    "release-please--branches--main"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  run_self_tests
   exit $?
 fi
 
@@ -89,12 +290,14 @@ case "${channel}" in
     release_branch="release-please--branches--premain"
     expected_shape="RC"
     noop_message="release-please no-op is a failed RC gate"
+    manifest_path=".release-please-manifest.premain.json"
     ;;
   stable)
     base_branch="main"
     release_branch="release-please--branches--main"
     expected_shape="stable"
     noop_message="release-please no-op is a failed stable gate"
+    manifest_path=".release-please-manifest.json"
     ;;
   *)
     echo "release-pr-postcondition: FAIL (usage: $0 prerelease|stable)" >&2
@@ -123,8 +326,13 @@ pr_number="$(
 )"
 
 if [[ -z "${pr_number}" ]]; then
-  echo "release-pr-postcondition: FAIL (${noop_message}; expected an open generated ${expected_shape} release-please PR ${release_branch} -> ${base_branch})" >&2
-  exit 1
+  verify_no_open_release_pr_is_legitimate_noop \
+    "${base_branch}" \
+    "${release_branch}" \
+    "${expected_shape}" \
+    "${noop_message}" \
+    "${manifest_path}"
+  exit $?
 fi
 
 title="$(gh pr view --repo "${repository}" "${pr_number}" --json title --jq '.title')"

--- a/scripts/verify-release-publish-postcondition.sh
+++ b/scripts/verify-release-publish-postcondition.sh
@@ -3,6 +3,195 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+releasable_subject_re='^(feat|fix|perf)(\([^)]+\))?(!)?: '
+
+is_rc_tag() {
+  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
+}
+
+is_stable_tag() {
+  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+fetch_base_branch_and_tags() {
+  local base_branch="$1"
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --force --tags origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}" >/dev/null 2>&1
+  fi
+}
+
+resolve_base_ref() {
+  local base_branch="$1"
+
+  if git rev-parse --verify --quiet "origin/${base_branch}^{commit}" >/dev/null; then
+    printf 'origin/%s\n' "${base_branch}"
+    return 0
+  fi
+
+  if git rev-parse --verify --quiet "${base_branch}^{commit}" >/dev/null; then
+    printf '%s\n' "${base_branch}"
+    return 0
+  fi
+
+  return 1
+}
+
+has_releasable_commits_since() {
+  local baseline="$1"
+  local base_ref="$2"
+  local commit_subjects
+
+  # Same user-facing predicate as the prerelease readiness gate:
+  # git log --no-merges --format=%s <baseline>..<base_branch> |
+  #   grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '
+  #
+  # Keep the subjects in memory instead of piping directly into grep -q so
+  # pipefail cannot turn a matching early grep exit into a false negative.
+  commit_subjects="$(git log --no-merges --format=%s "${baseline}..${base_ref}")"
+  grep -Eq "${releasable_subject_re}" <<<"${commit_subjects}"
+}
+
+is_published_release() {
+  local tag="$1"
+  local release_state
+
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if ! release_state="$(
+    gh release view "${tag}" \
+      --json isDraft,isPrerelease \
+      --jq 'if (.isDraft == false and .isPrerelease == false) then "published-stable" else "" end' \
+      2>/dev/null
+  )"; then
+    return 1
+  fi
+
+  [[ "${release_state}" == "published-stable" ]]
+}
+
+stable_already_published_noop_is_legitimate() {
+  local base_ref
+
+  if ! is_stable_tag "${expected_tag}"; then
+    return 1
+  fi
+
+  if ! is_published_release "${expected_tag}"; then
+    return 1
+  fi
+
+  if ! fetch_base_branch_and_tags "main"; then
+    return 1
+  fi
+
+  if ! git rev-parse --verify --quiet "${expected_tag}^{commit}" >/dev/null; then
+    return 1
+  fi
+
+  if ! base_ref="$(resolve_base_ref "main")"; then
+    return 1
+  fi
+
+  if has_releasable_commits_since "${expected_tag}" "${base_ref}"; then
+    return 1
+  fi
+
+  echo "release-publish-postcondition: PASS (already published ${expected_tag}; legitimate no-op)"
+}
+
+require_created_tag() {
+  local expected_shape="$1"
+
+  if [[ "${release_created}" != "true" ]]; then
+    if [[ "${expected_shape}" == "stable" ]] && stable_already_published_noop_is_legitimate; then
+      return 0
+    fi
+
+    echo "release-publish-postcondition: FAIL (release-please no-op is a failed ${expected_shape} publish gate; release_created=${release_created:-<empty>})" >&2
+    return 1
+  fi
+
+  if [[ -z "${tag_name}" ]]; then
+    echo "release-publish-postcondition: FAIL (${expected_shape} publish gate created a release without tag_name)" >&2
+    return 1
+  fi
+
+  if [[ "${tag_name}" != "${expected_tag}" ]]; then
+    echo "release-publish-postcondition: FAIL (${expected_shape} tag ${tag_name} != expected ${expected_tag})" >&2
+    return 1
+  fi
+}
+
+commit_self_test_change() {
+  local subject="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${path}"
+  git add "${path}"
+  git \
+    -c user.name="AppTheory Release Self Test" \
+    -c user.email="apptheory-release-self-test@example.invalid" \
+    commit -q -m "${subject}"
+}
+
+self_test_stable_already_published_noop() {
+  local tmp
+  local output
+
+  tmp="$(mktemp -d)"
+  (
+    cd "${tmp}"
+    git init -q
+    git checkout -q -b main
+    commit_self_test_change "chore: seed stable baseline" "self-test.txt" "baseline"
+    git update-ref refs/tags/v1.0.0 HEAD
+
+    expected_tag="v1.0.0"
+    release_created="false"
+    tag_name=""
+
+    is_published_release() {
+      [[ "${1:-}" == "v1.0.0" ]]
+    }
+
+    commit_self_test_change "docs: internal release note" "self-test.txt" "docs"
+    if ! output="$(require_created_tag "stable" 2>&1)"; then
+      printf '%s\n' "${output}" >&2
+      echo "release-publish-postcondition: FAIL (self-test stable already-published no-op was rejected)" >&2
+      return 1
+    fi
+    grep -Fq "already published v1.0.0; legitimate no-op" <<<"${output}" || {
+      printf '%s\n' "${output}" >&2
+      echo "release-publish-postcondition: FAIL (self-test stable no-op did not report already-published tolerance)" >&2
+      return 1
+    }
+    echo "release-publish-postcondition: PASS (self-test stable already-published tag with zero user-facing commits passed)"
+
+    commit_self_test_change "perf: self-test releasable change" "self-test.txt" "perf"
+    if output="$(require_created_tag "stable" 2>&1)"; then
+      printf '%s\n' "${output}" >&2
+      echo "release-publish-postcondition: FAIL (self-test stable genuine miss was accepted)" >&2
+      return 1
+    fi
+    grep -Fq "release-publish-postcondition: FAIL (release-please no-op is a failed stable publish gate; release_created=false)" <<<"${output}" || {
+      printf '%s\n' "${output}" >&2
+      echo "release-publish-postcondition: FAIL (self-test stable genuine miss did not preserve the fail-closed message)" >&2
+      return 1
+    }
+    echo "release-publish-postcondition: PASS (self-test stable already-published tag with a user-facing commit failed closed)"
+  )
+  rm -rf "${tmp}"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test_stable_already_published_noop
+  exit $?
+fi
+
 channel="${1:-}"
 release_created="${2:-}"
 tag_name="${3:-}"
@@ -17,37 +206,10 @@ esac
 
 expected_tag="v$(./scripts/read-version.sh)"
 
-is_rc_tag() {
-  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
-}
-
-is_stable_tag() {
-  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]
-}
-
-require_created_tag() {
-  local expected_shape="$1"
-
-  if [[ "${release_created}" != "true" ]]; then
-    echo "release-publish-postcondition: FAIL (release-please no-op is a failed ${expected_shape} publish gate; release_created=${release_created:-<empty>})" >&2
-    exit 1
-  fi
-
-  if [[ -z "${tag_name}" ]]; then
-    echo "release-publish-postcondition: FAIL (${expected_shape} publish gate created a release without tag_name)" >&2
-    exit 1
-  fi
-
-  if [[ "${tag_name}" != "${expected_tag}" ]]; then
-    echo "release-publish-postcondition: FAIL (${expected_shape} tag ${tag_name} != expected ${expected_tag})" >&2
-    exit 1
-  fi
-}
-
 case "${channel}" in
   prerelease)
     if is_rc_tag "${expected_tag}"; then
-      require_created_tag "RC"
+      require_created_tag "RC" || exit 1
       if ! is_rc_tag "${tag_name}"; then
         echo "release-publish-postcondition: FAIL (prerelease tag ${tag_name} is not RC-shaped)" >&2
         exit 1
@@ -73,7 +235,10 @@ case "${channel}" in
       exit 0
     fi
 
-    require_created_tag "stable"
+    require_created_tag "stable" || exit 1
+    if [[ "${release_created}" != "true" ]]; then
+      exit 0
+    fi
     if ! is_stable_tag "${tag_name}"; then
       echo "release-publish-postcondition: FAIL (stable tag ${tag_name} is not stable-shaped)" >&2
       exit 1

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -807,6 +807,7 @@ for forbidden in (
 
 subprocess.run(["bash", "scripts/verify-branch-version-sync.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/verify-release-pr-postcondition.sh", "--self-test"], check=True)
+subprocess.run(["bash", "scripts/verify-release-publish-postcondition.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/sync-release-pr-generated.sh", "--self-test"], check=True)
 
 print("release-workflows: PASS")


### PR DESCRIPTION
## What changed

- Makes `scripts/verify-release-pr-postcondition.sh prerelease|stable` no-op-aware when no generated release-please PR is open.
- Anchors the no-op decision on the manifest-recorded tag and the CI user-facing commit predicate (`feat|fix|perf`, no merges), not on lingering release-please branch refs.
- Lets `scripts/verify-release-publish-postcondition.sh stable` pass an already-published stable no-op only when the expected stable release is published and no user-facing commits exist since its tag.
- Adds self-test coverage for legitimate no-op pass and genuine-miss fail-closed cases, and wires the publish self-test into `verify-release-workflows.sh`.

## Why

Promoting already-released `v1.13.1` content can make release-please legitimately no-op. The previous postcondition treated every missing generated PR/tag creation as a failed gate, even when no user-facing release was owed. This keeps the gate fail-closed for real misses while allowing the true no-op case.

## Validation

- `bash scripts/verify-release-pr-postcondition.sh --self-test`
- `bash scripts/verify-release-publish-postcondition.sh --self-test`
- `scripts/verify-release-pr-postcondition.sh prerelease`
- `scripts/verify-release-pr-postcondition.sh stable`
- `scripts/verify-release-publish-postcondition.sh stable false ""`
- real no-op check: `v1.13.1..origin/premain` has zero `--no-merges` `feat|fix|perf` matches
- real releasable range check: manifest baseline `v1.13.0` against `origin/staging` fails closed with user-facing commits present
- `bash scripts/verify-release-workflows.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-ci-rubric-enforced.sh`
- `make test`
