### PR TITLE
feat(M15): pin Lambda MicroVM contract foundation

### DIFF
--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -12,13 +12,14 @@ File layout:
 - `contract-tests/fixtures/m3/` — API Gateway REST v1 (+ SSE)
 - `contract-tests/fixtures/m12/` — Lift parity completion extensions (middleware/ctx bag/naming/SSE streaming)
 - `contract-tests/fixtures/m14/` — FaceTheory enablement (streaming contract, catch-all routing, SSR helpers)
+- `contract-tests/fixtures/m15/` — Lambda MicroVM contract foundation (validation-only lifecycle/controller/session vocabulary)
 
 Each fixture is a single JSON object.
 
 ## Common shape
 
-- `id` (string): stable identifier (use `p0.*`, `p1.*`, `p2.*`, `m1.*`, `m2.*`, `m3.*`, `m12.*` prefixes).
-- `tier` (string): `p0` / `p1` / `p2` / `m1` / `m2` / `m3` / `m12`.
+- `id` (string): stable identifier (use `p0.*`, `p1.*`, `p2.*`, `m1.*`, `m2.*`, `m3.*`, `m12.*`, `m14.*`, `m15.*` prefixes).
+- `tier` (string): `p0` / `p1` / `p2` / `m1` / `m2` / `m3` / `m12` / `m14` / `m15`.
 - `name` (string): short human-friendly name.
 - `setup.routes` (array): route table for the fixture runner.
   - `method` (string): HTTP method (e.g. `GET`).
@@ -202,6 +203,23 @@ service, function, request ID, trace ID, error type/code, stack hash, and normal
 Validation-only fixtures use `expect.profile_validation_errors` and may omit `input.request`; runtimes must fail
 closed with deterministic validation messages for unsupported schema versions, profile names, encodings, config options,
 field names, context sources, or stack hash algorithms.
+
+## M15 Lambda MicroVM contract-foundation fixtures
+
+M15 fixtures pin the additive `apptheory.lambda_microvm` / `m15.microvm/v1` contract vocabulary before runtime or CDK
+implementation work. They are validation-only fixtures: passing them proves the lifecycle/controller/session vocabulary is
+parseable and fail-closed, not that a deployable MicroVM surface exists.
+
+The lifecycle fixture requires the hooks `prepare_image`, `start`, `readiness`, `stop`, `teardown`, and `failure`; the
+portable states include image-preparation, start, readiness, stop, teardown, `terminated`, and `failed` states. The
+controller/session fixture requires `create`, `start`, `stop`, `status`, and `session` command envelopes with `command`,
+`request_id`, `tenant_id`, and `auth_context` fields, plus TableTheory-patterned durable session-record guidance.
+
+Denial fixtures intentionally describe invalid contracts and expect the runners to reject them with deterministic error
+codes for raw AWS SDK escape hatches, raw lifecycle hook bypasses, and unauthenticated controller defaults. Later MicroVM
+runtime and CDK milestones must grow from these fixtures; they must not introduce raw AWS SDK escape hatches or private
+lifecycle-hook bypasses.
+
 
 ## Bytes in JSON
 

--- a/contract-tests/fixtures/m15/microvm-controller-session-contract.json
+++ b/contract-tests/fixtures/m15/microvm-controller-session-contract.json
@@ -1,0 +1,111 @@
+{
+  "id": "m15.microvm.controller_session.v1",
+  "tier": "m15",
+  "name": "Lambda MicroVM controller and durable session contract vocabulary v1",
+  "setup": {
+    "microvm_contract": {
+      "contract": "apptheory.lambda_microvm",
+      "version": "m15.microvm/v1",
+      "kind": "controller_session",
+      "escape_hatches": {
+        "raw_aws_sdk": false,
+        "raw_lifecycle_hook_bypass": false
+      },
+      "controller": {
+        "auth": {
+          "required": true,
+          "default": "deny"
+        },
+        "envelope": {
+          "required_fields": ["command", "request_id", "tenant_id", "auth_context"],
+          "safe_error_fields": ["code", "message", "request_id"],
+          "forbidden_fields": ["aws_access_key_id", "aws_secret_access_key", "raw_sdk_client", "bearer_token"]
+        },
+        "commands": [
+          {
+            "name": "create",
+            "method": "POST",
+            "path": "/microvms",
+            "request_fields": ["image_ref", "network_connector_ref", "session_spec"],
+            "response_fields": ["session_id", "state", "registry_version"]
+          },
+          {
+            "name": "start",
+            "method": "POST",
+            "path": "/microvms/{session_id}/start",
+            "request_fields": ["session_id"],
+            "response_fields": ["session_id", "state", "desired_state"]
+          },
+          {
+            "name": "stop",
+            "method": "POST",
+            "path": "/microvms/{session_id}/stop",
+            "request_fields": ["session_id"],
+            "response_fields": ["session_id", "state", "desired_state"]
+          },
+          {
+            "name": "status",
+            "method": "GET",
+            "path": "/microvms/{session_id}/status",
+            "request_fields": ["session_id"],
+            "response_fields": ["session_id", "state", "lifecycle_state", "last_transition"]
+          },
+          {
+            "name": "session",
+            "method": "GET",
+            "path": "/microvms/{session_id}",
+            "request_fields": ["session_id"],
+            "response_fields": ["session_id", "tenant_id", "namespace", "state", "registry_version"]
+          }
+        ]
+      },
+      "session_registry": {
+        "pattern": "tabletheory-single-table",
+        "tenant_binding": ["tenant_id", "namespace"],
+        "required_fields": [
+          "tenant_id",
+          "namespace",
+          "session_id",
+          "state",
+          "desired_state",
+          "image_ref",
+          "controller_id",
+          "created_at",
+          "updated_at",
+          "expires_at",
+          "generation",
+          "last_command_id",
+          "auth_subject"
+        ],
+        "state_values": [
+          "requested",
+          "image_preparing",
+          "image_prepared",
+          "starting",
+          "started",
+          "readiness_probing",
+          "ready",
+          "stopping",
+          "stopped",
+          "tearing_down",
+          "terminated",
+          "failed"
+        ],
+        "forbidden_fields": [
+          "raw_aws_credentials",
+          "raw_lifecycle_hook_payload",
+          "bearer_token",
+          "session_token_plaintext"
+        ]
+      }
+    }
+  },
+  "input": {},
+  "expect": {
+    "microvm_contract_validation": {
+      "valid": true,
+      "kind": "controller_session",
+      "version": "m15.microvm/v1"
+    }
+  }
+}

--- a/contract-tests/fixtures/m15/microvm-deny-lifecycle-bypass.json
+++ b/contract-tests/fixtures/m15/microvm-deny-lifecycle-bypass.json
@@ -1,0 +1,26 @@
+{
+  "id": "m15.microvm.denies.lifecycle_bypass",
+  "tier": "m15",
+  "name": "Lambda MicroVM contract rejects raw lifecycle hook bypass",
+  "setup": {
+    "microvm_contract": {
+      "contract": "apptheory.lambda_microvm",
+      "version": "m15.microvm/v1",
+      "kind": "lifecycle",
+      "escape_hatches": {
+        "raw_aws_sdk": false,
+        "raw_lifecycle_hook_bypass": true
+      }
+    }
+  },
+  "input": {},
+  "expect": {
+    "microvm_contract_validation": {
+      "valid": false,
+      "kind": "lifecycle",
+      "version": "m15.microvm/v1",
+      "error_code": "m15.microvm.lifecycle_bypass",
+      "error_message": "apptheory: microvm contract forbids raw lifecycle hook bypass"
+    }
+  }
+}

--- a/contract-tests/fixtures/m15/microvm-deny-raw-sdk-escape-hatch.json
+++ b/contract-tests/fixtures/m15/microvm-deny-raw-sdk-escape-hatch.json
@@ -1,0 +1,32 @@
+{
+  "id": "m15.microvm.denies.raw_sdk_escape_hatch",
+  "tier": "m15",
+  "name": "Lambda MicroVM contract rejects raw AWS SDK escape hatches",
+  "setup": {
+    "microvm_contract": {
+      "contract": "apptheory.lambda_microvm",
+      "version": "m15.microvm/v1",
+      "kind": "controller_session",
+      "escape_hatches": {
+        "raw_aws_sdk": true,
+        "raw_lifecycle_hook_bypass": false
+      },
+      "controller": {
+        "auth": {
+          "required": true,
+          "default": "deny"
+        }
+      }
+    }
+  },
+  "input": {},
+  "expect": {
+    "microvm_contract_validation": {
+      "valid": false,
+      "kind": "controller_session",
+      "version": "m15.microvm/v1",
+      "error_code": "m15.microvm.raw_sdk_escape_hatch",
+      "error_message": "apptheory: microvm contract forbids raw AWS SDK escape hatch"
+    }
+  }
+}

--- a/contract-tests/fixtures/m15/microvm-deny-unauthenticated-controller.json
+++ b/contract-tests/fixtures/m15/microvm-deny-unauthenticated-controller.json
@@ -1,0 +1,32 @@
+{
+  "id": "m15.microvm.denies.unauthenticated_controller_default",
+  "tier": "m15",
+  "name": "Lambda MicroVM contract rejects unauthenticated controller defaults",
+  "setup": {
+    "microvm_contract": {
+      "contract": "apptheory.lambda_microvm",
+      "version": "m15.microvm/v1",
+      "kind": "controller_session",
+      "escape_hatches": {
+        "raw_aws_sdk": false,
+        "raw_lifecycle_hook_bypass": false
+      },
+      "controller": {
+        "auth": {
+          "required": false,
+          "default": "allow"
+        }
+      }
+    }
+  },
+  "input": {},
+  "expect": {
+    "microvm_contract_validation": {
+      "valid": false,
+      "kind": "controller_session",
+      "version": "m15.microvm/v1",
+      "error_code": "m15.microvm.unauthenticated_controller",
+      "error_message": "apptheory: microvm controller must default to authenticated deny"
+    }
+  }
+}

--- a/contract-tests/fixtures/m15/microvm-lifecycle-contract.json
+++ b/contract-tests/fixtures/m15/microvm-lifecycle-contract.json
@@ -1,0 +1,102 @@
+{
+  "id": "m15.microvm.lifecycle.v1",
+  "tier": "m15",
+  "name": "Lambda MicroVM lifecycle contract vocabulary v1",
+  "setup": {
+    "microvm_contract": {
+      "contract": "apptheory.lambda_microvm",
+      "version": "m15.microvm/v1",
+      "kind": "lifecycle",
+      "escape_hatches": {
+        "raw_aws_sdk": false,
+        "raw_lifecycle_hook_bypass": false
+      },
+      "lifecycle": {
+        "hooks": [
+          {
+            "name": "prepare_image",
+            "phase": "image_preparation",
+            "state": "image_preparing",
+            "success_state": "image_prepared",
+            "failure_state": "failed"
+          },
+          {
+            "name": "start",
+            "phase": "start",
+            "state": "starting",
+            "success_state": "started",
+            "failure_state": "failed"
+          },
+          {
+            "name": "readiness",
+            "phase": "readiness",
+            "state": "readiness_probing",
+            "success_state": "ready",
+            "failure_state": "failed"
+          },
+          {
+            "name": "stop",
+            "phase": "stop",
+            "state": "stopping",
+            "success_state": "stopped",
+            "failure_state": "failed"
+          },
+          {
+            "name": "teardown",
+            "phase": "teardown",
+            "state": "tearing_down",
+            "success_state": "terminated",
+            "failure_state": "failed"
+          },
+          {
+            "name": "failure",
+            "phase": "failure",
+            "state": "failed",
+            "success_state": "failed",
+            "failure_state": "failed"
+          }
+        ],
+        "states": [
+          "requested",
+          "image_preparing",
+          "image_prepared",
+          "starting",
+          "started",
+          "readiness_probing",
+          "ready",
+          "stopping",
+          "stopped",
+          "tearing_down",
+          "terminated",
+          "failed"
+        ],
+        "terminal_states": ["terminated", "failed"],
+        "transitions": [
+          {"from": "requested", "hook": "prepare_image", "to": "image_preparing"},
+          {"from": "image_preparing", "hook": "prepare_image", "to": "image_prepared"},
+          {"from": "image_prepared", "hook": "start", "to": "starting"},
+          {"from": "starting", "hook": "start", "to": "started"},
+          {"from": "started", "hook": "readiness", "to": "readiness_probing"},
+          {"from": "readiness_probing", "hook": "readiness", "to": "ready"},
+          {"from": "ready", "hook": "stop", "to": "stopping"},
+          {"from": "stopping", "hook": "stop", "to": "stopped"},
+          {"from": "stopped", "hook": "teardown", "to": "tearing_down"},
+          {"from": "tearing_down", "hook": "teardown", "to": "terminated"},
+          {"from": "image_preparing", "hook": "failure", "to": "failed"},
+          {"from": "starting", "hook": "failure", "to": "failed"},
+          {"from": "readiness_probing", "hook": "failure", "to": "failed"},
+          {"from": "stopping", "hook": "failure", "to": "failed"},
+          {"from": "tearing_down", "hook": "failure", "to": "failed"}
+        ]
+      }
+    }
+  },
+  "input": {},
+  "expect": {
+    "microvm_contract_validation": {
+      "valid": true,
+      "kind": "lifecycle",
+      "version": "m15.microvm/v1"
+    }
+  }
+}

--- a/contract-tests/runners/go/apptheory_m15.go
+++ b/contract-tests/runners/go/apptheory_m15.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+const (
+	microVMContractName    = "apptheory.lambda_microvm"
+	microVMContractVersion = "m15.microvm/v1"
+	microVMKindLifecycle   = "lifecycle"
+	microVMKindController  = "controller_session"
+
+	microVMErrInvalidContract           = "m15.microvm.invalid_contract"
+	microVMErrRawSDKEscapeHatch         = "m15.microvm.raw_sdk_escape_hatch"
+	microVMErrLifecycleBypass           = "m15.microvm.lifecycle_bypass" //nolint:gosec // Contract error code, not a credential.
+	microVMErrUnauthenticatedController = "m15.microvm.unauthenticated_controller"
+	microVMErrLifecycleIncomplete       = "m15.microvm.lifecycle_incomplete"
+	microVMErrControllerIncomplete      = "m15.microvm.controller_incomplete"
+	microVMErrSessionRegistryIncomplete = "m15.microvm.session_registry_incomplete"
+)
+
+var (
+	requiredMicroVMLifecycleHooks  = []string{"prepare_image", "start", "readiness", "stop", "teardown", "failure"}
+	requiredMicroVMLifecycleStates = []string{
+		"requested",
+		"image_preparing",
+		"image_prepared",
+		"starting",
+		"started",
+		"readiness_probing",
+		"ready",
+		"stopping",
+		"stopped",
+		"tearing_down",
+		"terminated",
+		"failed",
+	}
+	requiredMicroVMControllerCommands = []string{"create", "start", "stop", "status", "session"}
+	requiredMicroVMEnvelopeFields     = []string{"command", "request_id", "tenant_id", "auth_context"}
+	requiredMicroVMSessionFields      = []string{
+		"tenant_id",
+		"namespace",
+		"session_id",
+		"state",
+		"desired_state",
+		"image_ref",
+		"controller_id",
+		"created_at",
+		"updated_at",
+		"expires_at",
+		"generation",
+		"last_command_id",
+		"auth_subject",
+	}
+)
+
+type microVMContractFixture struct {
+	Contract        string                     `json:"contract"`
+	Version         string                     `json:"version"`
+	Kind            string                     `json:"kind"`
+	EscapeHatches   microVMEscapeHatches       `json:"escape_hatches"`
+	Lifecycle       microVMLifecycleContract   `json:"lifecycle"`
+	Controller      microVMControllerContract  `json:"controller"`
+	SessionRegistry microVMSessionRegistrySpec `json:"session_registry"`
+}
+
+type microVMEscapeHatches struct {
+	RawAWSSDK              bool `json:"raw_aws_sdk"`
+	RawLifecycleHookBypass bool `json:"raw_lifecycle_hook_bypass"`
+}
+
+type microVMLifecycleContract struct {
+	Hooks          []microVMLifecycleHook       `json:"hooks"`
+	States         []string                     `json:"states"`
+	TerminalStates []string                     `json:"terminal_states"`
+	Transitions    []microVMLifecycleTransition `json:"transitions"`
+}
+
+type microVMLifecycleHook struct {
+	Name         string `json:"name"`
+	Phase        string `json:"phase"`
+	State        string `json:"state"`
+	SuccessState string `json:"success_state"`
+	FailureState string `json:"failure_state"`
+}
+
+type microVMLifecycleTransition struct {
+	From string `json:"from"`
+	Hook string `json:"hook"`
+	To   string `json:"to"`
+}
+
+type microVMControllerContract struct {
+	Auth     microVMControllerAuth      `json:"auth"`
+	Envelope microVMControllerEnvelope  `json:"envelope"`
+	Commands []microVMControllerCommand `json:"commands"`
+}
+
+type microVMControllerAuth struct {
+	Required bool   `json:"required"`
+	Default  string `json:"default"`
+}
+
+type microVMControllerEnvelope struct {
+	RequiredFields  []string `json:"required_fields"`
+	SafeErrorFields []string `json:"safe_error_fields"`
+	ForbiddenFields []string `json:"forbidden_fields"`
+}
+
+type microVMControllerCommand struct {
+	Name           string   `json:"name"`
+	Method         string   `json:"method"`
+	Path           string   `json:"path"`
+	RequestFields  []string `json:"request_fields"`
+	ResponseFields []string `json:"response_fields"`
+}
+
+type microVMSessionRegistrySpec struct {
+	Pattern         string   `json:"pattern"`
+	TenantBinding   []string `json:"tenant_binding"`
+	RequiredFields  []string `json:"required_fields"`
+	StateValues     []string `json:"state_values"`
+	ForbiddenFields []string `json:"forbidden_fields"`
+}
+
+func runFixtureM15(f Fixture) error {
+	actual := validateMicroVMContractFixture(f.Setup.MicroVMContract)
+	expected := f.Expect.MicroVMContractValidation
+	if expected == nil {
+		return fmt.Errorf("fixture missing expect.microvm_contract_validation")
+	}
+	if !reflect.DeepEqual(*expected, actual) {
+		return fmt.Errorf("microvm_contract_validation mismatch: expected %+v, got %+v", *expected, actual)
+	}
+	return nil
+}
+
+func validateMicroVMContractFixture(raw json.RawMessage) FixtureMicroVMContractValidation {
+	if len(raw) == 0 {
+		return invalidMicroVMContract(microVMErrInvalidContract, "apptheory: microvm contract fixture missing")
+	}
+
+	var contract microVMContractFixture
+	if err := json.Unmarshal(raw, &contract); err != nil {
+		return invalidMicroVMContract(microVMErrInvalidContract, "apptheory: microvm contract fixture is not parseable")
+	}
+
+	actual := FixtureMicroVMContractValidation{
+		Valid:   true,
+		Kind:    strings.TrimSpace(contract.Kind),
+		Version: strings.TrimSpace(contract.Version),
+	}
+
+	if strings.TrimSpace(contract.Contract) != microVMContractName || actual.Version != microVMContractVersion {
+		return invalidMicroVMContract(microVMErrInvalidContract, "apptheory: microvm contract must be named and versioned")
+	}
+	if actual.Kind != microVMKindLifecycle && actual.Kind != microVMKindController {
+		return invalidMicroVMContract(microVMErrInvalidContract, "apptheory: microvm contract kind is unsupported")
+	}
+	if invalid := validateMicroVMEscapeHatches(actual, contract.EscapeHatches); invalid != nil {
+		return *invalid
+	}
+	if actual.Kind == microVMKindController && !controllerAuthDefaultsDeny(contract.Controller.Auth) {
+		return FixtureMicroVMContractValidation{
+			Valid:        false,
+			Kind:         actual.Kind,
+			Version:      actual.Version,
+			ErrorCode:    microVMErrUnauthenticatedController,
+			ErrorMessage: "apptheory: microvm controller must default to authenticated deny",
+		}
+	}
+
+	switch actual.Kind {
+	case microVMKindLifecycle:
+		if err := validateMicroVMLifecycle(contract.Lifecycle); err != nil {
+			return invalidMicroVMContract(microVMErrLifecycleIncomplete, err.Error())
+		}
+	case microVMKindController:
+		if err := validateMicroVMController(contract.Controller); err != nil {
+			return invalidMicroVMContract(microVMErrControllerIncomplete, err.Error())
+		}
+		if err := validateMicroVMSessionRegistry(contract.SessionRegistry); err != nil {
+			return invalidMicroVMContract(microVMErrSessionRegistryIncomplete, err.Error())
+		}
+	}
+
+	return actual
+}
+
+func validateMicroVMEscapeHatches(
+	actual FixtureMicroVMContractValidation,
+	escapeHatches microVMEscapeHatches,
+) *FixtureMicroVMContractValidation {
+	if escapeHatches.RawAWSSDK {
+		return &FixtureMicroVMContractValidation{
+			Valid:        false,
+			Kind:         actual.Kind,
+			Version:      actual.Version,
+			ErrorCode:    microVMErrRawSDKEscapeHatch,
+			ErrorMessage: "apptheory: microvm contract forbids raw AWS SDK escape hatch",
+		}
+	}
+	if escapeHatches.RawLifecycleHookBypass {
+		return &FixtureMicroVMContractValidation{
+			Valid:        false,
+			Kind:         actual.Kind,
+			Version:      actual.Version,
+			ErrorCode:    microVMErrLifecycleBypass,
+			ErrorMessage: "apptheory: microvm contract forbids raw lifecycle hook bypass",
+		}
+	}
+	return nil
+}
+
+func invalidMicroVMContract(code, message string) FixtureMicroVMContractValidation {
+	return FixtureMicroVMContractValidation{Valid: false, ErrorCode: code, ErrorMessage: message}
+}
+
+func controllerAuthDefaultsDeny(auth microVMControllerAuth) bool {
+	return auth.Required && strings.EqualFold(strings.TrimSpace(auth.Default), "deny")
+}
+
+func validateMicroVMLifecycle(lifecycle microVMLifecycleContract) error {
+	if missing := missingStrings(requiredMicroVMLifecycleHooks, lifecycleHookNames(lifecycle.Hooks)); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm lifecycle missing hooks: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings(requiredMicroVMLifecycleStates, lifecycle.States); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm lifecycle missing states: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings([]string{"terminated", "failed"}, lifecycle.TerminalStates); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm lifecycle missing terminal states: %s", strings.Join(missing, ","))
+	}
+	if err := validateMicroVMLifecycleTransitions(lifecycle.Transitions); err != nil {
+		return err
+	}
+	return validateMicroVMLifecycleHookFields(lifecycle.Hooks)
+}
+
+func validateMicroVMLifecycleTransitions(transitions []microVMLifecycleTransition) error {
+	transitionHooks := map[string]struct{}{}
+	for _, transition := range transitions {
+		if strings.TrimSpace(transition.From) == "" || strings.TrimSpace(transition.To) == "" {
+			return fmt.Errorf("apptheory: microvm lifecycle transition states must be explicit")
+		}
+		if strings.TrimSpace(transition.Hook) != "" {
+			transitionHooks[strings.TrimSpace(transition.Hook)] = struct{}{}
+		}
+	}
+	for _, hook := range requiredMicroVMLifecycleHooks {
+		if _, ok := transitionHooks[hook]; !ok {
+			return fmt.Errorf("apptheory: microvm lifecycle missing transition for hook %s", hook)
+		}
+	}
+	return nil
+}
+
+func validateMicroVMLifecycleHookFields(hooks []microVMLifecycleHook) error {
+	for _, hook := range hooks {
+		if strings.TrimSpace(hook.Name) == "" || strings.TrimSpace(hook.Phase) == "" || strings.TrimSpace(hook.State) == "" || strings.TrimSpace(hook.SuccessState) == "" || strings.TrimSpace(hook.FailureState) == "" {
+			return fmt.Errorf("apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state")
+		}
+	}
+	return nil
+}
+
+func validateMicroVMController(controller microVMControllerContract) error {
+	if !controllerAuthDefaultsDeny(controller.Auth) {
+		return fmt.Errorf("apptheory: microvm controller must default to authenticated deny")
+	}
+	if missing := missingStrings(requiredMicroVMEnvelopeFields, controller.Envelope.RequiredFields); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm controller envelope missing fields: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings([]string{"raw_sdk_client", "bearer_token"}, controller.Envelope.ForbiddenFields); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm controller envelope missing forbidden fields: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings(requiredMicroVMControllerCommands, controllerCommandNames(controller.Commands)); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm controller missing commands: %s", strings.Join(missing, ","))
+	}
+	for _, command := range controller.Commands {
+		if strings.TrimSpace(command.Name) == "" || strings.TrimSpace(command.Method) == "" || strings.TrimSpace(command.Path) == "" {
+			return fmt.Errorf("apptheory: microvm controller commands must define name, method, and path")
+		}
+		if len(command.RequestFields) == 0 || len(command.ResponseFields) == 0 {
+			return fmt.Errorf("apptheory: microvm controller command %s must define request and response fields", command.Name)
+		}
+	}
+	return nil
+}
+
+func validateMicroVMSessionRegistry(registry microVMSessionRegistrySpec) error {
+	if strings.TrimSpace(registry.Pattern) != "tabletheory-single-table" {
+		return fmt.Errorf("apptheory: microvm session registry must use tabletheory-single-table guidance")
+	}
+	if missing := missingStrings([]string{"tenant_id", "namespace"}, registry.TenantBinding); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm session registry missing tenant binding: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings(requiredMicroVMSessionFields, registry.RequiredFields); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm session registry missing fields: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings(requiredMicroVMLifecycleStates, registry.StateValues); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm session registry missing states: %s", strings.Join(missing, ","))
+	}
+	if missing := missingStrings([]string{"raw_aws_credentials", "raw_lifecycle_hook_payload", "bearer_token"}, registry.ForbiddenFields); len(missing) > 0 {
+		return fmt.Errorf("apptheory: microvm session registry missing forbidden fields: %s", strings.Join(missing, ","))
+	}
+	return nil
+}
+
+func lifecycleHookNames(hooks []microVMLifecycleHook) []string {
+	out := make([]string, 0, len(hooks))
+	for _, hook := range hooks {
+		out = append(out, hook.Name)
+	}
+	return out
+}
+
+func controllerCommandNames(commands []microVMControllerCommand) []string {
+	out := make([]string, 0, len(commands))
+	for _, command := range commands {
+		out = append(out, command.Name)
+	}
+	return out
+}
+
+func missingStrings(required []string, got []string) []string {
+	seen := make(map[string]struct{}, len(got))
+	for _, value := range got {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			seen[trimmed] = struct{}{}
+		}
+	}
+	var missing []string
+	for _, value := range required {
+		if _, ok := seen[value]; !ok {
+			missing = append(missing, value)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/contract-tests/runners/go/fixture.go
+++ b/contract-tests/runners/go/fixture.go
@@ -33,6 +33,7 @@ type FixtureSetup struct {
 	SNS             []FixtureSNSRoute         `json:"sns,omitempty"`
 	EventBridge     []FixtureEventBridgeRoute `json:"eventbridge,omitempty"`
 	DynamoDB        []FixtureDynamoDBRoute    `json:"dynamodb,omitempty"`
+	MicroVMContract json.RawMessage           `json:"microvm_contract,omitempty"`
 }
 
 type FixtureCORSConfig struct {
@@ -119,6 +120,15 @@ type FixtureExpect struct {
 	ProfileLogs                []map[string]any                   `json:"profile_logs,omitempty"`
 	ProfileValidationErrors    []string                           `json:"profile_validation_errors,omitempty"`
 	LoggingProfileCatalog      map[string]any                     `json:"logging_profile_catalog,omitempty"`
+	MicroVMContractValidation  *FixtureMicroVMContractValidation  `json:"microvm_contract_validation,omitempty"`
+}
+
+type FixtureMicroVMContractValidation struct {
+	Valid        bool   `json:"valid"`
+	Kind         string `json:"kind,omitempty"`
+	Version      string `json:"version,omitempty"`
+	ErrorCode    string `json:"error_code,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
 }
 
 type FixtureError struct {
@@ -208,7 +218,7 @@ type FixtureSpanRecord struct {
 
 func loadFixtures(fixturesRoot string) ([]Fixture, error) {
 	var files []string
-	for _, tier := range []string{"p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14"} {
+	for _, tier := range []string{"p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14", "m15"} {
 		matches, err := filepath.Glob(filepath.Join(fixturesRoot, tier, "*.json"))
 		if err != nil {
 			return nil, fmt.Errorf("glob %s fixtures: %w", tier, err)

--- a/contract-tests/runners/go/runner.go
+++ b/contract-tests/runners/go/runner.go
@@ -38,6 +38,8 @@ func runFixture(f Fixture) error {
 		return runFixtureM12(f)
 	case "m14":
 		return runFixtureM14(f)
+	case "m15":
+		return runFixtureM15(f)
 	default:
 		return runFixtureLegacy(f)
 	}

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -58,7 +58,7 @@ def stable_json(value: Any) -> str:
 
 def list_fixture_files(fixtures_root: Path) -> list[Path]:
     files: list[Path] = []
-    for tier in ("p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14"):
+    for tier in ("p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14", "m15"):
         tier_dir = fixtures_root / tier
         if not tier_dir.exists():
             continue
@@ -765,6 +765,234 @@ def decode_logging_profile_validation_errors(runtime: Any, profile: Any) -> list
     return []
 
 
+MICROVM_CONTRACT_NAME = "apptheory.lambda_microvm"
+MICROVM_CONTRACT_VERSION = "m15.microvm/v1"
+MICROVM_REQUIRED_LIFECYCLE_HOOKS = ["prepare_image", "start", "readiness", "stop", "teardown", "failure"]
+MICROVM_REQUIRED_LIFECYCLE_STATES = [
+    "requested",
+    "image_preparing",
+    "image_prepared",
+    "starting",
+    "started",
+    "readiness_probing",
+    "ready",
+    "stopping",
+    "stopped",
+    "tearing_down",
+    "terminated",
+    "failed",
+]
+MICROVM_REQUIRED_CONTROLLER_COMMANDS = ["create", "start", "stop", "status", "session"]
+MICROVM_REQUIRED_ENVELOPE_FIELDS = ["command", "request_id", "tenant_id", "auth_context"]
+MICROVM_REQUIRED_SESSION_FIELDS = [
+    "tenant_id",
+    "namespace",
+    "session_id",
+    "state",
+    "desired_state",
+    "image_ref",
+    "controller_id",
+    "created_at",
+    "updated_at",
+    "expires_at",
+    "generation",
+    "last_command_id",
+    "auth_subject",
+]
+
+
+def compare_microvm_contract_fixture(
+    fixture: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any], dict[str, Any], _DummyEffectsApp]:
+    actual = validate_microvm_contract_fixture((fixture.get("setup") or {}).get("microvm_contract"))
+    expected = (fixture.get("expect") or {}).get("microvm_contract_validation")
+    if not isinstance(expected, dict):
+        return (
+            False,
+            "missing expect.microvm_contract_validation",
+            actual,
+            {"microvm_contract_validation": None},
+            _DummyEffectsApp(),
+        )
+    if actual == expected:
+        return True, "", actual, expected, _DummyEffectsApp()
+    return False, "microvm_contract_validation mismatch", actual, expected, _DummyEffectsApp()
+
+
+def validate_microvm_contract_fixture(contract: Any) -> dict[str, Any]:
+    if not isinstance(contract, dict):
+        return invalid_microvm_contract(
+            "m15.microvm.invalid_contract",
+            "apptheory: microvm contract fixture missing",
+        )
+
+    kind = str(contract.get("kind", "")).strip()
+    version = str(contract.get("version", "")).strip()
+    if str(contract.get("contract", "")).strip() != MICROVM_CONTRACT_NAME or version != MICROVM_CONTRACT_VERSION:
+        return invalid_microvm_contract(
+            "m15.microvm.invalid_contract",
+            "apptheory: microvm contract must be named and versioned",
+        )
+    if kind not in {"lifecycle", "controller_session"}:
+        return invalid_microvm_contract(
+            "m15.microvm.invalid_contract",
+            "apptheory: microvm contract kind is unsupported",
+        )
+
+    escape_hatches = contract.get("escape_hatches") or {}
+    if escape_hatches.get("raw_aws_sdk") is True:
+        return {
+            "valid": False,
+            "kind": kind,
+            "version": version,
+            "error_code": "m15.microvm.raw_sdk_escape_hatch",
+            "error_message": "apptheory: microvm contract forbids raw AWS SDK escape hatch",
+        }
+    if escape_hatches.get("raw_lifecycle_hook_bypass") is True:
+        return {
+            "valid": False,
+            "kind": kind,
+            "version": version,
+            "error_code": "m15.microvm.lifecycle_bypass",
+            "error_message": "apptheory: microvm contract forbids raw lifecycle hook bypass",
+        }
+
+    controller = contract.get("controller") or {}
+    if kind == "controller_session" and not microvm_controller_auth_defaults_deny(controller.get("auth") or {}):
+        return {
+            "valid": False,
+            "kind": kind,
+            "version": version,
+            "error_code": "m15.microvm.unauthenticated_controller",
+            "error_message": "apptheory: microvm controller must default to authenticated deny",
+        }
+
+    if kind == "lifecycle":
+        err = validate_microvm_lifecycle(contract.get("lifecycle") or {})
+        if err:
+            return invalid_microvm_contract("m15.microvm.lifecycle_incomplete", err)
+    else:
+        err = validate_microvm_controller(controller)
+        if err:
+            return invalid_microvm_contract("m15.microvm.controller_incomplete", err)
+        err = validate_microvm_session_registry(contract.get("session_registry") or {})
+        if err:
+            return invalid_microvm_contract("m15.microvm.session_registry_incomplete", err)
+
+    return {"valid": True, "kind": kind, "version": version}
+
+
+def invalid_microvm_contract(error_code: str, error_message: str) -> dict[str, Any]:
+    return {"valid": False, "error_code": error_code, "error_message": error_message}
+
+
+def microvm_controller_auth_defaults_deny(auth: dict[str, Any]) -> bool:
+    return auth.get("required") is True and str(auth.get("default", "")).strip().lower() == "deny"
+
+
+def validate_microvm_lifecycle(lifecycle: dict[str, Any]) -> str:
+    hooks = lifecycle.get("hooks") if isinstance(lifecycle.get("hooks"), list) else []
+    hook_names = [str(hook.get("name", "")) for hook in hooks if isinstance(hook, dict)]
+    missing_hooks = missing_strings(MICROVM_REQUIRED_LIFECYCLE_HOOKS, hook_names)
+    if missing_hooks:
+        return f"apptheory: microvm lifecycle missing hooks: {','.join(missing_hooks)}"
+
+    missing_states = missing_strings(MICROVM_REQUIRED_LIFECYCLE_STATES, lifecycle.get("states") or [])
+    if missing_states:
+        return f"apptheory: microvm lifecycle missing states: {','.join(missing_states)}"
+
+    missing_terminal = missing_strings(["terminated", "failed"], lifecycle.get("terminal_states") or [])
+    if missing_terminal:
+        return f"apptheory: microvm lifecycle missing terminal states: {','.join(missing_terminal)}"
+
+    transition_hooks: set[str] = set()
+    for transition in lifecycle.get("transitions") or []:
+        if not isinstance(transition, dict):
+            continue
+        if not str(transition.get("from", "")).strip() or not str(transition.get("to", "")).strip():
+            return "apptheory: microvm lifecycle transition states must be explicit"
+        hook = str(transition.get("hook", "")).strip()
+        if hook:
+            transition_hooks.add(hook)
+    for hook in MICROVM_REQUIRED_LIFECYCLE_HOOKS:
+        if hook not in transition_hooks:
+            return f"apptheory: microvm lifecycle missing transition for hook {hook}"
+
+    for hook in hooks:
+        if not isinstance(hook, dict):
+            return "apptheory: microvm lifecycle hooks must be objects"
+        if (
+            not str(hook.get("name", "")).strip()
+            or not str(hook.get("phase", "")).strip()
+            or not str(hook.get("state", "")).strip()
+            or not str(hook.get("success_state", "")).strip()
+            or not str(hook.get("failure_state", "")).strip()
+        ):
+            return "apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state"
+    return ""
+
+
+def validate_microvm_controller(controller: dict[str, Any]) -> str:
+    if not microvm_controller_auth_defaults_deny(controller.get("auth") or {}):
+        return "apptheory: microvm controller must default to authenticated deny"
+
+    envelope = controller.get("envelope") or {}
+    missing_envelope = missing_strings(MICROVM_REQUIRED_ENVELOPE_FIELDS, envelope.get("required_fields") or [])
+    if missing_envelope:
+        return f"apptheory: microvm controller envelope missing fields: {','.join(missing_envelope)}"
+
+    missing_forbidden = missing_strings(["raw_sdk_client", "bearer_token"], envelope.get("forbidden_fields") or [])
+    if missing_forbidden:
+        return f"apptheory: microvm controller envelope missing forbidden fields: {','.join(missing_forbidden)}"
+
+    commands = controller.get("commands") if isinstance(controller.get("commands"), list) else []
+    command_names = [str(command.get("name", "")) for command in commands if isinstance(command, dict)]
+    missing_commands = missing_strings(MICROVM_REQUIRED_CONTROLLER_COMMANDS, command_names)
+    if missing_commands:
+        return f"apptheory: microvm controller missing commands: {','.join(missing_commands)}"
+
+    for command in commands:
+        if not isinstance(command, dict):
+            return "apptheory: microvm controller commands must be objects"
+        name = str(command.get("name", "")).strip()
+        if not name or not str(command.get("method", "")).strip() or not str(command.get("path", "")).strip():
+            return "apptheory: microvm controller commands must define name, method, and path"
+        if not command.get("request_fields") or not command.get("response_fields"):
+            return f"apptheory: microvm controller command {name} must define request and response fields"
+    return ""
+
+
+def validate_microvm_session_registry(registry: dict[str, Any]) -> str:
+    if str(registry.get("pattern", "")).strip() != "tabletheory-single-table":
+        return "apptheory: microvm session registry must use tabletheory-single-table guidance"
+
+    missing_tenant_binding = missing_strings(["tenant_id", "namespace"], registry.get("tenant_binding") or [])
+    if missing_tenant_binding:
+        return f"apptheory: microvm session registry missing tenant binding: {','.join(missing_tenant_binding)}"
+
+    missing_fields = missing_strings(MICROVM_REQUIRED_SESSION_FIELDS, registry.get("required_fields") or [])
+    if missing_fields:
+        return f"apptheory: microvm session registry missing fields: {','.join(missing_fields)}"
+
+    missing_states = missing_strings(MICROVM_REQUIRED_LIFECYCLE_STATES, registry.get("state_values") or [])
+    if missing_states:
+        return f"apptheory: microvm session registry missing states: {','.join(missing_states)}"
+
+    missing_forbidden = missing_strings(
+        ["raw_aws_credentials", "raw_lifecycle_hook_payload", "bearer_token"],
+        registry.get("forbidden_fields") or [],
+    )
+    if missing_forbidden:
+        return f"apptheory: microvm session registry missing forbidden fields: {','.join(missing_forbidden)}"
+    return ""
+
+
+def missing_strings(required: list[str], got: Any) -> list[str]:
+    values = got if isinstance(got, list) else []
+    seen = {str(value).strip() for value in values if str(value).strip()}
+    return sorted(value for value in required if value not in seen)
+
+
 def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, dict[str, Any], FixtureApp]:
     tier = str(fixture.get("tier", "")).strip().lower()
     if tier == "p0":
@@ -788,6 +1016,8 @@ def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, 
         return run_fixture_m12(fixture)
     if tier == "m14":
         return run_fixture_m14(fixture)
+    if tier == "m15":
+        return compare_microvm_contract_fixture(fixture)
 
     setup = fixture.get("setup", {})
     input_ = fixture.get("input", {})
@@ -2831,6 +3061,9 @@ def main() -> int:
             if "profile_logs" in expect_obj:
                 print(f"  expected.profile_logs: {stable_json(expect_obj.get('profile_logs'))}", file=sys.stderr)
                 print(f"  got.profile_logs: {stable_json(actual.get('profile_logs'))}", file=sys.stderr)
+        elif "microvm_contract_validation" in expect_obj:
+            print(f"  expected.microvm_contract_validation: {stable_json(expected)}", file=sys.stderr)
+            print(f"  got.microvm_contract_validation: {stable_json(actual)}", file=sys.stderr)
         else:
             print(f"  expected: {stable_json(expected)}", file=sys.stderr)
             print(f"  got: {stable_json(debug_actual_for_expected(actual, expected))}", file=sys.stderr)

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -129,7 +129,7 @@ function decodeLoggingProfileValidationErrors(runtime, profile) {
 }
 
 function listFixtureFiles(fixturesRoot) {
-  const tiers = ["p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14"];
+  const tiers = ["p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14", "m15"];
   const files = [];
   for (const tier of tiers) {
     const dir = path.join(fixturesRoot, tier);
@@ -683,6 +683,228 @@ function compareHeaders(expectedHeaders, actualHeaders) {
   return deepEqual(e, a);
 }
 
+const MICROVM_CONTRACT_NAME = "apptheory.lambda_microvm";
+const MICROVM_CONTRACT_VERSION = "m15.microvm/v1";
+const MICROVM_REQUIRED_LIFECYCLE_HOOKS = ["prepare_image", "start", "readiness", "stop", "teardown", "failure"];
+const MICROVM_REQUIRED_LIFECYCLE_STATES = [
+  "requested",
+  "image_preparing",
+  "image_prepared",
+  "starting",
+  "started",
+  "readiness_probing",
+  "ready",
+  "stopping",
+  "stopped",
+  "tearing_down",
+  "terminated",
+  "failed",
+];
+const MICROVM_REQUIRED_CONTROLLER_COMMANDS = ["create", "start", "stop", "status", "session"];
+const MICROVM_REQUIRED_ENVELOPE_FIELDS = ["command", "request_id", "tenant_id", "auth_context"];
+const MICROVM_REQUIRED_SESSION_FIELDS = [
+  "tenant_id",
+  "namespace",
+  "session_id",
+  "state",
+  "desired_state",
+  "image_ref",
+  "controller_id",
+  "created_at",
+  "updated_at",
+  "expires_at",
+  "generation",
+  "last_command_id",
+  "auth_subject",
+];
+
+function compareMicroVMContractFixture(fixture) {
+  const actual = validateMicroVMContractFixture(fixture.setup?.microvm_contract);
+  const expected = fixture.expect?.microvm_contract_validation;
+  if (!expected) {
+    return {
+      ok: false,
+      reason: "missing expect.microvm_contract_validation",
+      expected_microvm_contract_validation: null,
+      actual_microvm_contract_validation: actual,
+    };
+  }
+  if (deepEqual(actual, expected)) return { ok: true };
+  return {
+    ok: false,
+    reason: "microvm_contract_validation mismatch",
+    expected_microvm_contract_validation: expected,
+    actual_microvm_contract_validation: actual,
+  };
+}
+
+function validateMicroVMContractFixture(contract) {
+  if (!contract || typeof contract !== "object" || Array.isArray(contract)) {
+    return invalidMicroVMContract("m15.microvm.invalid_contract", "apptheory: microvm contract fixture missing");
+  }
+
+  const kind = String(contract.kind ?? "").trim();
+  const version = String(contract.version ?? "").trim();
+  if (String(contract.contract ?? "").trim() !== MICROVM_CONTRACT_NAME || version !== MICROVM_CONTRACT_VERSION) {
+    return invalidMicroVMContract("m15.microvm.invalid_contract", "apptheory: microvm contract must be named and versioned");
+  }
+  if (kind !== "lifecycle" && kind !== "controller_session") {
+    return invalidMicroVMContract("m15.microvm.invalid_contract", "apptheory: microvm contract kind is unsupported");
+  }
+
+  const escapeHatches = contract.escape_hatches ?? {};
+  if (escapeHatches.raw_aws_sdk === true) {
+    return {
+      valid: false,
+      kind,
+      version,
+      error_code: "m15.microvm.raw_sdk_escape_hatch",
+      error_message: "apptheory: microvm contract forbids raw AWS SDK escape hatch",
+    };
+  }
+  if (escapeHatches.raw_lifecycle_hook_bypass === true) {
+    return {
+      valid: false,
+      kind,
+      version,
+      error_code: "m15.microvm.lifecycle_bypass",
+      error_message: "apptheory: microvm contract forbids raw lifecycle hook bypass",
+    };
+  }
+
+  const controller = contract.controller ?? {};
+  if (kind === "controller_session" && !microVMControllerAuthDefaultsDeny(controller.auth ?? {})) {
+    return {
+      valid: false,
+      kind,
+      version,
+      error_code: "m15.microvm.unauthenticated_controller",
+      error_message: "apptheory: microvm controller must default to authenticated deny",
+    };
+  }
+
+  if (kind === "lifecycle") {
+    const err = validateMicroVMLifecycle(contract.lifecycle ?? {});
+    if (err) return invalidMicroVMContract("m15.microvm.lifecycle_incomplete", err);
+  } else {
+    const controllerErr = validateMicroVMController(controller);
+    if (controllerErr) return invalidMicroVMContract("m15.microvm.controller_incomplete", controllerErr);
+    const registryErr = validateMicroVMSessionRegistry(contract.session_registry ?? {});
+    if (registryErr) return invalidMicroVMContract("m15.microvm.session_registry_incomplete", registryErr);
+  }
+
+  return { valid: true, kind, version };
+}
+
+function invalidMicroVMContract(errorCode, errorMessage) {
+  return { valid: false, error_code: errorCode, error_message: errorMessage };
+}
+
+function microVMControllerAuthDefaultsDeny(auth) {
+  return auth.required === true && String(auth.default ?? "").trim().toLowerCase() === "deny";
+}
+
+function validateMicroVMLifecycle(lifecycle) {
+  const hooks = Array.isArray(lifecycle.hooks) ? lifecycle.hooks : [];
+  const hookNames = hooks.map((hook) => String(hook?.name ?? ""));
+  const missingHooks = missingStrings(MICROVM_REQUIRED_LIFECYCLE_HOOKS, hookNames);
+  if (missingHooks.length > 0) return `apptheory: microvm lifecycle missing hooks: ${missingHooks.join(",")}`;
+
+  const missingStates = missingStrings(MICROVM_REQUIRED_LIFECYCLE_STATES, lifecycle.states ?? []);
+  if (missingStates.length > 0) return `apptheory: microvm lifecycle missing states: ${missingStates.join(",")}`;
+
+  const missingTerminal = missingStrings(["terminated", "failed"], lifecycle.terminal_states ?? []);
+  if (missingTerminal.length > 0) {
+    return `apptheory: microvm lifecycle missing terminal states: ${missingTerminal.join(",")}`;
+  }
+
+  const transitionHooks = new Set();
+  for (const transition of lifecycle.transitions ?? []) {
+    if (!String(transition?.from ?? "").trim() || !String(transition?.to ?? "").trim()) {
+      return "apptheory: microvm lifecycle transition states must be explicit";
+    }
+    const hook = String(transition?.hook ?? "").trim();
+    if (hook) transitionHooks.add(hook);
+  }
+  for (const hook of MICROVM_REQUIRED_LIFECYCLE_HOOKS) {
+    if (!transitionHooks.has(hook)) return `apptheory: microvm lifecycle missing transition for hook ${hook}`;
+  }
+
+  for (const hook of hooks) {
+    if (
+      !String(hook?.name ?? "").trim() ||
+      !String(hook?.phase ?? "").trim() ||
+      !String(hook?.state ?? "").trim() ||
+      !String(hook?.success_state ?? "").trim() ||
+      !String(hook?.failure_state ?? "").trim()
+    ) {
+      return "apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state";
+    }
+  }
+  return "";
+}
+
+function validateMicroVMController(controller) {
+  if (!microVMControllerAuthDefaultsDeny(controller.auth ?? {})) {
+    return "apptheory: microvm controller must default to authenticated deny";
+  }
+  const envelope = controller.envelope ?? {};
+  const missingEnvelope = missingStrings(MICROVM_REQUIRED_ENVELOPE_FIELDS, envelope.required_fields ?? []);
+  if (missingEnvelope.length > 0) {
+    return `apptheory: microvm controller envelope missing fields: ${missingEnvelope.join(",")}`;
+  }
+  const missingForbidden = missingStrings(["raw_sdk_client", "bearer_token"], envelope.forbidden_fields ?? []);
+  if (missingForbidden.length > 0) {
+    return `apptheory: microvm controller envelope missing forbidden fields: ${missingForbidden.join(",")}`;
+  }
+  const commands = Array.isArray(controller.commands) ? controller.commands : [];
+  const missingCommands = missingStrings(
+    MICROVM_REQUIRED_CONTROLLER_COMMANDS,
+    commands.map((command) => String(command?.name ?? "")),
+  );
+  if (missingCommands.length > 0) return `apptheory: microvm controller missing commands: ${missingCommands.join(",")}`;
+
+  for (const command of commands) {
+    const name = String(command?.name ?? "").trim();
+    if (!name || !String(command?.method ?? "").trim() || !String(command?.path ?? "").trim()) {
+      return "apptheory: microvm controller commands must define name, method, and path";
+    }
+    if (!Array.isArray(command.request_fields) || command.request_fields.length === 0 || !Array.isArray(command.response_fields) || command.response_fields.length === 0) {
+      return `apptheory: microvm controller command ${name} must define request and response fields`;
+    }
+  }
+  return "";
+}
+
+function validateMicroVMSessionRegistry(registry) {
+  if (String(registry.pattern ?? "").trim() !== "tabletheory-single-table") {
+    return "apptheory: microvm session registry must use tabletheory-single-table guidance";
+  }
+  const missingTenantBinding = missingStrings(["tenant_id", "namespace"], registry.tenant_binding ?? []);
+  if (missingTenantBinding.length > 0) {
+    return `apptheory: microvm session registry missing tenant binding: ${missingTenantBinding.join(",")}`;
+  }
+  const missingFields = missingStrings(MICROVM_REQUIRED_SESSION_FIELDS, registry.required_fields ?? []);
+  if (missingFields.length > 0) return `apptheory: microvm session registry missing fields: ${missingFields.join(",")}`;
+
+  const missingStates = missingStrings(MICROVM_REQUIRED_LIFECYCLE_STATES, registry.state_values ?? []);
+  if (missingStates.length > 0) return `apptheory: microvm session registry missing states: ${missingStates.join(",")}`;
+
+  const missingForbidden = missingStrings(
+    ["raw_aws_credentials", "raw_lifecycle_hook_payload", "bearer_token"],
+    registry.forbidden_fields ?? [],
+  );
+  if (missingForbidden.length > 0) {
+    return `apptheory: microvm session registry missing forbidden fields: ${missingForbidden.join(",")}`;
+  }
+  return "";
+}
+
+function missingStrings(required, got) {
+  const seen = new Set((Array.isArray(got) ? got : []).map((value) => String(value ?? "").trim()).filter(Boolean));
+  return required.filter((value) => !seen.has(value)).sort();
+}
+
 async function runFixture(fixture) {
   const tier = String(fixture.tier ?? "").trim().toLowerCase();
 
@@ -730,6 +952,9 @@ async function runFixture(fixture) {
   if (tier === "m14") {
     const { actual } = await runFixtureM14(fixture);
     return compareFixture(fixture, actual, { logs: [], metrics: [], spans: [] });
+  }
+  if (tier === "m15") {
+    return compareMicroVMContractFixture(fixture);
   }
 
   const enableP1 = ["p1", "p2"].includes(tier);
@@ -2935,6 +3160,13 @@ async function main() {
       } else if ("expected_profile_logs" in result) {
         console.error(`  expected.profile_logs: ${stableStringify(result.expected_profile_logs)}`);
         console.error(`  got.profile_logs: ${stableStringify(result.actual_profile_logs)}`);
+      } else if ("expected_microvm_contract_validation" in result) {
+        console.error(
+          `  expected.microvm_contract_validation: ${stableStringify(result.expected_microvm_contract_validation)}`,
+        );
+        console.error(
+          `  got.microvm_contract_validation: ${stableStringify(result.actual_microvm_contract_validation)}`,
+        );
       } else {
         console.error(`  expected: ${stableStringify(result.expected)}`);
         console.error(`  got: ${stableStringify(debugActualForExpected(result.actual, result.expected))}`);

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -40,6 +40,7 @@ groups:
     items:
       - { id: feature-events,         title: Event Workload Contracts, url: /features/event-workloads/,  icon: shuffle,      tag: ga }
       - { id: feature-jobs,           title: Jobs Ledger,             url: /features/jobs-ledger/,       icon: list-checks }
+      - { id: feature-microvm-contract, title: MicroVM Contract,       url: /features/lambda-microvm-contract-foundation/, icon: cpu, tag: new }
 
   - label: MCP
     items:
@@ -97,6 +98,7 @@ order:
   - feature-sanitization
   - feature-events
   - feature-jobs
+  - feature-microvm-contract
   - int-mcp
   - int-remote-mcp
   - int-agentcore
@@ -141,6 +143,7 @@ url_to_id:
   /features/sanitization/:                      feature-sanitization
   /features/event-workloads/:                   feature-events
   /features/jobs-ledger/:                       feature-jobs
+  /features/lambda-microvm-contract-foundation/: feature-microvm-contract
   /integrations/mcp/:                           int-mcp
   /integrations/remote-mcp/:                    int-remote-mcp
   /integrations/agentcore-mcp/:                 int-agentcore

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,6 +17,7 @@ contract.
 - [Jobs Ledger](./jobs-ledger.md)
 - [Event Workload Contracts](./event-workloads.md)
 - [Object Store Helper](./object-store.md)
+- [Lambda MicroVM Contract Foundation](./lambda-microvm-contract-foundation.md)
 
 ## Boundary
 

--- a/docs/features/lambda-microvm-contract-foundation.md
+++ b/docs/features/lambda-microvm-contract-foundation.md
@@ -1,0 +1,69 @@
+---
+title: Lambda MicroVM Contract Foundation
+description: M15 fixture-backed vocabulary for future first-class AWS Lambda MicroVM support.
+---
+
+# Lambda MicroVM Contract Foundation
+
+M15 introduces the **contract foundation** for first-class AWS Lambda MicroVM support in AppTheory. This is not a
+runtime implementation, CDK deployment surface, or deployment proof. It is the fixture-backed vocabulary that later
+milestones must implement consistently across Go, TypeScript, and Python before MicroVM deployments are considered
+shippable.
+
+The contract name is `apptheory.lambda_microvm`; the fixture version is `m15.microvm/v1`. Fixtures live under
+`contract-tests/fixtures/m15/` and are validated by the Go, TypeScript, and Python contract runners.
+
+## What M15 pins
+
+The M15 fixtures define:
+
+- lifecycle hook vocabulary for `prepare_image`, `start`, `readiness`, `stop`, `teardown`, and `failure`;
+- lifecycle states from `requested` through image preparation, start, readiness, stop, teardown, `terminated`, and
+  `failed`;
+- controller command vocabulary for `create`, `start`, `stop`, `status`, and `session` interactions;
+- controller envelope requirements for `command`, `request_id`, `tenant_id`, and `auth_context`;
+- safe error-envelope fields for controller responses;
+- durable session registry guidance using a TableTheory-patterned, tenant-and-namespace-bound record shape;
+- explicit denial fixtures for raw AWS SDK escape hatches, raw lifecycle hook bypasses, and unauthenticated controller
+  defaults.
+
+## Security posture
+
+The contract grows AppTheory's single path rather than adding a bypass. Later runtime and CDK work must preserve these
+M15 invariants:
+
+- no raw AWS SDK escape hatch for callers;
+- no raw lifecycle hook bypass outside the AppTheory lifecycle contract;
+- no unauthenticated controller default;
+- session records remain tenant and namespace scoped;
+- session registries must not persist raw AWS credentials, bearer tokens, or raw lifecycle hook payloads.
+
+## What this does not ship yet
+
+This milestone intentionally does **not** provide:
+
+- Go lifecycle adapters or control-plane runtime APIs;
+- TypeScript or Python runtime parity implementation;
+- a durable TableTheory-backed session registry implementation;
+- `AppTheoryMicrovm*` CDK constructs;
+- example applications;
+- any cloud deployment, live AWS receipt, account mutation, DNS mutation, or IAM mutation.
+
+Those items belong to follow-up milestones. Until they land with fixture-backed parity, AppTheory documentation should
+describe MicroVM support as contract foundation only.
+
+## Validating the foundation
+
+Run the shared contract runners:
+
+```bash
+./scripts/verify-contract-tests.sh
+```
+
+For focused debugging of only the fixture validators, run the three language runners directly:
+
+```bash
+go run ./contract-tests/runners/go
+node contract-tests/runners/ts/run.cjs
+python3 contract-tests/runners/py/run.py
+```

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 128 shared fixtures that arbitrate behavior across Go, TypeScript, and Python.
+description: The 133 shared fixtures that arbitrate behavior across Go, TypeScript, and Python.
 ---
 
 # Contract Fixtures
 
-AppTheory ships **128 contract test fixtures** in `contract-tests/fixtures/` that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **133 contract test fixtures** in `contract-tests/fixtures/` that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -27,7 +27,7 @@ When the contract needs to grow, the fixture grows first. When the fixture grows
 
 ## Categories
 
-The 128 fixtures span (counts approximate; see `contract-tests/fixtures/` for the canonical inventory):
+The 133 fixtures span (counts approximate; see `contract-tests/fixtures/` for the canonical inventory):
 
 | Category | Covers |
 | --- | --- |
@@ -47,6 +47,7 @@ The 128 fixtures span (counts approximate; see `contract-tests/fixtures/` for th
 | Kinesis | Partial-batch response, stream routing, fail-closed for unregistered streams, CloudWatch Logs subscription envelope decoding. |
 | Remote MCP path dispatch | API Gateway REST proxy path normalization for Remote MCP and protected-resource metadata routes. The shared fixtures do **not** cover MCP JSON-RPC methods, session stores, DCR, PKCE, bearer-token validation, or OAuth challenges. |
 | Sanitization | Token-like value redaction, JSON/XML safe-logging output. |
+| Lambda MicroVM foundation | M15 validation-only lifecycle hooks/states, controller command envelopes, TableTheory-patterned session-record guidance, and denial fixtures for raw SDK escape hatches, lifecycle bypass, and unauthenticated controller defaults. |
 
 ## Running the fixtures
 


### PR DESCRIPTION
## Milestone
M15 MicroVM Contract Foundation — validation-only Lambda MicroVM contract vocabulary and fail-closed cases.

## Linear
https://linear.app/theorycloud/project/first-class-aws-lambda-microvm-support-1aac7b7874c3/overview

## Scope
- Adds M15 shared fixtures for `apptheory.lambda_microvm` / `m15.microvm/v1` lifecycle and controller/session vocabulary.
- Adds Go, TypeScript, and Python contract-runner validation for the M15 fixtures.
- Documents the contract foundation and explicitly keeps runtime, CDK, and cloud deployment work out of this milestone.

## Contract impact
Fixture-first additive contract growth. The new fixtures fail closed for raw AWS SDK escape hatches, lifecycle hook bypasses, and unauthenticated controller defaults.

## Validation
- `go run ./contract-tests/runners/go` — `contract-tests(go): PASS (133 fixtures)`
- `node contract-tests/runners/ts/run.cjs` — `contract-tests(ts): PASS (133 fixtures)`
- `python3 contract-tests/runners/py/run.py` — `contract-tests(py): PASS (133 fixtures)`
- `./scripts/verify-contract-tests.sh` — `contract-tests: PASS`
- `./scripts/verify-api-snapshots.sh` — `api-snapshots: PASS`
- `bash ./scripts/verify-docs-standard.sh` — `docs-standard: PASS`
- `make test` — Go tests pass; `version-alignment: PASS (1.13.2)`
- `make lint` — `go-lint: PASS`; `ts-lint: PASS`; `python-lint: PASS`
- `make build` — release artifact build passes for TS, Python, CDK TS, and CDK Python
- `make rubric` — `Status: PASS`; `Pass: 29`; `Fail: 0`; `Blocked: 0`; `rubric: PASS`

## Cross-repo notes
None. No cloud mutations, raw SDK escape hatches, lifecycle bypasses, release manifests, or runtime implementation beyond the M15 contract foundation.