### PR TITLE
feat(microvm): add Go MicroVM runtime

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2930,13 +2930,31 @@ func (sessionRecord) TableName() string
 
 ## github.com/theory-cloud/apptheory/runtime/microvm
 
+const CommandCreate Command = "create"
+
+const CommandSession Command = "session"
+
+const CommandStart Command = "start"
+
+const CommandStatus Command = "status"
+
+const CommandStop Command = "stop"
+
 const ContractName = "apptheory.lambda_microvm"
 
 const ContractVersion = "m15.microvm/v1"
 
+const ControllerAuthDefaultDeny = "deny"
+
+const ErrorCodeControllerCommandFailed = "m15.microvm.controller_command_failed"
+
+const ErrorCodeControllerIncomplete = "m15.microvm.controller_incomplete"
+
 const ErrorCodeForbiddenField = "m15.microvm.forbidden_field"
 
 const ErrorCodeInvalidContract = "m15.microvm.invalid_contract"
+
+const ErrorCodeInvalidControllerRequest = "m15.microvm.invalid_controller_request"
 
 const ErrorCodeInvalidLifecycleEvent = "m15.microvm.invalid_lifecycle_event"
 
@@ -2947,6 +2965,10 @@ const ErrorCodeLifecycleHookFailed = "m15.microvm.lifecycle_hook_failed"
 const ErrorCodeLifecycleIncomplete = "m15.microvm.lifecycle_incomplete"
 
 const ErrorCodeRawSDKEscapeHatch = "m15.microvm.raw_sdk_escape_hatch"
+
+const ErrorCodeSessionRegistryIncomplete = "m15.microvm.session_registry_incomplete"
+
+const ErrorCodeUnauthenticatedController = "m15.microvm.unauthenticated_controller"
 
 const HookFailure LifecycleHook = "failure"
 
@@ -2959,6 +2981,10 @@ const HookStart LifecycleHook = "start"
 const HookStop LifecycleHook = "stop"
 
 const HookTeardown LifecycleHook = "teardown"
+
+const KindControllerSession ContractKind = "controller_session"
+
+const KindLifecycle ContractKind = "lifecycle"
 
 const StateFailed LifecycleState = "failed"
 
@@ -2983,6 +3009,112 @@ const StateStopping LifecycleState = "stopping"
 const StateTearingDown LifecycleState = "tearing_down"
 
 const StateTerminated LifecycleState = "terminated"
+
+type AuthContext struct {
+	Subject      string            `json:"subject"`
+	TenantID     string            `json:"tenant_id"`
+	Namespace    string            `json:"namespace,omitempty"`
+	Entitlements []string          `json:"entitlements,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+type Client interface {
+	Create(context.Context, CreateSessionInput) (SessionRecord, error)
+	Start(context.Context, SessionCommandInput) (SessionRecord, error)
+	Stop(context.Context, SessionCommandInput) (SessionRecord, error)
+	Status(context.Context, SessionQueryInput) (SessionStatus, error)
+	Session(context.Context, SessionQueryInput) (SessionRecord, error)
+}
+
+type Clock interface {
+	Now() time.Time
+}
+
+type Command string
+
+type ContractKind string
+
+type Controller struct {
+	client       Client
+	controllerID string
+	clock        Clock
+	ids          IDGenerator
+}
+
+type ControllerAuthContract struct {
+	Required bool   `json:"required"`
+	Default  string `json:"default"`
+}
+
+type ControllerCommandContract struct {
+	Name           Command  `json:"name"`
+	Method         string   `json:"method"`
+	Path           string   `json:"path"`
+	RequestFields  []string `json:"request_fields"`
+	ResponseFields []string `json:"response_fields"`
+}
+
+type ControllerContract struct {
+	Auth     ControllerAuthContract      `json:"auth"`
+	Envelope ControllerEnvelopeContract  `json:"envelope"`
+	Commands []ControllerCommandContract `json:"commands"`
+}
+
+type ControllerEnvelopeContract struct {
+	RequiredFields  []string `json:"required_fields"`
+	SafeErrorFields []string `json:"safe_error_fields"`
+	ForbiddenFields []string `json:"forbidden_fields"`
+}
+
+type ControllerOption func(*Controller)
+
+type ControllerRequest struct {
+	Command             Command     `json:"command"`
+	RequestID           string      `json:"request_id"`
+	TenantID            string      `json:"tenant_id"`
+	Namespace           string      `json:"namespace"`
+	AuthContext         AuthContext `json:"auth_context"`
+	SessionID           string      `json:"session_id,omitempty"`
+	ImageRef            string      `json:"image_ref,omitempty"`
+	NetworkConnectorRef string      `json:"network_connector_ref,omitempty"`
+	SessionSpec         SessionSpec `json:"session_spec,omitempty"`
+}
+
+type ControllerResponse struct {
+	Command         Command        `json:"command"`
+	RequestID       string         `json:"request_id"`
+	TenantID        string         `json:"tenant_id,omitempty"`
+	Namespace       string         `json:"namespace,omitempty"`
+	SessionID       string         `json:"session_id,omitempty"`
+	State           LifecycleState `json:"state,omitempty"`
+	DesiredState    LifecycleState `json:"desired_state,omitempty"`
+	LifecycleState  LifecycleState `json:"lifecycle_state,omitempty"`
+	LastTransition  time.Time      `json:"last_transition,omitempty"`
+	RegistryVersion int64          `json:"registry_version,omitempty"`
+	Error           *SafeError     `json:"error,omitempty"`
+}
+
+type CreateSessionInput struct {
+	RequestID           string      `json:"request_id"`
+	TenantID            string      `json:"tenant_id"`
+	Namespace           string      `json:"namespace"`
+	SessionID           string      `json:"session_id"`
+	ImageRef            string      `json:"image_ref"`
+	NetworkConnectorRef string      `json:"network_connector_ref"`
+	SessionSpec         SessionSpec `json:"session_spec"`
+	ControllerID        string      `json:"controller_id"`
+	AuthSubject         string      `json:"auth_subject"`
+	Now                 time.Time   `json:"now"`
+}
+
+type EscapeHatches struct {
+	RawAWSSDK              bool `json:"raw_aws_sdk"`
+	RawLifecycleHookBypass bool `json:"raw_lifecycle_hook_bypass"`
+}
+
+type IDGenerator interface {
+	NewID() string
+}
 
 type LifecycleAdapter struct {
 	contract LifecycleContract
@@ -3046,21 +3178,119 @@ type SafeError struct {
 	RequestID string `json:"request_id,omitempty"`
 }
 
+type SessionCommandInput struct {
+	RequestID    string         `json:"request_id"`
+	TenantID     string         `json:"tenant_id"`
+	Namespace    string         `json:"namespace"`
+	SessionID    string         `json:"session_id"`
+	ControllerID string         `json:"controller_id"`
+	AuthSubject  string         `json:"auth_subject"`
+	DesiredState LifecycleState `json:"desired_state"`
+	Now          time.Time      `json:"now"`
+}
+
+type SessionKey struct {
+	TenantID  string `json:"tenant_id"`
+	Namespace string `json:"namespace"`
+	SessionID string `json:"session_id"`
+}
+
+type SessionQueryInput struct {
+	RequestID   string `json:"request_id"`
+	TenantID    string `json:"tenant_id"`
+	Namespace   string `json:"namespace"`
+	SessionID   string `json:"session_id"`
+	AuthSubject string `json:"auth_subject"`
+}
+
+type SessionRecord struct {
+	TenantID            string            `json:"tenant_id"`
+	Namespace           string            `json:"namespace"`
+	SessionID           string            `json:"session_id"`
+	State               LifecycleState    `json:"state"`
+	DesiredState        LifecycleState    `json:"desired_state"`
+	ImageRef            string            `json:"image_ref"`
+	NetworkConnectorRef string            `json:"network_connector_ref,omitempty"`
+	ControllerID        string            `json:"controller_id"`
+	CreatedAt           time.Time         `json:"created_at"`
+	UpdatedAt           time.Time         `json:"updated_at"`
+	ExpiresAt           time.Time         `json:"expires_at"`
+	Generation          int64             `json:"generation"`
+	LastCommandID       string            `json:"last_command_id"`
+	AuthSubject         string            `json:"auth_subject"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
+}
+
+type SessionRegistryContract struct {
+	Pattern         string   `json:"pattern"`
+	TenantBinding   []string `json:"tenant_binding"`
+	RequiredFields  []string `json:"required_fields"`
+	StateValues     []string `json:"state_values"`
+	ForbiddenFields []string `json:"forbidden_fields"`
+}
+
+type SessionSpec struct {
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type SessionStatus struct {
+	TenantID        string         `json:"tenant_id"`
+	Namespace       string         `json:"namespace"`
+	SessionID       string         `json:"session_id"`
+	State           LifecycleState `json:"state"`
+	DesiredState    LifecycleState `json:"desired_state"`
+	LifecycleState  LifecycleState `json:"lifecycle_state"`
+	LastTransition  time.Time      `json:"last_transition"`
+	RegistryVersion int64          `json:"registry_version"`
+}
+
+func DefaultControllerContract() ControllerContract
+
 func DefaultLifecycleContract() LifecycleContract
+
+func DefaultSessionRegistryContract() SessionRegistryContract
 
 func IsTerminalState(LifecycleState) bool
 
+func NewController(Client, ...ControllerOption) (*Controller, error)
+
 func NewLifecycleAdapter(...LifecycleOption) (*LifecycleAdapter, error)
 
+func ValidateControllerContract(ControllerContract) error
+
+func ValidateEscapeHatches(EscapeHatches) error
+
 func ValidateLifecycleContract(LifecycleContract) error
+
+func ValidateSessionRecord(SessionRecord) error
+
+func ValidateSessionRegistryContract(SessionRegistryContract) error
+
+func ValidateSessionStatus(SessionStatus) error
+
+func WithControllerClock(Clock) ControllerOption
+
+func WithControllerID(string) ControllerOption
+
+func WithControllerIDGenerator(IDGenerator) ControllerOption
 
 func WithLifecycleContract(LifecycleContract) LifecycleOption
 
 func WithLifecycleHandler(LifecycleHook, LifecycleHandler) LifecycleOption
 
+func (*Controller) Handle(context.Context, ControllerRequest) (ControllerResponse, error)
+
 func (*LifecycleAdapter) Handle(context.Context, LifecycleEvent) (LifecycleResult, error)
 
 func (SafeError) Error() string
+
+func (SessionRecord) Key() SessionKey
+
+func (SessionStatus) Key() SessionKey
+
+func (randomIDGenerator) NewID() string
+
+func (realClock) Now() time.Time
 
 ## github.com/theory-cloud/apptheory/runtime/oauth
 
@@ -3602,6 +3832,41 @@ func (*Stream) Next() (*SSEMessage, error)
 func (*Stream) ReadAll() ([]SSEMessage, error)
 
 func (*Stream) Response() apptheory.Response
+
+## github.com/theory-cloud/apptheory/testkit/microvm
+
+type Call struct {
+	Command   runtimemicrovm.Command
+	RequestID string
+	TenantID  string
+	Namespace string
+	SessionID string
+}
+
+type FakeClient struct {
+	mu       sync.Mutex
+	now      time.Time
+	sessions map[runtimemicrovm.SessionKey]runtimemicrovm.SessionRecord
+	calls    []Call
+}
+
+func NewFakeClient() *FakeClient
+
+func NewFakeClientWithTime(time.Time) *FakeClient
+
+func (*FakeClient) Calls() []Call
+
+func (*FakeClient) Create(context.Context, runtimemicrovm.CreateSessionInput) (runtimemicrovm.SessionRecord, error)
+
+func (*FakeClient) Session(context.Context, runtimemicrovm.SessionQueryInput) (runtimemicrovm.SessionRecord, error)
+
+func (*FakeClient) SetNow(time.Time)
+
+func (*FakeClient) Start(context.Context, runtimemicrovm.SessionCommandInput) (runtimemicrovm.SessionRecord, error)
+
+func (*FakeClient) Status(context.Context, runtimemicrovm.SessionQueryInput) (runtimemicrovm.SessionStatus, error)
+
+func (*FakeClient) Stop(context.Context, runtimemicrovm.SessionCommandInput) (runtimemicrovm.SessionRecord, error)
 
 ## github.com/theory-cloud/apptheory/testkit/oauth
 

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2928,6 +2928,140 @@ func (dynamoTaskRecord) TableName() string
 
 func (sessionRecord) TableName() string
 
+## github.com/theory-cloud/apptheory/runtime/microvm
+
+const ContractName = "apptheory.lambda_microvm"
+
+const ContractVersion = "m15.microvm/v1"
+
+const ErrorCodeForbiddenField = "m15.microvm.forbidden_field"
+
+const ErrorCodeInvalidContract = "m15.microvm.invalid_contract"
+
+const ErrorCodeInvalidLifecycleEvent = "m15.microvm.invalid_lifecycle_event"
+
+const ErrorCodeLifecycleBypass = "m15.microvm.lifecycle_bypass"
+
+const ErrorCodeLifecycleHookFailed = "m15.microvm.lifecycle_hook_failed"
+
+const ErrorCodeLifecycleIncomplete = "m15.microvm.lifecycle_incomplete"
+
+const ErrorCodeRawSDKEscapeHatch = "m15.microvm.raw_sdk_escape_hatch"
+
+const HookFailure LifecycleHook = "failure"
+
+const HookPrepareImage LifecycleHook = "prepare_image"
+
+const HookReadiness LifecycleHook = "readiness"
+
+const HookStart LifecycleHook = "start"
+
+const HookStop LifecycleHook = "stop"
+
+const HookTeardown LifecycleHook = "teardown"
+
+const StateFailed LifecycleState = "failed"
+
+const StateImagePrepared LifecycleState = "image_prepared"
+
+const StateImagePreparing LifecycleState = "image_preparing"
+
+const StateReadinessProbing LifecycleState = "readiness_probing"
+
+const StateReady LifecycleState = "ready"
+
+const StateRequested LifecycleState = "requested"
+
+const StateStarted LifecycleState = "started"
+
+const StateStarting LifecycleState = "starting"
+
+const StateStopped LifecycleState = "stopped"
+
+const StateStopping LifecycleState = "stopping"
+
+const StateTearingDown LifecycleState = "tearing_down"
+
+const StateTerminated LifecycleState = "terminated"
+
+type LifecycleAdapter struct {
+	contract LifecycleContract
+	handlers map[LifecycleHook]LifecycleHandler
+}
+
+type LifecycleContract struct {
+	Hooks          []LifecycleHookSpec   `json:"hooks"`
+	States         []LifecycleState      `json:"states"`
+	TerminalStates []LifecycleState      `json:"terminal_states"`
+	Transitions    []LifecycleTransition `json:"transitions"`
+}
+
+type LifecycleEvent struct {
+	RequestID string            `json:"request_id"`
+	TenantID  string            `json:"tenant_id"`
+	Namespace string            `json:"namespace"`
+	SessionID string            `json:"session_id"`
+	Hook      LifecycleHook     `json:"hook"`
+	State     LifecycleState    `json:"state"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+type LifecycleHandler func(context.Context, LifecycleEvent) error
+
+type LifecycleHook string
+
+type LifecycleHookSpec struct {
+	Name         LifecycleHook  `json:"name"`
+	Phase        string         `json:"phase"`
+	State        LifecycleState `json:"state"`
+	SuccessState LifecycleState `json:"success_state"`
+	FailureState LifecycleState `json:"failure_state"`
+}
+
+type LifecycleOption func(*LifecycleAdapter)
+
+type LifecycleResult struct {
+	RequestID     string            `json:"request_id"`
+	TenantID      string            `json:"tenant_id"`
+	Namespace     string            `json:"namespace"`
+	SessionID     string            `json:"session_id"`
+	Hook          LifecycleHook     `json:"hook"`
+	PreviousState LifecycleState    `json:"previous_state"`
+	State         LifecycleState    `json:"state"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Error         *SafeError        `json:"error,omitempty"`
+}
+
+type LifecycleState string
+
+type LifecycleTransition struct {
+	From LifecycleState `json:"from"`
+	Hook LifecycleHook  `json:"hook"`
+	To   LifecycleState `json:"to"`
+}
+
+type SafeError struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id,omitempty"`
+}
+
+func DefaultLifecycleContract() LifecycleContract
+
+func IsTerminalState(LifecycleState) bool
+
+func NewLifecycleAdapter(...LifecycleOption) (*LifecycleAdapter, error)
+
+func ValidateLifecycleContract(LifecycleContract) error
+
+func WithLifecycleContract(LifecycleContract) LifecycleOption
+
+func WithLifecycleHandler(LifecycleHook, LifecycleHandler) LifecycleOption
+
+func (*LifecycleAdapter) Handle(context.Context, LifecycleEvent) (LifecycleResult, error)
+
+func (SafeError) Error() string
+
 ## github.com/theory-cloud/apptheory/runtime/oauth
 
 const ContextKeyBearerToken = "oauth.bearer_token"

--- a/contract-tests/runners/go/apptheory_m15.go
+++ b/contract-tests/runners/go/apptheory_m15.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
 	"strings"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 )
 
 const (
@@ -24,7 +27,6 @@ const (
 )
 
 var (
-	requiredMicroVMLifecycleHooks  = []string{"prepare_image", "start", "readiness", "stop", "teardown", "failure"}
 	requiredMicroVMLifecycleStates = []string{
 		"requested",
 		"image_preparing",
@@ -225,47 +227,102 @@ func controllerAuthDefaultsDeny(auth microVMControllerAuth) bool {
 }
 
 func validateMicroVMLifecycle(lifecycle microVMLifecycleContract) error {
-	if missing := missingStrings(requiredMicroVMLifecycleHooks, lifecycleHookNames(lifecycle.Hooks)); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm lifecycle missing hooks: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings(requiredMicroVMLifecycleStates, lifecycle.States); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm lifecycle missing states: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings([]string{"terminated", "failed"}, lifecycle.TerminalStates); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm lifecycle missing terminal states: %s", strings.Join(missing, ","))
-	}
-	if err := validateMicroVMLifecycleTransitions(lifecycle.Transitions); err != nil {
+	contract := runtimeLifecycleContract(lifecycle)
+	if err := runtimemicrovm.ValidateLifecycleContract(contract); err != nil {
 		return err
 	}
-	return validateMicroVMLifecycleHookFields(lifecycle.Hooks)
-}
 
-func validateMicroVMLifecycleTransitions(transitions []microVMLifecycleTransition) error {
-	transitionHooks := map[string]struct{}{}
-	for _, transition := range transitions {
-		if strings.TrimSpace(transition.From) == "" || strings.TrimSpace(transition.To) == "" {
-			return fmt.Errorf("apptheory: microvm lifecycle transition states must be explicit")
-		}
-		if strings.TrimSpace(transition.Hook) != "" {
-			transitionHooks[strings.TrimSpace(transition.Hook)] = struct{}{}
-		}
+	adapter, err := runtimemicrovm.NewLifecycleAdapter(
+		runtimemicrovm.WithLifecycleContract(contract),
+		runtimemicrovm.WithLifecycleHandler(runtimemicrovm.HookPrepareImage, noopRuntimeLifecycleHandler),
+		runtimemicrovm.WithLifecycleHandler(runtimemicrovm.HookStart, noopRuntimeLifecycleHandler),
+		runtimemicrovm.WithLifecycleHandler(runtimemicrovm.HookReadiness, noopRuntimeLifecycleHandler),
+		runtimemicrovm.WithLifecycleHandler(runtimemicrovm.HookStop, noopRuntimeLifecycleHandler),
+		runtimemicrovm.WithLifecycleHandler(runtimemicrovm.HookTeardown, noopRuntimeLifecycleHandler),
+		runtimemicrovm.WithLifecycleHandler(runtimemicrovm.HookFailure, noopRuntimeLifecycleHandler),
+	)
+	if err != nil {
+		return err
 	}
-	for _, hook := range requiredMicroVMLifecycleHooks {
-		if _, ok := transitionHooks[hook]; !ok {
-			return fmt.Errorf("apptheory: microvm lifecycle missing transition for hook %s", hook)
+
+	state := runtimemicrovm.StateRequested
+	for _, hook := range []runtimemicrovm.LifecycleHook{
+		runtimemicrovm.HookPrepareImage,
+		runtimemicrovm.HookStart,
+		runtimemicrovm.HookReadiness,
+		runtimemicrovm.HookStop,
+		runtimemicrovm.HookTeardown,
+	} {
+		result, handleErr := adapter.Handle(context.Background(), runtimemicrovm.LifecycleEvent{
+			RequestID: "m15-lifecycle-fixture",
+			TenantID:  "tenant-fixture",
+			Namespace: "namespace-fixture",
+			SessionID: "session-fixture",
+			Hook:      hook,
+			State:     state,
+		})
+		if handleErr != nil {
+			return handleErr
 		}
+		state = result.State
+	}
+	if state != runtimemicrovm.StateTerminated {
+		return fmt.Errorf("apptheory: microvm lifecycle adapter terminated at %s", state)
+	}
+
+	failure, err := adapter.Handle(context.Background(), runtimemicrovm.LifecycleEvent{
+		RequestID: "m15-lifecycle-fixture-failure",
+		TenantID:  "tenant-fixture",
+		Namespace: "namespace-fixture",
+		SessionID: "session-fixture",
+		Hook:      runtimemicrovm.HookFailure,
+		State:     runtimemicrovm.StateStarting,
+	})
+	if err != nil {
+		return err
+	}
+	if failure.State != runtimemicrovm.StateFailed {
+		return fmt.Errorf("apptheory: microvm lifecycle failure hook produced %s", failure.State)
 	}
 	return nil
 }
 
-func validateMicroVMLifecycleHookFields(hooks []microVMLifecycleHook) error {
-	for _, hook := range hooks {
-		if strings.TrimSpace(hook.Name) == "" || strings.TrimSpace(hook.Phase) == "" || strings.TrimSpace(hook.State) == "" || strings.TrimSpace(hook.SuccessState) == "" || strings.TrimSpace(hook.FailureState) == "" {
-			return fmt.Errorf("apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state")
-		}
+func runtimeLifecycleContract(lifecycle microVMLifecycleContract) runtimemicrovm.LifecycleContract {
+	hooks := make([]runtimemicrovm.LifecycleHookSpec, 0, len(lifecycle.Hooks))
+	for _, hook := range lifecycle.Hooks {
+		hooks = append(hooks, runtimemicrovm.LifecycleHookSpec{
+			Name:         runtimemicrovm.LifecycleHook(hook.Name),
+			Phase:        hook.Phase,
+			State:        runtimemicrovm.LifecycleState(hook.State),
+			SuccessState: runtimemicrovm.LifecycleState(hook.SuccessState),
+			FailureState: runtimemicrovm.LifecycleState(hook.FailureState),
+		})
 	}
-	return nil
+	states := make([]runtimemicrovm.LifecycleState, 0, len(lifecycle.States))
+	for _, state := range lifecycle.States {
+		states = append(states, runtimemicrovm.LifecycleState(state))
+	}
+	terminalStates := make([]runtimemicrovm.LifecycleState, 0, len(lifecycle.TerminalStates))
+	for _, state := range lifecycle.TerminalStates {
+		terminalStates = append(terminalStates, runtimemicrovm.LifecycleState(state))
+	}
+	transitions := make([]runtimemicrovm.LifecycleTransition, 0, len(lifecycle.Transitions))
+	for _, transition := range lifecycle.Transitions {
+		transitions = append(transitions, runtimemicrovm.LifecycleTransition{
+			From: runtimemicrovm.LifecycleState(transition.From),
+			Hook: runtimemicrovm.LifecycleHook(transition.Hook),
+			To:   runtimemicrovm.LifecycleState(transition.To),
+		})
+	}
+	return runtimemicrovm.LifecycleContract{
+		Hooks:          hooks,
+		States:         states,
+		TerminalStates: terminalStates,
+		Transitions:    transitions,
+	}
 }
+
+func noopRuntimeLifecycleHandler(context.Context, runtimemicrovm.LifecycleEvent) error { return nil }
 
 func validateMicroVMController(controller microVMControllerContract) error {
 	if !controllerAuthDefaultsDeny(controller.Auth) {
@@ -308,14 +365,6 @@ func validateMicroVMSessionRegistry(registry microVMSessionRegistrySpec) error {
 		return fmt.Errorf("apptheory: microvm session registry missing forbidden fields: %s", strings.Join(missing, ","))
 	}
 	return nil
-}
-
-func lifecycleHookNames(hooks []microVMLifecycleHook) []string {
-	out := make([]string, 0, len(hooks))
-	for _, hook := range hooks {
-		out = append(out, hook.Name)
-	}
-	return out
 }
 
 func controllerCommandNames(commands []microVMControllerCommand) []string {

--- a/contract-tests/runners/go/apptheory_m15.go
+++ b/contract-tests/runners/go/apptheory_m15.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 
 	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+	microvmtest "github.com/theory-cloud/apptheory/testkit/microvm"
 )
 
 const (
@@ -24,40 +25,6 @@ const (
 	microVMErrLifecycleIncomplete       = "m15.microvm.lifecycle_incomplete"
 	microVMErrControllerIncomplete      = "m15.microvm.controller_incomplete"
 	microVMErrSessionRegistryIncomplete = "m15.microvm.session_registry_incomplete"
-)
-
-var (
-	requiredMicroVMLifecycleStates = []string{
-		"requested",
-		"image_preparing",
-		"image_prepared",
-		"starting",
-		"started",
-		"readiness_probing",
-		"ready",
-		"stopping",
-		"stopped",
-		"tearing_down",
-		"terminated",
-		"failed",
-	}
-	requiredMicroVMControllerCommands = []string{"create", "start", "stop", "status", "session"}
-	requiredMicroVMEnvelopeFields     = []string{"command", "request_id", "tenant_id", "auth_context"}
-	requiredMicroVMSessionFields      = []string{
-		"tenant_id",
-		"namespace",
-		"session_id",
-		"state",
-		"desired_state",
-		"image_ref",
-		"controller_id",
-		"created_at",
-		"updated_at",
-		"expires_at",
-		"generation",
-		"last_command_id",
-		"auth_subject",
-	}
 )
 
 type microVMContractFixture struct {
@@ -197,25 +164,28 @@ func validateMicroVMEscapeHatches(
 	actual FixtureMicroVMContractValidation,
 	escapeHatches microVMEscapeHatches,
 ) *FixtureMicroVMContractValidation {
-	if escapeHatches.RawAWSSDK {
-		return &FixtureMicroVMContractValidation{
-			Valid:        false,
-			Kind:         actual.Kind,
-			Version:      actual.Version,
-			ErrorCode:    microVMErrRawSDKEscapeHatch,
-			ErrorMessage: "apptheory: microvm contract forbids raw AWS SDK escape hatch",
-		}
+	err := runtimemicrovm.ValidateEscapeHatches(runtimemicrovm.EscapeHatches{
+		RawAWSSDK:              escapeHatches.RawAWSSDK,
+		RawLifecycleHookBypass: escapeHatches.RawLifecycleHookBypass,
+	})
+	if err == nil {
+		return nil
 	}
-	if escapeHatches.RawLifecycleHookBypass {
-		return &FixtureMicroVMContractValidation{
-			Valid:        false,
-			Kind:         actual.Kind,
-			Version:      actual.Version,
-			ErrorCode:    microVMErrLifecycleBypass,
-			ErrorMessage: "apptheory: microvm contract forbids raw lifecycle hook bypass",
-		}
+	var safe runtimemicrovm.SafeError
+	if !errors.As(err, &safe) {
+		return fixtureMicroVMValidationRef(invalidMicroVMContract(microVMErrInvalidContract, err.Error()))
 	}
-	return nil
+	return &FixtureMicroVMContractValidation{
+		Valid:        false,
+		Kind:         actual.Kind,
+		Version:      actual.Version,
+		ErrorCode:    safe.Code,
+		ErrorMessage: safe.Message,
+	}
+}
+
+func fixtureMicroVMValidationRef(validation FixtureMicroVMContractValidation) *FixtureMicroVMContractValidation {
+	return &validation
 }
 
 func invalidMicroVMContract(code, message string) FixtureMicroVMContractValidation {
@@ -325,70 +295,148 @@ func runtimeLifecycleContract(lifecycle microVMLifecycleContract) runtimemicrovm
 func noopRuntimeLifecycleHandler(context.Context, runtimemicrovm.LifecycleEvent) error { return nil }
 
 func validateMicroVMController(controller microVMControllerContract) error {
-	if !controllerAuthDefaultsDeny(controller.Auth) {
-		return fmt.Errorf("apptheory: microvm controller must default to authenticated deny")
+	contract := runtimeControllerContract(controller)
+	if err := runtimemicrovm.ValidateControllerContract(contract); err != nil {
+		return err
 	}
-	if missing := missingStrings(requiredMicroVMEnvelopeFields, controller.Envelope.RequiredFields); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm controller envelope missing fields: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings([]string{"raw_sdk_client", "bearer_token"}, controller.Envelope.ForbiddenFields); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm controller envelope missing forbidden fields: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings(requiredMicroVMControllerCommands, controllerCommandNames(controller.Commands)); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm controller missing commands: %s", strings.Join(missing, ","))
-	}
+	return exerciseRuntimeController()
+}
+
+func runtimeControllerContract(controller microVMControllerContract) runtimemicrovm.ControllerContract {
+	commands := make([]runtimemicrovm.ControllerCommandContract, 0, len(controller.Commands))
 	for _, command := range controller.Commands {
-		if strings.TrimSpace(command.Name) == "" || strings.TrimSpace(command.Method) == "" || strings.TrimSpace(command.Path) == "" {
-			return fmt.Errorf("apptheory: microvm controller commands must define name, method, and path")
-		}
-		if len(command.RequestFields) == 0 || len(command.ResponseFields) == 0 {
-			return fmt.Errorf("apptheory: microvm controller command %s must define request and response fields", command.Name)
-		}
+		commands = append(commands, runtimemicrovm.ControllerCommandContract{
+			Name:           runtimemicrovm.Command(command.Name),
+			Method:         command.Method,
+			Path:           command.Path,
+			RequestFields:  append([]string(nil), command.RequestFields...),
+			ResponseFields: append([]string(nil), command.ResponseFields...),
+		})
+	}
+	return runtimemicrovm.ControllerContract{
+		Auth: runtimemicrovm.ControllerAuthContract{
+			Required: controller.Auth.Required,
+			Default:  controller.Auth.Default,
+		},
+		Envelope: runtimemicrovm.ControllerEnvelopeContract{
+			RequiredFields:  append([]string(nil), controller.Envelope.RequiredFields...),
+			SafeErrorFields: append([]string(nil), controller.Envelope.SafeErrorFields...),
+			ForbiddenFields: append([]string(nil), controller.Envelope.ForbiddenFields...),
+		},
+		Commands: commands,
+	}
+}
+
+func exerciseRuntimeController() error {
+	client := microvmtest.NewFakeClient()
+	controller, err := runtimemicrovm.NewController(
+		client,
+		runtimemicrovm.WithControllerID("controller-fixture"),
+		runtimemicrovm.WithControllerIDGenerator(microVMFixtureIDs{}),
+	)
+	if err != nil {
+		return err
+	}
+
+	create, err := controller.Handle(context.Background(), runtimeControllerRequest(runtimemicrovm.CommandCreate, "m15-create", ""))
+	if err != nil {
+		return err
+	}
+	if err := requireCreateResponse(create); err != nil {
+		return err
+	}
+	return exerciseRuntimeControllerCommands(controller, create.SessionID)
+}
+
+func exerciseRuntimeControllerCommands(controller *runtimemicrovm.Controller, sessionID string) error {
+	start, err := controller.Handle(context.Background(), runtimeControllerRequest(runtimemicrovm.CommandStart, "m15-start", sessionID))
+	if err != nil {
+		return err
+	}
+	if validationErr := requireStartStopResponse("start", start, sessionID, runtimemicrovm.StateStarted); validationErr != nil {
+		return validationErr
+	}
+
+	status, err := controller.Handle(context.Background(), runtimeControllerRequest(runtimemicrovm.CommandStatus, "m15-status", sessionID))
+	if err != nil {
+		return err
+	}
+	if validationErr := requireStatusResponse(status, sessionID); validationErr != nil {
+		return validationErr
+	}
+
+	session, err := controller.Handle(context.Background(), runtimeControllerRequest(runtimemicrovm.CommandSession, "m15-session", sessionID))
+	if err != nil {
+		return err
+	}
+	if validationErr := requireSessionResponse(session, sessionID); validationErr != nil {
+		return validationErr
+	}
+
+	stop, err := controller.Handle(context.Background(), runtimeControllerRequest(runtimemicrovm.CommandStop, "m15-stop", sessionID))
+	if err != nil {
+		return err
+	}
+	return requireStartStopResponse("stop", stop, sessionID, runtimemicrovm.StateStopped)
+}
+
+func requireCreateResponse(response runtimemicrovm.ControllerResponse) error {
+	if response.SessionID == "" || response.State != runtimemicrovm.StateRequested || response.RegistryVersion == 0 {
+		return fmt.Errorf("apptheory: microvm controller create response incomplete")
 	}
 	return nil
 }
+
+func requireStartStopResponse(name string, response runtimemicrovm.ControllerResponse, sessionID string, desired runtimemicrovm.LifecycleState) error {
+	if response.SessionID != sessionID || response.State == "" || response.DesiredState != desired {
+		return fmt.Errorf("apptheory: microvm controller %s response incomplete", name)
+	}
+	return nil
+}
+
+func requireStatusResponse(response runtimemicrovm.ControllerResponse, sessionID string) error {
+	if response.SessionID != sessionID || response.LifecycleState == "" || response.LastTransition.IsZero() {
+		return fmt.Errorf("apptheory: microvm controller status response incomplete")
+	}
+	return nil
+}
+
+func requireSessionResponse(response runtimemicrovm.ControllerResponse, sessionID string) error {
+	if response.SessionID != sessionID || response.TenantID == "" || response.Namespace == "" || response.RegistryVersion == 0 {
+		return fmt.Errorf("apptheory: microvm controller session response incomplete")
+	}
+	return nil
+}
+
+func runtimeControllerRequest(command runtimemicrovm.Command, requestID string, sessionID string) runtimemicrovm.ControllerRequest {
+	request := runtimemicrovm.ControllerRequest{
+		Command:   command,
+		RequestID: requestID,
+		TenantID:  "tenant-fixture",
+		Namespace: "namespace-fixture",
+		AuthContext: runtimemicrovm.AuthContext{
+			Subject:  "subject-fixture",
+			TenantID: "tenant-fixture",
+		},
+		SessionID: sessionID,
+	}
+	if command == runtimemicrovm.CommandCreate {
+		request.ImageRef = "image-fixture"
+		request.NetworkConnectorRef = "network-fixture"
+	}
+	return request
+}
+
+type microVMFixtureIDs struct{}
+
+func (microVMFixtureIDs) NewID() string { return "session-fixture" }
 
 func validateMicroVMSessionRegistry(registry microVMSessionRegistrySpec) error {
-	if strings.TrimSpace(registry.Pattern) != "tabletheory-single-table" {
-		return fmt.Errorf("apptheory: microvm session registry must use tabletheory-single-table guidance")
-	}
-	if missing := missingStrings([]string{"tenant_id", "namespace"}, registry.TenantBinding); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm session registry missing tenant binding: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings(requiredMicroVMSessionFields, registry.RequiredFields); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm session registry missing fields: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings(requiredMicroVMLifecycleStates, registry.StateValues); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm session registry missing states: %s", strings.Join(missing, ","))
-	}
-	if missing := missingStrings([]string{"raw_aws_credentials", "raw_lifecycle_hook_payload", "bearer_token"}, registry.ForbiddenFields); len(missing) > 0 {
-		return fmt.Errorf("apptheory: microvm session registry missing forbidden fields: %s", strings.Join(missing, ","))
-	}
-	return nil
-}
-
-func controllerCommandNames(commands []microVMControllerCommand) []string {
-	out := make([]string, 0, len(commands))
-	for _, command := range commands {
-		out = append(out, command.Name)
-	}
-	return out
-}
-
-func missingStrings(required []string, got []string) []string {
-	seen := make(map[string]struct{}, len(got))
-	for _, value := range got {
-		trimmed := strings.TrimSpace(value)
-		if trimmed != "" {
-			seen[trimmed] = struct{}{}
-		}
-	}
-	var missing []string
-	for _, value := range required {
-		if _, ok := seen[value]; !ok {
-			missing = append(missing, value)
-		}
-	}
-	sort.Strings(missing)
-	return missing
+	return runtimemicrovm.ValidateSessionRegistryContract(runtimemicrovm.SessionRegistryContract{
+		Pattern:         registry.Pattern,
+		TenantBinding:   append([]string(nil), registry.TenantBinding...),
+		RequiredFields:  append([]string(nil), registry.RequiredFields...),
+		StateValues:     append([]string(nil), registry.StateValues...),
+		ForbiddenFields: append([]string(nil), registry.ForbiddenFields...),
+	})
 }

--- a/runtime/microvm/controller.go
+++ b/runtime/microvm/controller.go
@@ -1,0 +1,428 @@
+package microvm
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+const (
+	// ErrorCodeInvalidControllerRequest reports a malformed controller request envelope.
+	ErrorCodeInvalidControllerRequest = "m15.microvm.invalid_controller_request"
+	// ErrorCodeControllerCommandFailed reports a sanitized client command failure.
+	ErrorCodeControllerCommandFailed = "m15.microvm.controller_command_failed"
+)
+
+// Command names a constrained MicroVM controller command.
+type Command string
+
+const (
+	CommandCreate  Command = "create"
+	CommandStart   Command = "start"
+	CommandStop    Command = "stop"
+	CommandStatus  Command = "status"
+	CommandSession Command = "session"
+)
+
+// Clock supplies controller timestamps.
+type Clock interface {
+	Now() time.Time
+}
+
+// IDGenerator supplies controller-created session identifiers.
+type IDGenerator interface {
+	NewID() string
+}
+
+// AuthContext is the sanitized authenticated principal context required by controller requests.
+type AuthContext struct {
+	Subject      string            `json:"subject"`
+	TenantID     string            `json:"tenant_id"`
+	Namespace    string            `json:"namespace,omitempty"`
+	Entitlements []string          `json:"entitlements,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// SessionSpec is the safe session specification accepted by the controller.
+type SessionSpec struct {
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// ControllerRequest is the single AppTheory MicroVM control-plane request envelope.
+type ControllerRequest struct {
+	Command             Command     `json:"command"`
+	RequestID           string      `json:"request_id"`
+	TenantID            string      `json:"tenant_id"`
+	Namespace           string      `json:"namespace"`
+	AuthContext         AuthContext `json:"auth_context"`
+	SessionID           string      `json:"session_id,omitempty"`
+	ImageRef            string      `json:"image_ref,omitempty"`
+	NetworkConnectorRef string      `json:"network_connector_ref,omitempty"`
+	SessionSpec         SessionSpec `json:"session_spec,omitempty"`
+}
+
+// ControllerResponse is the safe controller response envelope.
+type ControllerResponse struct {
+	Command         Command        `json:"command"`
+	RequestID       string         `json:"request_id"`
+	TenantID        string         `json:"tenant_id,omitempty"`
+	Namespace       string         `json:"namespace,omitempty"`
+	SessionID       string         `json:"session_id,omitempty"`
+	State           LifecycleState `json:"state,omitempty"`
+	DesiredState    LifecycleState `json:"desired_state,omitempty"`
+	LifecycleState  LifecycleState `json:"lifecycle_state,omitempty"`
+	LastTransition  time.Time      `json:"last_transition,omitempty"`
+	RegistryVersion int64          `json:"registry_version,omitempty"`
+	Error           *SafeError     `json:"error,omitempty"`
+}
+
+// Client is the constrained MicroVM client surface. It deliberately exposes no raw AWS SDK client.
+type Client interface {
+	Create(context.Context, CreateSessionInput) (SessionRecord, error)
+	Start(context.Context, SessionCommandInput) (SessionRecord, error)
+	Stop(context.Context, SessionCommandInput) (SessionRecord, error)
+	Status(context.Context, SessionQueryInput) (SessionStatus, error)
+	Session(context.Context, SessionQueryInput) (SessionRecord, error)
+}
+
+// Controller handles constrained MicroVM control-plane commands.
+type Controller struct {
+	client       Client
+	controllerID string
+	clock        Clock
+	ids          IDGenerator
+}
+
+// ControllerOption configures a Controller.
+type ControllerOption func(*Controller)
+
+// WithControllerID sets the controller_id written into session records.
+func WithControllerID(controllerID string) ControllerOption {
+	return func(controller *Controller) {
+		controllerID = strings.TrimSpace(controllerID)
+		if controllerID != "" {
+			controller.controllerID = controllerID
+		}
+	}
+}
+
+// WithControllerClock sets the controller clock. Nil restores the real clock.
+func WithControllerClock(clock Clock) ControllerOption {
+	return func(controller *Controller) {
+		if clock == nil {
+			controller.clock = realClock{}
+			return
+		}
+		controller.clock = clock
+	}
+}
+
+// WithControllerIDGenerator sets the controller session ID generator. Nil restores the default generator.
+func WithControllerIDGenerator(ids IDGenerator) ControllerOption {
+	return func(controller *Controller) {
+		if ids == nil {
+			controller.ids = randomIDGenerator{}
+			return
+		}
+		controller.ids = ids
+	}
+}
+
+// NewController creates a fail-closed MicroVM controller.
+func NewController(client Client, opts ...ControllerOption) (*Controller, error) {
+	if client == nil {
+		return nil, safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller requires a constrained client", "")
+	}
+	controller := &Controller{
+		client:       client,
+		controllerID: "apptheory-microvm-controller",
+		clock:        realClock{},
+		ids:          randomIDGenerator{},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(controller)
+		}
+	}
+	return controller, nil
+}
+
+// Handle executes a controller request after authenticated, tenant-bound envelope validation.
+func (c *Controller) Handle(ctx context.Context, request ControllerRequest) (ControllerResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c == nil || c.client == nil {
+		err := safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller requires a constrained client", request.RequestID)
+		return controllerErrorResponse(request, err), err
+	}
+	request = normalizeControllerRequest(request)
+	if err := validateControllerRequest(request); err != nil {
+		safe := asSafeError(err, request.RequestID)
+		return controllerErrorResponse(request, safe), safe
+	}
+
+	switch request.Command {
+	case CommandCreate:
+		return c.handleCreate(ctx, request)
+	case CommandStart:
+		return c.handleCommand(ctx, request, StateStarted, c.client.Start)
+	case CommandStop:
+		return c.handleCommand(ctx, request, StateStopped, c.client.Stop)
+	case CommandStatus:
+		return c.handleStatus(ctx, request)
+	case CommandSession:
+		return c.handleSession(ctx, request)
+	default:
+		err := safeError(ErrorCodeInvalidControllerRequest, "apptheory: microvm controller command is unsupported", request.RequestID)
+		return controllerErrorResponse(request, err), err
+	}
+}
+
+func (c *Controller) handleCreate(ctx context.Context, request ControllerRequest) (ControllerResponse, error) {
+	input := CreateSessionInput{
+		RequestID:           request.RequestID,
+		TenantID:            request.TenantID,
+		Namespace:           request.Namespace,
+		SessionID:           strings.TrimSpace(request.SessionID),
+		ImageRef:            request.ImageRef,
+		NetworkConnectorRef: request.NetworkConnectorRef,
+		SessionSpec:         cloneSessionSpec(request.SessionSpec),
+		ControllerID:        c.controllerID,
+		AuthSubject:         request.AuthContext.Subject,
+		Now:                 c.clock.Now(),
+	}
+	if input.SessionID == "" {
+		input.SessionID = strings.TrimSpace(c.ids.NewID())
+	}
+	if input.SessionID == "" {
+		err := safeError(ErrorCodeInvalidControllerRequest, "apptheory: microvm controller could not allocate session id", request.RequestID)
+		return controllerErrorResponse(request, err), err
+	}
+	record, err := c.client.Create(ctx, input)
+	if err != nil {
+		return commandFailedResponse(request)
+	}
+	if err := ValidateSessionRecord(record); err != nil {
+		safe := asSafeError(err, request.RequestID)
+		return controllerErrorResponse(request, safe), safe
+	}
+	return responseFromSession(request, record), nil
+}
+
+func (c *Controller) handleCommand(
+	ctx context.Context,
+	request ControllerRequest,
+	desired LifecycleState,
+	run func(context.Context, SessionCommandInput) (SessionRecord, error),
+) (ControllerResponse, error) {
+	record, err := run(ctx, SessionCommandInput{
+		RequestID:    request.RequestID,
+		TenantID:     request.TenantID,
+		Namespace:    request.Namespace,
+		SessionID:    request.SessionID,
+		ControllerID: c.controllerID,
+		AuthSubject:  request.AuthContext.Subject,
+		DesiredState: desired,
+		Now:          c.clock.Now(),
+	})
+	if err != nil {
+		return commandFailedResponse(request)
+	}
+	if err := ValidateSessionRecord(record); err != nil {
+		safe := asSafeError(err, request.RequestID)
+		return controllerErrorResponse(request, safe), safe
+	}
+	return responseFromSession(request, record), nil
+}
+
+func (c *Controller) handleStatus(ctx context.Context, request ControllerRequest) (ControllerResponse, error) {
+	status, err := c.client.Status(ctx, controllerQueryInput(request))
+	if err != nil {
+		return commandFailedResponse(request)
+	}
+	if err := ValidateSessionStatus(status); err != nil {
+		safe := asSafeError(err, request.RequestID)
+		return controllerErrorResponse(request, safe), safe
+	}
+	return responseFromStatus(request, status), nil
+}
+
+func (c *Controller) handleSession(ctx context.Context, request ControllerRequest) (ControllerResponse, error) {
+	record, err := c.client.Session(ctx, controllerQueryInput(request))
+	if err != nil {
+		return commandFailedResponse(request)
+	}
+	if err := ValidateSessionRecord(record); err != nil {
+		safe := asSafeError(err, request.RequestID)
+		return controllerErrorResponse(request, safe), safe
+	}
+	return responseFromSession(request, record), nil
+}
+
+func controllerQueryInput(request ControllerRequest) SessionQueryInput {
+	return SessionQueryInput{
+		RequestID:   request.RequestID,
+		TenantID:    request.TenantID,
+		Namespace:   request.Namespace,
+		SessionID:   request.SessionID,
+		AuthSubject: request.AuthContext.Subject,
+	}
+}
+
+func commandFailedResponse(request ControllerRequest) (ControllerResponse, error) {
+	safe := safeError(ErrorCodeControllerCommandFailed, "apptheory: microvm controller command failed", request.RequestID)
+	return controllerErrorResponse(request, safe), safe
+}
+
+func validateControllerRequest(request ControllerRequest) error {
+	if err := validateControllerEnvelope(request); err != nil {
+		return err
+	}
+	if err := validateControllerAuth(request); err != nil {
+		return err
+	}
+	if err := validateControllerSafeFields(request); err != nil {
+		return err
+	}
+	return validateControllerCommandFields(request)
+}
+
+func validateControllerEnvelope(request ControllerRequest) error {
+	if request.Command == "" || request.RequestID == "" || request.TenantID == "" || request.Namespace == "" {
+		return safeError(ErrorCodeInvalidControllerRequest, "apptheory: microvm controller envelope is incomplete", request.RequestID)
+	}
+	return nil
+}
+
+func validateControllerAuth(request ControllerRequest) error {
+	if request.AuthContext.Subject == "" || request.AuthContext.TenantID == "" {
+		return safeError(ErrorCodeUnauthenticatedController, "apptheory: microvm controller must default to authenticated deny", request.RequestID)
+	}
+	if request.AuthContext.TenantID != request.TenantID {
+		return safeError(ErrorCodeUnauthenticatedController, "apptheory: microvm controller tenant binding mismatch", request.RequestID)
+	}
+	if request.AuthContext.Namespace != "" && request.AuthContext.Namespace != request.Namespace {
+		return safeError(ErrorCodeUnauthenticatedController, "apptheory: microvm controller namespace binding mismatch", request.RequestID)
+	}
+	return nil
+}
+
+func validateControllerSafeFields(request ControllerRequest) error {
+	if err := validateSafeMetadata(request.AuthContext.Metadata, request.RequestID); err != nil {
+		return err
+	}
+	return validateSafeMetadata(request.SessionSpec.Metadata, request.RequestID)
+}
+
+func validateControllerCommandFields(request ControllerRequest) error {
+	switch request.Command {
+	case CommandCreate:
+		return validateCreateRequestFields(request)
+	case CommandStart, CommandStop, CommandStatus, CommandSession:
+		return validateSessionCommandFields(request)
+	default:
+		return safeError(ErrorCodeInvalidControllerRequest, "apptheory: microvm controller command is unsupported", request.RequestID)
+	}
+}
+
+func validateCreateRequestFields(request ControllerRequest) error {
+	if request.ImageRef == "" || request.NetworkConnectorRef == "" {
+		return safeError(ErrorCodeInvalidControllerRequest, "apptheory: microvm create requires image and network connector refs", request.RequestID)
+	}
+	return nil
+}
+
+func validateSessionCommandFields(request ControllerRequest) error {
+	if request.SessionID == "" {
+		return safeError(ErrorCodeInvalidControllerRequest, "apptheory: microvm controller session_id is required", request.RequestID)
+	}
+	return nil
+}
+
+func normalizeControllerRequest(request ControllerRequest) ControllerRequest {
+	request.Command = normalizeCommand(request.Command)
+	request.RequestID = strings.TrimSpace(request.RequestID)
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.Namespace = strings.TrimSpace(request.Namespace)
+	request.SessionID = strings.TrimSpace(request.SessionID)
+	request.ImageRef = strings.TrimSpace(request.ImageRef)
+	request.NetworkConnectorRef = strings.TrimSpace(request.NetworkConnectorRef)
+	request.AuthContext = normalizeAuthContext(request.AuthContext)
+	request.SessionSpec = cloneSessionSpec(request.SessionSpec)
+	return request
+}
+
+func normalizeAuthContext(auth AuthContext) AuthContext {
+	auth.Subject = strings.TrimSpace(auth.Subject)
+	auth.TenantID = strings.TrimSpace(auth.TenantID)
+	auth.Namespace = strings.TrimSpace(auth.Namespace)
+	auth.Entitlements = append([]string(nil), auth.Entitlements...)
+	auth.Metadata = cloneStringMap(auth.Metadata)
+	return auth
+}
+
+func cloneSessionSpec(spec SessionSpec) SessionSpec {
+	return SessionSpec{Metadata: cloneStringMap(spec.Metadata)}
+}
+
+func responseFromSession(request ControllerRequest, record SessionRecord) ControllerResponse {
+	return ControllerResponse{
+		Command:         request.Command,
+		RequestID:       request.RequestID,
+		TenantID:        record.TenantID,
+		Namespace:       record.Namespace,
+		SessionID:       record.SessionID,
+		State:           record.State,
+		DesiredState:    record.DesiredState,
+		LifecycleState:  record.State,
+		LastTransition:  record.UpdatedAt,
+		RegistryVersion: record.Generation,
+	}
+}
+
+func responseFromStatus(request ControllerRequest, status SessionStatus) ControllerResponse {
+	return ControllerResponse{
+		Command:         request.Command,
+		RequestID:       request.RequestID,
+		TenantID:        status.TenantID,
+		Namespace:       status.Namespace,
+		SessionID:       status.SessionID,
+		State:           status.State,
+		DesiredState:    status.DesiredState,
+		LifecycleState:  status.LifecycleState,
+		LastTransition:  status.LastTransition,
+		RegistryVersion: status.RegistryVersion,
+	}
+}
+
+func controllerErrorResponse(request ControllerRequest, err SafeError) ControllerResponse {
+	return ControllerResponse{
+		Command:   normalizeCommand(request.Command),
+		RequestID: strings.TrimSpace(request.RequestID),
+		TenantID:  strings.TrimSpace(request.TenantID),
+		Namespace: strings.TrimSpace(request.Namespace),
+		SessionID: strings.TrimSpace(request.SessionID),
+		Error:     &err,
+	}
+}
+
+func normalizeCommand(command Command) Command {
+	return Command(strings.TrimSpace(string(command)))
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
+type randomIDGenerator struct{}
+
+func (randomIDGenerator) NewID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err == nil {
+		return "microvm-" + hex.EncodeToString(buf[:])
+	}
+	return "microvm-" + time.Now().UTC().Format("20060102150405.000000000")
+}

--- a/runtime/microvm/controller_contract.go
+++ b/runtime/microvm/controller_contract.go
@@ -1,0 +1,238 @@
+package microvm
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// KindLifecycle is the lifecycle contract kind.
+	KindLifecycle ContractKind = "lifecycle"
+	// KindControllerSession is the controller/session contract kind.
+	KindControllerSession ContractKind = "controller_session"
+
+	// ControllerAuthDefaultDeny is the only controller auth default AppTheory accepts.
+	ControllerAuthDefaultDeny = "deny"
+
+	// ErrorCodeUnauthenticatedController reports a controller contract or request that does not fail closed.
+	ErrorCodeUnauthenticatedController = "m15.microvm.unauthenticated_controller"
+	// ErrorCodeControllerIncomplete reports an incomplete controller contract.
+	ErrorCodeControllerIncomplete = "m15.microvm.controller_incomplete"
+	// ErrorCodeSessionRegistryIncomplete reports an incomplete session registry contract.
+	ErrorCodeSessionRegistryIncomplete = "m15.microvm.session_registry_incomplete"
+)
+
+// ContractKind identifies a MicroVM contract vocabulary kind.
+type ContractKind string
+
+// EscapeHatches captures forbidden extension points that must remain disabled.
+type EscapeHatches struct {
+	RawAWSSDK              bool `json:"raw_aws_sdk"`
+	RawLifecycleHookBypass bool `json:"raw_lifecycle_hook_bypass"`
+}
+
+// ControllerAuthContract describes controller authentication requirements.
+type ControllerAuthContract struct {
+	Required bool   `json:"required"`
+	Default  string `json:"default"`
+}
+
+// ControllerEnvelopeContract describes the safe controller envelope vocabulary.
+type ControllerEnvelopeContract struct {
+	RequiredFields  []string `json:"required_fields"`
+	SafeErrorFields []string `json:"safe_error_fields"`
+	ForbiddenFields []string `json:"forbidden_fields"`
+}
+
+// ControllerCommandContract describes a single controller command.
+type ControllerCommandContract struct {
+	Name           Command  `json:"name"`
+	Method         string   `json:"method"`
+	Path           string   `json:"path"`
+	RequestFields  []string `json:"request_fields"`
+	ResponseFields []string `json:"response_fields"`
+}
+
+// ControllerContract is the AppTheory MicroVM controller vocabulary.
+type ControllerContract struct {
+	Auth     ControllerAuthContract      `json:"auth"`
+	Envelope ControllerEnvelopeContract  `json:"envelope"`
+	Commands []ControllerCommandContract `json:"commands"`
+}
+
+// SessionRegistryContract is the TableTheory-patterned session record vocabulary.
+type SessionRegistryContract struct {
+	Pattern         string   `json:"pattern"`
+	TenantBinding   []string `json:"tenant_binding"`
+	RequiredFields  []string `json:"required_fields"`
+	StateValues     []string `json:"state_values"`
+	ForbiddenFields []string `json:"forbidden_fields"`
+}
+
+// ValidateEscapeHatches fails closed when a contract enables a raw SDK or lifecycle bypass.
+func ValidateEscapeHatches(escapeHatches EscapeHatches) error {
+	if escapeHatches.RawAWSSDK {
+		return safeError(ErrorCodeRawSDKEscapeHatch, "apptheory: microvm contract forbids raw AWS SDK escape hatch", "")
+	}
+	if escapeHatches.RawLifecycleHookBypass {
+		return safeError(ErrorCodeLifecycleBypass, "apptheory: microvm contract forbids raw lifecycle hook bypass", "")
+	}
+	return nil
+}
+
+// DefaultControllerContract returns the M15 controller command and envelope vocabulary.
+func DefaultControllerContract() ControllerContract {
+	return ControllerContract{
+		Auth: ControllerAuthContract{Required: true, Default: ControllerAuthDefaultDeny},
+		Envelope: ControllerEnvelopeContract{
+			RequiredFields:  []string{"command", "request_id", "tenant_id", "auth_context"},
+			SafeErrorFields: []string{"code", "message", "request_id"},
+			ForbiddenFields: []string{"aws_access_key_id", "aws_secret_access_key", "raw_sdk_client", "bearer_token"}, //nolint:gosec // Contract field names, not credentials.
+		},
+		Commands: []ControllerCommandContract{
+			{
+				Name:           CommandCreate,
+				Method:         "POST",
+				Path:           "/microvms",
+				RequestFields:  []string{"image_ref", "network_connector_ref", "session_spec"},
+				ResponseFields: []string{"session_id", "state", "registry_version"},
+			},
+			{
+				Name:           CommandStart,
+				Method:         "POST",
+				Path:           "/microvms/{session_id}/start",
+				RequestFields:  []string{"session_id"},
+				ResponseFields: []string{"session_id", "state", "desired_state"},
+			},
+			{
+				Name:           CommandStop,
+				Method:         "POST",
+				Path:           "/microvms/{session_id}/stop",
+				RequestFields:  []string{"session_id"},
+				ResponseFields: []string{"session_id", "state", "desired_state"},
+			},
+			{
+				Name:           CommandStatus,
+				Method:         "GET",
+				Path:           "/microvms/{session_id}/status",
+				RequestFields:  []string{"session_id"},
+				ResponseFields: []string{"session_id", "state", "lifecycle_state", "last_transition"},
+			},
+			{
+				Name:           CommandSession,
+				Method:         "GET",
+				Path:           "/microvms/{session_id}",
+				RequestFields:  []string{"session_id"},
+				ResponseFields: []string{"session_id", "tenant_id", "namespace", "state", "registry_version"},
+			},
+		},
+	}
+}
+
+// DefaultSessionRegistryContract returns the M15 session registry vocabulary.
+func DefaultSessionRegistryContract() SessionRegistryContract {
+	states := requiredLifecycleStates()
+	stateValues := make([]string, 0, len(states))
+	for _, state := range states {
+		stateValues = append(stateValues, string(state))
+	}
+	return SessionRegistryContract{
+		Pattern:       "tabletheory-single-table",
+		TenantBinding: []string{"tenant_id", "namespace"},
+		RequiredFields: []string{
+			"tenant_id",
+			"namespace",
+			"session_id",
+			"state",
+			"desired_state",
+			"image_ref",
+			"controller_id",
+			"created_at",
+			"updated_at",
+			"expires_at",
+			"generation",
+			"last_command_id",
+			"auth_subject",
+		},
+		StateValues:     stateValues,
+		ForbiddenFields: []string{"raw_aws_credentials", "raw_lifecycle_hook_payload", "bearer_token", "session_token_plaintext"},
+	}
+}
+
+// ValidateControllerContract validates the controller contract vocabulary.
+func ValidateControllerContract(contract ControllerContract) error {
+	if !controllerAuthDefaultsDeny(contract.Auth) {
+		return safeError(ErrorCodeUnauthenticatedController, "apptheory: microvm controller must default to authenticated deny", "")
+	}
+	if missing := missingStrings([]string{"command", "request_id", "tenant_id", "auth_context"}, contract.Envelope.RequiredFields); len(missing) > 0 {
+		return safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller envelope missing fields: "+strings.Join(missing, ","), "")
+	}
+	if missing := missingStrings([]string{"code", "message", "request_id"}, contract.Envelope.SafeErrorFields); len(missing) > 0 {
+		return safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller safe error missing fields: "+strings.Join(missing, ","), "")
+	}
+	if missing := missingStrings([]string{"raw_sdk_client", "bearer_token"}, contract.Envelope.ForbiddenFields); len(missing) > 0 {
+		return safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller envelope missing forbidden fields: "+strings.Join(missing, ","), "")
+	}
+	commands := map[Command]ControllerCommandContract{}
+	for _, command := range contract.Commands {
+		name := normalizeCommand(command.Name)
+		if name == "" || strings.TrimSpace(command.Method) == "" || strings.TrimSpace(command.Path) == "" {
+			return safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller commands must define name, method, and path", "")
+		}
+		if len(command.RequestFields) == 0 || len(command.ResponseFields) == 0 {
+			return safeError(ErrorCodeControllerIncomplete, fmt.Sprintf("apptheory: microvm controller command %s must define request and response fields", name), "")
+		}
+		commands[name] = command
+	}
+	for _, required := range []Command{CommandCreate, CommandStart, CommandStop, CommandStatus, CommandSession} {
+		if _, ok := commands[required]; !ok {
+			return safeError(ErrorCodeControllerIncomplete, "apptheory: microvm controller missing command: "+string(required), "")
+		}
+	}
+	return nil
+}
+
+// ValidateSessionRegistryContract validates the session registry contract vocabulary.
+func ValidateSessionRegistryContract(registry SessionRegistryContract) error {
+	if strings.TrimSpace(registry.Pattern) != "tabletheory-single-table" {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session registry must use tabletheory-single-table guidance", "")
+	}
+	if missing := missingStrings([]string{"tenant_id", "namespace"}, registry.TenantBinding); len(missing) > 0 {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session registry missing tenant binding: "+strings.Join(missing, ","), "")
+	}
+	if missing := missingStrings(DefaultSessionRegistryContract().RequiredFields, registry.RequiredFields); len(missing) > 0 {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session registry missing fields: "+strings.Join(missing, ","), "")
+	}
+	stateValues := make([]string, 0, len(requiredLifecycleStates()))
+	for _, state := range requiredLifecycleStates() {
+		stateValues = append(stateValues, string(state))
+	}
+	if missing := missingStrings(stateValues, registry.StateValues); len(missing) > 0 {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session registry missing states: "+strings.Join(missing, ","), "")
+	}
+	if missing := missingStrings([]string{"raw_aws_credentials", "raw_lifecycle_hook_payload", "bearer_token"}, registry.ForbiddenFields); len(missing) > 0 {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session registry missing forbidden fields: "+strings.Join(missing, ","), "")
+	}
+	return nil
+}
+
+func controllerAuthDefaultsDeny(auth ControllerAuthContract) bool {
+	return auth.Required && strings.EqualFold(strings.TrimSpace(auth.Default), ControllerAuthDefaultDeny)
+}
+
+func missingStrings(required []string, got []string) []string {
+	seen := make(map[string]struct{}, len(got))
+	for _, value := range got {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			seen[trimmed] = struct{}{}
+		}
+	}
+	missing := make([]string, 0)
+	for _, value := range required {
+		if _, ok := seen[value]; !ok {
+			missing = append(missing, value)
+		}
+	}
+	return missing
+}

--- a/runtime/microvm/controller_test.go
+++ b/runtime/microvm/controller_test.go
@@ -136,14 +136,24 @@ func (c *stubClient) Start(_ context.Context, input SessionCommandInput) (Sessio
 	record.Generation++
 	record.LastCommandID = input.RequestID
 	record.AuthSubject = input.AuthSubject
+	c.record = record
 	return record, nil
 }
 
-func (c stubClient) Stop(context.Context, SessionCommandInput) (SessionRecord, error) {
+func (c *stubClient) Stop(_ context.Context, input SessionCommandInput) (SessionRecord, error) {
+	c.lastCommand = CommandStop
 	if c.err != nil {
 		return SessionRecord{}, c.err
 	}
-	return c.record, nil
+	record := c.record
+	record.State = StateStopping
+	record.DesiredState = input.DesiredState
+	record.UpdatedAt = input.Now
+	record.Generation++
+	record.LastCommandID = input.RequestID
+	record.AuthSubject = input.AuthSubject
+	c.record = record
+	return record, nil
 }
 
 func (c stubClient) Status(context.Context, SessionQueryInput) (SessionStatus, error) {
@@ -186,4 +196,179 @@ func validControllerRequest(command Command, requestID string, sessionID string)
 		req.NetworkConnectorRef = "network-ref"
 	}
 	return req
+}
+
+func TestControllerStatusSessionAndStop(t *testing.T) {
+	now := time.Unix(456, 0).UTC()
+	client := &stubClient{}
+	controller, err := NewController(
+		client,
+		WithControllerID("controller-1"),
+		WithControllerClock(fixedControllerClock{now: now}),
+		WithControllerIDGenerator(fixedControllerIDs{id: "session-1"}),
+	)
+	require.NoError(t, err)
+
+	create, err := controller.Handle(context.Background(), validControllerRequest(CommandCreate, "req-create", ""))
+	require.NoError(t, err)
+	_, err = controller.Handle(context.Background(), validControllerRequest(CommandStart, "req-start", create.SessionID))
+	require.NoError(t, err)
+
+	status, err := controller.Handle(context.Background(), validControllerRequest(CommandStatus, "req-status", create.SessionID))
+	require.NoError(t, err)
+	require.Equal(t, StateStarting, status.LifecycleState)
+	require.Equal(t, int64(2), status.RegistryVersion)
+
+	session, err := controller.Handle(context.Background(), validControllerRequest(CommandSession, "req-session", create.SessionID))
+	require.NoError(t, err)
+	require.Equal(t, "tenant-1", session.TenantID)
+
+	stop, err := controller.Handle(context.Background(), validControllerRequest(CommandStop, "req-stop", create.SessionID))
+	require.NoError(t, err)
+	require.Equal(t, StateStopped, stop.DesiredState)
+}
+
+func TestControllerOptionsAndInvalidRequests(t *testing.T) {
+	_, err := NewController(nil)
+	require.Error(t, err)
+
+	controller, err := NewController(&stubClient{}, WithControllerID(" "), WithControllerClock(nil), WithControllerIDGenerator(nil))
+	require.NoError(t, err)
+
+	cases := []ControllerRequest{
+		{},
+		func() ControllerRequest {
+			req := validControllerRequest(CommandCreate, "req-1", "")
+			req.AuthContext.TenantID = "other"
+			return req
+		}(),
+		func() ControllerRequest {
+			req := validControllerRequest(CommandCreate, "req-1", "")
+			req.AuthContext.Namespace = "other"
+			return req
+		}(),
+		func() ControllerRequest {
+			req := validControllerRequest(Command("unknown"), "req-1", "")
+			return req
+		}(),
+		validControllerRequest(CommandStart, "req-1", ""),
+		func() ControllerRequest {
+			req := validControllerRequest(CommandCreate, "req-1", "")
+			req.ImageRef = ""
+			return req
+		}(),
+	}
+	for _, req := range cases {
+		result, err := controller.Handle(context.Background(), req)
+		require.Error(t, err)
+		require.NotNil(t, result.Error)
+	}
+}
+
+func TestControllerContractValidationFailures(t *testing.T) {
+	contract := DefaultControllerContract()
+	contract.Auth.Required = false
+	require.Error(t, ValidateControllerContract(contract))
+
+	contract = DefaultControllerContract()
+	contract.Envelope.RequiredFields = nil
+	require.Error(t, ValidateControllerContract(contract))
+
+	contract = DefaultControllerContract()
+	contract.Envelope.SafeErrorFields = nil
+	require.Error(t, ValidateControllerContract(contract))
+
+	contract = DefaultControllerContract()
+	contract.Envelope.ForbiddenFields = nil
+	require.Error(t, ValidateControllerContract(contract))
+
+	contract = DefaultControllerContract()
+	contract.Commands[0].Path = ""
+	require.Error(t, ValidateControllerContract(contract))
+
+	contract = DefaultControllerContract()
+	contract.Commands[0].RequestFields = nil
+	require.Error(t, ValidateControllerContract(contract))
+
+	contract = DefaultControllerContract()
+	contract.Commands = contract.Commands[:1]
+	require.Error(t, ValidateControllerContract(contract))
+}
+
+func TestSessionRegistryValidationFailures(t *testing.T) {
+	registry := DefaultSessionRegistryContract()
+	registry.Pattern = "raw-table"
+	require.Error(t, ValidateSessionRegistryContract(registry))
+
+	registry = DefaultSessionRegistryContract()
+	registry.TenantBinding = []string{"tenant_id"}
+	require.Error(t, ValidateSessionRegistryContract(registry))
+
+	registry = DefaultSessionRegistryContract()
+	registry.RequiredFields = []string{"tenant_id"}
+	require.Error(t, ValidateSessionRegistryContract(registry))
+
+	registry = DefaultSessionRegistryContract()
+	registry.StateValues = []string{"requested"}
+	require.Error(t, ValidateSessionRegistryContract(registry))
+
+	registry = DefaultSessionRegistryContract()
+	registry.ForbiddenFields = []string{"bearer_token"}
+	require.Error(t, ValidateSessionRegistryContract(registry))
+}
+
+func TestSessionValidationAndKeys(t *testing.T) {
+	now := time.Unix(1, 0).UTC()
+	record := SessionRecord{
+		TenantID:      "tenant-1",
+		Namespace:     "namespace-1",
+		SessionID:     "session-1",
+		State:         StateRequested,
+		DesiredState:  StateRequested,
+		ImageRef:      "image-ref",
+		ControllerID:  "controller-1",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		ExpiresAt:     now.Add(time.Hour),
+		Generation:    1,
+		LastCommandID: "req-1",
+		AuthSubject:   "subject-1",
+	}
+	require.NoError(t, ValidateSessionRecord(record))
+	require.Equal(t, SessionKey{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1"}, record.Key())
+
+	bad := record
+	bad.TenantID = ""
+	require.Error(t, ValidateSessionRecord(bad))
+
+	bad = record
+	bad.CreatedAt = time.Time{}
+	require.Error(t, ValidateSessionRecord(bad))
+
+	bad = record
+	bad.State = LifecycleState("unknown")
+	require.Error(t, ValidateSessionRecord(bad))
+
+	bad = record
+	bad.Metadata = map[string]string{"bearer_token": "secret"}
+	require.Error(t, ValidateSessionRecord(bad))
+
+	status := SessionStatus{
+		TenantID:        "tenant-1",
+		Namespace:       "namespace-1",
+		SessionID:       "session-1",
+		State:           StateStarting,
+		DesiredState:    StateStarted,
+		LifecycleState:  StateStarting,
+		LastTransition:  now,
+		RegistryVersion: 2,
+	}
+	require.NoError(t, ValidateSessionStatus(status))
+	require.Equal(t, record.Key(), status.Key())
+
+	status.LifecycleState = LifecycleState("unknown")
+	require.Error(t, ValidateSessionStatus(status))
+	status.LifecycleState = StateStarting
+	status.LastTransition = time.Time{}
+	require.Error(t, ValidateSessionStatus(status))
 }

--- a/runtime/microvm/controller_test.go
+++ b/runtime/microvm/controller_test.go
@@ -1,0 +1,189 @@
+package microvm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultControllerAndRegistryContractsValidate(t *testing.T) {
+	require.NoError(t, ValidateControllerContract(DefaultControllerContract()))
+	require.NoError(t, ValidateSessionRegistryContract(DefaultSessionRegistryContract()))
+	require.NoError(t, ValidateEscapeHatches(EscapeHatches{}))
+	require.EqualError(t, ValidateEscapeHatches(EscapeHatches{RawAWSSDK: true}), "apptheory: microvm contract forbids raw AWS SDK escape hatch")
+}
+
+func TestControllerRequiresAuthenticatedDeny(t *testing.T) {
+	controller, err := NewController(&stubClient{})
+	require.NoError(t, err)
+
+	result, err := controller.Handle(context.Background(), ControllerRequest{
+		Command:             CommandCreate,
+		RequestID:           "req-1",
+		TenantID:            "tenant-1",
+		Namespace:           "namespace-1",
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+
+	require.Error(t, err)
+	require.NotNil(t, result.Error)
+	require.Equal(t, ErrorCodeUnauthenticatedController, result.Error.Code)
+}
+
+func TestControllerCreateAndStart(t *testing.T) {
+	now := time.Unix(123, 0).UTC()
+	client := &stubClient{}
+	controller, err := NewController(
+		client,
+		WithControllerID("controller-1"),
+		WithControllerClock(fixedControllerClock{now: now}),
+		WithControllerIDGenerator(fixedControllerIDs{id: "session-1"}),
+	)
+	require.NoError(t, err)
+
+	create, err := controller.Handle(context.Background(), validControllerRequest(CommandCreate, "req-create", ""))
+	require.NoError(t, err)
+	require.Equal(t, "session-1", create.SessionID)
+	require.Equal(t, StateRequested, create.State)
+	require.Equal(t, int64(1), create.RegistryVersion)
+
+	startReq := validControllerRequest(CommandStart, "req-start", create.SessionID)
+	start, err := controller.Handle(context.Background(), startReq)
+	require.NoError(t, err)
+	require.Equal(t, StateStarting, start.State)
+	require.Equal(t, StateStarted, start.DesiredState)
+	require.Equal(t, CommandStart, client.lastCommand)
+}
+
+func TestControllerSanitizesClientErrors(t *testing.T) {
+	controller, err := NewController(&stubClient{err: errors.New("raw bearer_token provider error")})
+	require.NoError(t, err)
+
+	result, err := controller.Handle(context.Background(), validControllerRequest(CommandCreate, "req-1", ""))
+
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "bearer_token")
+	require.NotNil(t, result.Error)
+	require.Equal(t, ErrorCodeControllerCommandFailed, result.Error.Code)
+}
+
+func TestControllerRejectsForbiddenSessionSpec(t *testing.T) {
+	controller, err := NewController(&stubClient{})
+	require.NoError(t, err)
+	req := validControllerRequest(CommandCreate, "req-1", "")
+	req.SessionSpec.Metadata = map[string]string{"raw_lifecycle_hook_payload": "payload"}
+
+	result, err := controller.Handle(context.Background(), req)
+
+	require.Error(t, err)
+	require.NotNil(t, result.Error)
+	require.Equal(t, ErrorCodeForbiddenField, result.Error.Code)
+}
+
+type fixedControllerClock struct{ now time.Time }
+
+func (c fixedControllerClock) Now() time.Time { return c.now }
+
+type fixedControllerIDs struct{ id string }
+
+func (g fixedControllerIDs) NewID() string { return g.id }
+
+type stubClient struct {
+	err         error
+	lastCommand Command
+	record      SessionRecord
+}
+
+func (c *stubClient) Create(_ context.Context, input CreateSessionInput) (SessionRecord, error) {
+	c.lastCommand = CommandCreate
+	if c.err != nil {
+		return SessionRecord{}, c.err
+	}
+	record := SessionRecord{
+		TenantID:            input.TenantID,
+		Namespace:           input.Namespace,
+		SessionID:           input.SessionID,
+		State:               StateRequested,
+		DesiredState:        StateRequested,
+		ImageRef:            input.ImageRef,
+		NetworkConnectorRef: input.NetworkConnectorRef,
+		ControllerID:        input.ControllerID,
+		CreatedAt:           input.Now,
+		UpdatedAt:           input.Now,
+		ExpiresAt:           input.Now.Add(time.Hour),
+		Generation:          1,
+		LastCommandID:       input.RequestID,
+		AuthSubject:         input.AuthSubject,
+		Metadata:            input.SessionSpec.Metadata,
+	}
+	c.record = record
+	return record, nil
+}
+
+func (c *stubClient) Start(_ context.Context, input SessionCommandInput) (SessionRecord, error) {
+	c.lastCommand = CommandStart
+	if c.err != nil {
+		return SessionRecord{}, c.err
+	}
+	record := c.record
+	record.State = StateStarting
+	record.DesiredState = input.DesiredState
+	record.UpdatedAt = input.Now
+	record.Generation++
+	record.LastCommandID = input.RequestID
+	record.AuthSubject = input.AuthSubject
+	return record, nil
+}
+
+func (c stubClient) Stop(context.Context, SessionCommandInput) (SessionRecord, error) {
+	if c.err != nil {
+		return SessionRecord{}, c.err
+	}
+	return c.record, nil
+}
+
+func (c stubClient) Status(context.Context, SessionQueryInput) (SessionStatus, error) {
+	if c.err != nil {
+		return SessionStatus{}, c.err
+	}
+	return SessionStatus{
+		TenantID:        c.record.TenantID,
+		Namespace:       c.record.Namespace,
+		SessionID:       c.record.SessionID,
+		State:           c.record.State,
+		DesiredState:    c.record.DesiredState,
+		LifecycleState:  c.record.State,
+		LastTransition:  c.record.UpdatedAt,
+		RegistryVersion: c.record.Generation,
+	}, nil
+}
+
+func (c stubClient) Session(context.Context, SessionQueryInput) (SessionRecord, error) {
+	if c.err != nil {
+		return SessionRecord{}, c.err
+	}
+	return c.record, nil
+}
+
+func validControllerRequest(command Command, requestID string, sessionID string) ControllerRequest {
+	req := ControllerRequest{
+		Command:   command,
+		RequestID: requestID,
+		TenantID:  "tenant-1",
+		Namespace: "namespace-1",
+		AuthContext: AuthContext{
+			Subject:  "subject-1",
+			TenantID: "tenant-1",
+		},
+		SessionID: sessionID,
+	}
+	if command == CommandCreate {
+		req.ImageRef = "image-ref"
+		req.NetworkConnectorRef = "network-ref"
+	}
+	return req
+}

--- a/runtime/microvm/errors.go
+++ b/runtime/microvm/errors.go
@@ -1,0 +1,49 @@
+package microvm
+
+import "strings"
+
+const (
+	// ErrorCodeInvalidContract reports an unsupported or malformed MicroVM contract.
+	ErrorCodeInvalidContract = "m15.microvm.invalid_contract"
+	// ErrorCodeRawSDKEscapeHatch reports a forbidden raw AWS SDK escape hatch.
+	ErrorCodeRawSDKEscapeHatch = "m15.microvm.raw_sdk_escape_hatch"
+	// ErrorCodeLifecycleBypass reports a forbidden raw lifecycle hook bypass.
+	ErrorCodeLifecycleBypass = "m15.microvm.lifecycle_bypass"
+	// ErrorCodeLifecycleIncomplete reports an incomplete lifecycle contract.
+	ErrorCodeLifecycleIncomplete = "m15.microvm.lifecycle_incomplete"
+	// ErrorCodeForbiddenField reports a field that AppTheory refuses to persist or echo.
+	ErrorCodeForbiddenField = "m15.microvm.forbidden_field"
+	// ErrorCodeInvalidLifecycleEvent reports a malformed lifecycle event.
+	ErrorCodeInvalidLifecycleEvent = "m15.microvm.invalid_lifecycle_event"
+	// ErrorCodeLifecycleHookFailed reports a lifecycle hook handler failure.
+	ErrorCodeLifecycleHookFailed = "m15.microvm.lifecycle_hook_failed"
+)
+
+// SafeError is the MicroVM-safe error envelope exposed by lifecycle and controller adapters.
+// It carries only code, message, and request_id so callers cannot leak raw provider errors,
+// bearer tokens, AWS credentials, or lifecycle payloads through AppTheory primitives.
+type SafeError struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id,omitempty"`
+}
+
+func (e SafeError) Error() string {
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	return e.Code
+}
+
+func safeError(code, message, requestID string) SafeError {
+	return SafeError{
+		Code:      strings.TrimSpace(code),
+		Message:   strings.TrimSpace(message),
+		RequestID: strings.TrimSpace(requestID),
+	}
+}
+
+func invalidContractError(code, message string) error {
+	err := safeError(code, message, "")
+	return err
+}

--- a/runtime/microvm/errors.go
+++ b/runtime/microvm/errors.go
@@ -1,6 +1,9 @@
 package microvm
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 const (
 	// ErrorCodeInvalidContract reports an unsupported or malformed MicroVM contract.
@@ -8,7 +11,7 @@ const (
 	// ErrorCodeRawSDKEscapeHatch reports a forbidden raw AWS SDK escape hatch.
 	ErrorCodeRawSDKEscapeHatch = "m15.microvm.raw_sdk_escape_hatch"
 	// ErrorCodeLifecycleBypass reports a forbidden raw lifecycle hook bypass.
-	ErrorCodeLifecycleBypass = "m15.microvm.lifecycle_bypass"
+	ErrorCodeLifecycleBypass = "m15.microvm.lifecycle_bypass" //nolint:gosec // Contract error code, not a credential.
 	// ErrorCodeLifecycleIncomplete reports an incomplete lifecycle contract.
 	ErrorCodeLifecycleIncomplete = "m15.microvm.lifecycle_incomplete"
 	// ErrorCodeForbiddenField reports a field that AppTheory refuses to persist or echo.
@@ -46,4 +49,18 @@ func safeError(code, message, requestID string) SafeError {
 func invalidContractError(code, message string) error {
 	err := safeError(code, message, "")
 	return err
+}
+
+func asSafeError(err error, requestID string) SafeError {
+	if err == nil {
+		return SafeError{}
+	}
+	var safe SafeError
+	if errors.As(err, &safe) {
+		if safe.RequestID == "" {
+			safe.RequestID = strings.TrimSpace(requestID)
+		}
+		return safe
+	}
+	return safeError(ErrorCodeControllerCommandFailed, "apptheory: microvm controller command failed", requestID)
 }

--- a/runtime/microvm/lifecycle.go
+++ b/runtime/microvm/lifecycle.go
@@ -1,0 +1,486 @@
+// Package microvm provides AppTheory's constrained AWS Lambda MicroVM runtime primitives.
+package microvm
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// ContractName is the only supported AppTheory MicroVM contract name.
+	ContractName = "apptheory.lambda_microvm"
+	// ContractVersion is the M15 MicroVM contract version implemented by this package.
+	ContractVersion = "m15.microvm/v1"
+)
+
+// LifecycleHook names a first-class MicroVM lifecycle hook.
+type LifecycleHook string
+
+const (
+	HookPrepareImage LifecycleHook = "prepare_image"
+	HookStart        LifecycleHook = "start"
+	HookReadiness    LifecycleHook = "readiness"
+	HookStop         LifecycleHook = "stop"
+	HookTeardown     LifecycleHook = "teardown"
+	HookFailure      LifecycleHook = "failure"
+)
+
+// LifecycleState names a contract-defined MicroVM lifecycle state.
+type LifecycleState string
+
+const (
+	StateRequested        LifecycleState = "requested"
+	StateImagePreparing   LifecycleState = "image_preparing"
+	StateImagePrepared    LifecycleState = "image_prepared"
+	StateStarting         LifecycleState = "starting"
+	StateStarted          LifecycleState = "started"
+	StateReadinessProbing LifecycleState = "readiness_probing"
+	StateReady            LifecycleState = "ready"
+	StateStopping         LifecycleState = "stopping"
+	StateStopped          LifecycleState = "stopped"
+	StateTearingDown      LifecycleState = "tearing_down"
+	StateTerminated       LifecycleState = "terminated"
+	StateFailed           LifecycleState = "failed"
+)
+
+// LifecycleHookSpec is the contract vocabulary for one lifecycle hook.
+type LifecycleHookSpec struct {
+	Name         LifecycleHook  `json:"name"`
+	Phase        string         `json:"phase"`
+	State        LifecycleState `json:"state"`
+	SuccessState LifecycleState `json:"success_state"`
+	FailureState LifecycleState `json:"failure_state"`
+}
+
+// LifecycleTransition is one allowed contract transition.
+type LifecycleTransition struct {
+	From LifecycleState `json:"from"`
+	Hook LifecycleHook  `json:"hook"`
+	To   LifecycleState `json:"to"`
+}
+
+// LifecycleContract is the AppTheory MicroVM lifecycle vocabulary.
+type LifecycleContract struct {
+	Hooks          []LifecycleHookSpec   `json:"hooks"`
+	States         []LifecycleState      `json:"states"`
+	TerminalStates []LifecycleState      `json:"terminal_states"`
+	Transitions    []LifecycleTransition `json:"transitions"`
+}
+
+// LifecycleEvent is the sanitized event passed to lifecycle hook handlers.
+// It intentionally contains no raw Lambda payload and no raw AWS SDK client.
+type LifecycleEvent struct {
+	RequestID string            `json:"request_id"`
+	TenantID  string            `json:"tenant_id"`
+	Namespace string            `json:"namespace"`
+	SessionID string            `json:"session_id"`
+	Hook      LifecycleHook     `json:"hook"`
+	State     LifecycleState    `json:"state"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// LifecycleResult is the safe result returned by a lifecycle adapter.
+type LifecycleResult struct {
+	RequestID     string            `json:"request_id"`
+	TenantID      string            `json:"tenant_id"`
+	Namespace     string            `json:"namespace"`
+	SessionID     string            `json:"session_id"`
+	Hook          LifecycleHook     `json:"hook"`
+	PreviousState LifecycleState    `json:"previous_state"`
+	State         LifecycleState    `json:"state"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Error         *SafeError        `json:"error,omitempty"`
+}
+
+// LifecycleHandler handles one sanitized lifecycle hook invocation.
+type LifecycleHandler func(context.Context, LifecycleEvent) error
+
+// LifecycleAdapter executes MicroVM lifecycle hooks through the contract vocabulary.
+type LifecycleAdapter struct {
+	contract LifecycleContract
+	handlers map[LifecycleHook]LifecycleHandler
+}
+
+// LifecycleOption configures a LifecycleAdapter.
+type LifecycleOption func(*LifecycleAdapter)
+
+// WithLifecycleContract replaces the default M15 lifecycle contract.
+func WithLifecycleContract(contract LifecycleContract) LifecycleOption {
+	return func(adapter *LifecycleAdapter) {
+		adapter.contract = cloneLifecycleContract(contract)
+	}
+}
+
+// WithLifecycleHandler registers a handler for a contract lifecycle hook.
+func WithLifecycleHandler(hook LifecycleHook, handler LifecycleHandler) LifecycleOption {
+	return func(adapter *LifecycleAdapter) {
+		if adapter.handlers == nil {
+			adapter.handlers = map[LifecycleHook]LifecycleHandler{}
+		}
+		hook = normalizeLifecycleHook(hook)
+		if hook == "" || handler == nil {
+			return
+		}
+		adapter.handlers[hook] = handler
+	}
+}
+
+// NewLifecycleAdapter creates a lifecycle adapter that fails closed when its contract is incomplete.
+func NewLifecycleAdapter(opts ...LifecycleOption) (*LifecycleAdapter, error) {
+	adapter := &LifecycleAdapter{
+		contract: DefaultLifecycleContract(),
+		handlers: map[LifecycleHook]LifecycleHandler{},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(adapter)
+		}
+	}
+	if err := ValidateLifecycleContract(adapter.contract); err != nil {
+		return nil, err
+	}
+	return adapter, nil
+}
+
+// DefaultLifecycleContract returns the M15 MicroVM lifecycle contract vocabulary.
+func DefaultLifecycleContract() LifecycleContract {
+	return LifecycleContract{
+		Hooks: []LifecycleHookSpec{
+			{Name: HookPrepareImage, Phase: "image_preparation", State: StateImagePreparing, SuccessState: StateImagePrepared, FailureState: StateFailed},
+			{Name: HookStart, Phase: "start", State: StateStarting, SuccessState: StateStarted, FailureState: StateFailed},
+			{Name: HookReadiness, Phase: "readiness", State: StateReadinessProbing, SuccessState: StateReady, FailureState: StateFailed},
+			{Name: HookStop, Phase: "stop", State: StateStopping, SuccessState: StateStopped, FailureState: StateFailed},
+			{Name: HookTeardown, Phase: "teardown", State: StateTearingDown, SuccessState: StateTerminated, FailureState: StateFailed},
+			{Name: HookFailure, Phase: "failure", State: StateFailed, SuccessState: StateFailed, FailureState: StateFailed},
+		},
+		States: []LifecycleState{
+			StateRequested,
+			StateImagePreparing,
+			StateImagePrepared,
+			StateStarting,
+			StateStarted,
+			StateReadinessProbing,
+			StateReady,
+			StateStopping,
+			StateStopped,
+			StateTearingDown,
+			StateTerminated,
+			StateFailed,
+		},
+		TerminalStates: []LifecycleState{StateTerminated, StateFailed},
+		Transitions: []LifecycleTransition{
+			{From: StateRequested, Hook: HookPrepareImage, To: StateImagePreparing},
+			{From: StateImagePreparing, Hook: HookPrepareImage, To: StateImagePrepared},
+			{From: StateImagePrepared, Hook: HookStart, To: StateStarting},
+			{From: StateStarting, Hook: HookStart, To: StateStarted},
+			{From: StateStarted, Hook: HookReadiness, To: StateReadinessProbing},
+			{From: StateReadinessProbing, Hook: HookReadiness, To: StateReady},
+			{From: StateReady, Hook: HookStop, To: StateStopping},
+			{From: StateStopping, Hook: HookStop, To: StateStopped},
+			{From: StateStopped, Hook: HookTeardown, To: StateTearingDown},
+			{From: StateTearingDown, Hook: HookTeardown, To: StateTerminated},
+			{From: StateImagePreparing, Hook: HookFailure, To: StateFailed},
+			{From: StateStarting, Hook: HookFailure, To: StateFailed},
+			{From: StateReadinessProbing, Hook: HookFailure, To: StateFailed},
+			{From: StateStopping, Hook: HookFailure, To: StateFailed},
+			{From: StateTearingDown, Hook: HookFailure, To: StateFailed},
+		},
+	}
+}
+
+// ValidateLifecycleContract validates the lifecycle contract and returns a safe error on failure.
+func ValidateLifecycleContract(contract LifecycleContract) error {
+	hookSpecs := map[LifecycleHook]LifecycleHookSpec{}
+	for _, hook := range contract.Hooks {
+		name := normalizeLifecycleHook(hook.Name)
+		if name == "" || strings.TrimSpace(hook.Phase) == "" || hook.State == "" || hook.SuccessState == "" || hook.FailureState == "" {
+			return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state")
+		}
+		hook.Name = name
+		hookSpecs[name] = hook
+	}
+	if missing := missingLifecycleHooks(requiredLifecycleHooks(), hookSpecs); len(missing) > 0 {
+		return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing hooks: "+strings.Join(missing, ","))
+	}
+	if missing := missingLifecycleStates(requiredLifecycleStates(), lifecycleStateSet(contract.States)); len(missing) > 0 {
+		return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing states: "+strings.Join(missing, ","))
+	}
+	if missing := missingLifecycleStates([]LifecycleState{StateTerminated, StateFailed}, lifecycleStateSet(contract.TerminalStates)); len(missing) > 0 {
+		return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing terminal states: "+strings.Join(missing, ","))
+	}
+	transitions := transitionSet(contract.Transitions)
+	for _, spec := range hookSpecs {
+		if spec.Name == HookFailure {
+			continue
+		}
+		if !transitions.has(preStateForHook(spec.Name), spec.Name, spec.State) {
+			return invalidContractError(ErrorCodeLifecycleIncomplete, fmt.Sprintf("apptheory: microvm lifecycle missing active transition for hook %s", spec.Name))
+		}
+		if !transitions.has(spec.State, spec.Name, spec.SuccessState) {
+			return invalidContractError(ErrorCodeLifecycleIncomplete, fmt.Sprintf("apptheory: microvm lifecycle missing success transition for hook %s", spec.Name))
+		}
+	}
+	for _, state := range []LifecycleState{StateImagePreparing, StateStarting, StateReadinessProbing, StateStopping, StateTearingDown} {
+		if !transitions.has(state, HookFailure, StateFailed) {
+			return invalidContractError(ErrorCodeLifecycleIncomplete, fmt.Sprintf("apptheory: microvm lifecycle missing failure transition from %s", state))
+		}
+	}
+	return nil
+}
+
+// Handle executes one lifecycle hook. Handler errors are sanitized and translated to failed state.
+func (a *LifecycleAdapter) Handle(ctx context.Context, event LifecycleEvent) (LifecycleResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if a == nil {
+		err := safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle adapter is nil", event.RequestID)
+		return lifecycleErrorResult(event, StateFailed, err), err
+	}
+	if err := ValidateLifecycleContract(a.contract); err != nil {
+		safe := safeError(ErrorCodeLifecycleIncomplete, err.Error(), event.RequestID)
+		return lifecycleErrorResult(event, StateFailed, safe), safe
+	}
+	normalized, err := normalizeLifecycleEvent(event)
+	if err != nil {
+		safe := err.(SafeError) //nolint:forcetypeassert // normalizeLifecycleEvent only returns SafeError.
+		return lifecycleErrorResult(event, StateFailed, safe), safe
+	}
+
+	contract := a.contractIndex()
+	spec, ok := contract.hooks[normalized.Hook]
+	if !ok {
+		err := safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle hook is unsupported", normalized.RequestID)
+		return lifecycleErrorResult(normalized, StateFailed, err), err
+	}
+	activeState, ok := contract.nextState(normalized.State, normalized.Hook)
+	if !ok {
+		err := safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle transition is unsupported", normalized.RequestID)
+		return lifecycleErrorResult(normalized, StateFailed, err), err
+	}
+	if normalized.Hook != HookFailure && activeState != spec.State {
+		err := safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle transition is not the hook active state", normalized.RequestID)
+		return lifecycleErrorResult(normalized, StateFailed, err), err
+	}
+
+	handler := a.handlers[normalized.Hook]
+	if handler == nil {
+		err := safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle hook handler is missing", normalized.RequestID)
+		return lifecycleErrorResult(normalized, spec.FailureState, err), err
+	}
+
+	handlerEvent := normalized
+	handlerEvent.State = activeState
+	handlerEvent.Metadata = cloneStringMap(normalized.Metadata)
+	if err := handler(ctx, handlerEvent); err != nil {
+		safe := safeError(ErrorCodeLifecycleHookFailed, "apptheory: microvm lifecycle hook failed", normalized.RequestID)
+		return lifecycleErrorResult(normalized, spec.FailureState, safe), safe
+	}
+
+	state := spec.SuccessState
+	if normalized.Hook == HookFailure {
+		state = StateFailed
+	} else if !contract.transitions.has(activeState, normalized.Hook, state) {
+		err := safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle success transition is unsupported", normalized.RequestID)
+		return lifecycleErrorResult(normalized, spec.FailureState, err), err
+	}
+
+	return LifecycleResult{
+		RequestID:     normalized.RequestID,
+		TenantID:      normalized.TenantID,
+		Namespace:     normalized.Namespace,
+		SessionID:     normalized.SessionID,
+		Hook:          normalized.Hook,
+		PreviousState: normalized.State,
+		State:         state,
+		Metadata:      cloneStringMap(normalized.Metadata),
+	}, nil
+}
+
+// IsTerminalState reports whether a state is terminal under the M15 contract.
+func IsTerminalState(state LifecycleState) bool {
+	switch state {
+	case StateTerminated, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeLifecycleEvent(event LifecycleEvent) (LifecycleEvent, error) {
+	event.RequestID = strings.TrimSpace(event.RequestID)
+	event.TenantID = strings.TrimSpace(event.TenantID)
+	event.Namespace = strings.TrimSpace(event.Namespace)
+	event.SessionID = strings.TrimSpace(event.SessionID)
+	event.Hook = normalizeLifecycleHook(event.Hook)
+	event.State = LifecycleState(strings.TrimSpace(string(event.State)))
+	event.Metadata = cloneStringMap(event.Metadata)
+	if event.RequestID == "" || event.TenantID == "" || event.Namespace == "" || event.SessionID == "" {
+		return LifecycleEvent{}, safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle envelope is incomplete", event.RequestID)
+	}
+	if event.Hook == "" || event.State == "" {
+		return LifecycleEvent{}, safeError(ErrorCodeInvalidLifecycleEvent, "apptheory: microvm lifecycle hook and state are required", event.RequestID)
+	}
+	if err := validateSafeMetadata(event.Metadata, event.RequestID); err != nil {
+		return LifecycleEvent{}, err
+	}
+	return event, nil
+}
+
+func lifecycleErrorResult(event LifecycleEvent, state LifecycleState, err SafeError) LifecycleResult {
+	return LifecycleResult{
+		RequestID:     strings.TrimSpace(event.RequestID),
+		TenantID:      strings.TrimSpace(event.TenantID),
+		Namespace:     strings.TrimSpace(event.Namespace),
+		SessionID:     strings.TrimSpace(event.SessionID),
+		Hook:          normalizeLifecycleHook(event.Hook),
+		PreviousState: LifecycleState(strings.TrimSpace(string(event.State))),
+		State:         state,
+		Metadata:      cloneStringMap(event.Metadata),
+		Error:         &err,
+	}
+}
+
+func requiredLifecycleHooks() []LifecycleHook {
+	return []LifecycleHook{HookPrepareImage, HookStart, HookReadiness, HookStop, HookTeardown, HookFailure}
+}
+
+func requiredLifecycleStates() []LifecycleState {
+	return []LifecycleState{
+		StateRequested,
+		StateImagePreparing,
+		StateImagePrepared,
+		StateStarting,
+		StateStarted,
+		StateReadinessProbing,
+		StateReady,
+		StateStopping,
+		StateStopped,
+		StateTearingDown,
+		StateTerminated,
+		StateFailed,
+	}
+}
+
+func preStateForHook(hook LifecycleHook) LifecycleState {
+	switch hook {
+	case HookPrepareImage:
+		return StateRequested
+	case HookStart:
+		return StateImagePrepared
+	case HookReadiness:
+		return StateStarted
+	case HookStop:
+		return StateReady
+	case HookTeardown:
+		return StateStopped
+	default:
+		return ""
+	}
+}
+
+func cloneLifecycleContract(contract LifecycleContract) LifecycleContract {
+	out := LifecycleContract{
+		Hooks:          append([]LifecycleHookSpec(nil), contract.Hooks...),
+		States:         append([]LifecycleState(nil), contract.States...),
+		TerminalStates: append([]LifecycleState(nil), contract.TerminalStates...),
+		Transitions:    append([]LifecycleTransition(nil), contract.Transitions...),
+	}
+	return out
+}
+
+func normalizeLifecycleHook(hook LifecycleHook) LifecycleHook {
+	return LifecycleHook(strings.TrimSpace(string(hook)))
+}
+
+type lifecycleContractIndex struct {
+	hooks       map[LifecycleHook]LifecycleHookSpec
+	transitions lifecycleTransitionSet
+}
+
+func (a *LifecycleAdapter) contractIndex() lifecycleContractIndex {
+	idx := lifecycleContractIndex{
+		hooks:       map[LifecycleHook]LifecycleHookSpec{},
+		transitions: transitionSet(a.contract.Transitions),
+	}
+	for _, hook := range a.contract.Hooks {
+		hook.Name = normalizeLifecycleHook(hook.Name)
+		idx.hooks[hook.Name] = hook
+	}
+	return idx
+}
+
+func (idx lifecycleContractIndex) nextState(from LifecycleState, hook LifecycleHook) (LifecycleState, bool) {
+	from = LifecycleState(strings.TrimSpace(string(from)))
+	hook = normalizeLifecycleHook(hook)
+	for _, transition := range idx.transitions.list {
+		if transition.From == from && transition.Hook == hook {
+			return transition.To, true
+		}
+	}
+	return "", false
+}
+
+type lifecycleTransitionSet struct {
+	set  map[string]struct{}
+	list []LifecycleTransition
+}
+
+func transitionSet(transitions []LifecycleTransition) lifecycleTransitionSet {
+	out := lifecycleTransitionSet{set: map[string]struct{}{}, list: make([]LifecycleTransition, 0, len(transitions))}
+	for _, transition := range transitions {
+		transition.From = LifecycleState(strings.TrimSpace(string(transition.From)))
+		transition.Hook = normalizeLifecycleHook(transition.Hook)
+		transition.To = LifecycleState(strings.TrimSpace(string(transition.To)))
+		if transition.From == "" || transition.Hook == "" || transition.To == "" {
+			continue
+		}
+		out.set[transitionKey(transition.From, transition.Hook, transition.To)] = struct{}{}
+		out.list = append(out.list, transition)
+	}
+	return out
+}
+
+func (s lifecycleTransitionSet) has(from LifecycleState, hook LifecycleHook, to LifecycleState) bool {
+	_, ok := s.set[transitionKey(from, hook, to)]
+	return ok
+}
+
+func transitionKey(from LifecycleState, hook LifecycleHook, to LifecycleState) string {
+	return string(from) + "\x00" + string(hook) + "\x00" + string(to)
+}
+
+func lifecycleStateSet(states []LifecycleState) map[LifecycleState]struct{} {
+	out := map[LifecycleState]struct{}{}
+	for _, state := range states {
+		state = LifecycleState(strings.TrimSpace(string(state)))
+		if state != "" {
+			out[state] = struct{}{}
+		}
+	}
+	return out
+}
+
+func missingLifecycleHooks(required []LifecycleHook, got map[LifecycleHook]LifecycleHookSpec) []string {
+	missing := make([]string, 0)
+	for _, hook := range required {
+		if _, ok := got[hook]; !ok {
+			missing = append(missing, string(hook))
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func missingLifecycleStates(required []LifecycleState, got map[LifecycleState]struct{}) []string {
+	missing := make([]string, 0)
+	for _, state := range required {
+		if _, ok := got[state]; !ok {
+			missing = append(missing, string(state))
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/runtime/microvm/lifecycle.go
+++ b/runtime/microvm/lifecycle.go
@@ -192,25 +192,43 @@ func DefaultLifecycleContract() LifecycleContract {
 
 // ValidateLifecycleContract validates the lifecycle contract and returns a safe error on failure.
 func ValidateLifecycleContract(contract LifecycleContract) error {
+	hookSpecs, err := validateLifecycleHookSpecs(contract.Hooks)
+	if err != nil {
+		return err
+	}
+	if err := validateLifecycleStateLists(contract); err != nil {
+		return err
+	}
+	return validateLifecycleTransitionSet(hookSpecs, transitionSet(contract.Transitions))
+}
+
+func validateLifecycleHookSpecs(hooks []LifecycleHookSpec) (map[LifecycleHook]LifecycleHookSpec, error) {
 	hookSpecs := map[LifecycleHook]LifecycleHookSpec{}
-	for _, hook := range contract.Hooks {
+	for _, hook := range hooks {
 		name := normalizeLifecycleHook(hook.Name)
 		if name == "" || strings.TrimSpace(hook.Phase) == "" || hook.State == "" || hook.SuccessState == "" || hook.FailureState == "" {
-			return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state")
+			return nil, invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle hooks must name phase, active state, success state, and failure state")
 		}
 		hook.Name = name
 		hookSpecs[name] = hook
 	}
 	if missing := missingLifecycleHooks(requiredLifecycleHooks(), hookSpecs); len(missing) > 0 {
-		return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing hooks: "+strings.Join(missing, ","))
+		return nil, invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing hooks: "+strings.Join(missing, ","))
 	}
+	return hookSpecs, nil
+}
+
+func validateLifecycleStateLists(contract LifecycleContract) error {
 	if missing := missingLifecycleStates(requiredLifecycleStates(), lifecycleStateSet(contract.States)); len(missing) > 0 {
 		return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing states: "+strings.Join(missing, ","))
 	}
 	if missing := missingLifecycleStates([]LifecycleState{StateTerminated, StateFailed}, lifecycleStateSet(contract.TerminalStates)); len(missing) > 0 {
 		return invalidContractError(ErrorCodeLifecycleIncomplete, "apptheory: microvm lifecycle missing terminal states: "+strings.Join(missing, ","))
 	}
-	transitions := transitionSet(contract.Transitions)
+	return nil
+}
+
+func validateLifecycleTransitionSet(hookSpecs map[LifecycleHook]LifecycleHookSpec, transitions lifecycleTransitionSet) error {
 	for _, spec := range hookSpecs {
 		if spec.Name == HookFailure {
 			continue
@@ -222,6 +240,10 @@ func ValidateLifecycleContract(contract LifecycleContract) error {
 			return invalidContractError(ErrorCodeLifecycleIncomplete, fmt.Sprintf("apptheory: microvm lifecycle missing success transition for hook %s", spec.Name))
 		}
 	}
+	return validateLifecycleFailureTransitions(transitions)
+}
+
+func validateLifecycleFailureTransitions(transitions lifecycleTransitionSet) error {
 	for _, state := range []LifecycleState{StateImagePreparing, StateStarting, StateReadinessProbing, StateStopping, StateTearingDown} {
 		if !transitions.has(state, HookFailure, StateFailed) {
 			return invalidContractError(ErrorCodeLifecycleIncomplete, fmt.Sprintf("apptheory: microvm lifecycle missing failure transition from %s", state))
@@ -245,7 +267,7 @@ func (a *LifecycleAdapter) Handle(ctx context.Context, event LifecycleEvent) (Li
 	}
 	normalized, err := normalizeLifecycleEvent(event)
 	if err != nil {
-		safe := err.(SafeError) //nolint:forcetypeassert // normalizeLifecycleEvent only returns SafeError.
+		safe := asSafeError(err, event.RequestID)
 		return lifecycleErrorResult(event, StateFailed, safe), safe
 	}
 

--- a/runtime/microvm/lifecycle_test.go
+++ b/runtime/microvm/lifecycle_test.go
@@ -113,3 +113,47 @@ func recordLifecycleCall(calls *[]LifecycleEvent) LifecycleHandler {
 		return nil
 	}
 }
+
+func TestLifecycleAdapterValidationFailures(t *testing.T) {
+	contract := DefaultLifecycleContract()
+	contract.Hooks[0].Phase = ""
+	_, err := NewLifecycleAdapter(WithLifecycleContract(contract))
+	require.Error(t, err)
+
+	contract = DefaultLifecycleContract()
+	contract.States = []LifecycleState{StateRequested}
+	require.Error(t, ValidateLifecycleContract(contract))
+
+	contract = DefaultLifecycleContract()
+	contract.TerminalStates = []LifecycleState{StateTerminated}
+	require.Error(t, ValidateLifecycleContract(contract))
+
+	contract = DefaultLifecycleContract()
+	contract.Transitions = contract.Transitions[:1]
+	require.Error(t, ValidateLifecycleContract(contract))
+
+	adapter, err := NewLifecycleAdapter()
+	require.NoError(t, err)
+	result, err := adapter.Handle(context.Background(), LifecycleEvent{
+		RequestID: "req-1",
+		TenantID:  "tenant-1",
+		Namespace: "ns-1",
+		SessionID: "session-1",
+		Hook:      HookStart,
+		State:     StateRequested,
+	})
+	require.Error(t, err)
+	require.NotNil(t, result.Error)
+
+	result, err = (*LifecycleAdapter)(nil).Handle(context.Background(), LifecycleEvent{RequestID: "req-1"})
+	require.Error(t, err)
+	require.Equal(t, StateFailed, result.State)
+}
+
+func TestLifecycleHelpers(t *testing.T) {
+	require.False(t, IsTerminalState(StateReady))
+	require.True(t, forbiddenFieldName("x-amz-security-token"))
+	require.False(t, forbiddenFieldName("safe"))
+	require.Equal(t, "fallback", SafeError{Code: "fallback"}.Error())
+	require.Equal(t, ErrorCodeControllerCommandFailed, asSafeError(errors.New("raw"), "req-1").Code)
+}

--- a/runtime/microvm/lifecycle_test.go
+++ b/runtime/microvm/lifecycle_test.go
@@ -1,0 +1,115 @@
+package microvm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultLifecycleContractValidates(t *testing.T) {
+	require.NoError(t, ValidateLifecycleContract(DefaultLifecycleContract()))
+}
+
+func TestLifecycleAdapterAdvancesCanonicalPath(t *testing.T) {
+	calls := make([]LifecycleEvent, 0, 5)
+	adapter, err := NewLifecycleAdapter(
+		WithLifecycleHandler(HookPrepareImage, recordLifecycleCall(&calls)),
+		WithLifecycleHandler(HookStart, recordLifecycleCall(&calls)),
+		WithLifecycleHandler(HookReadiness, recordLifecycleCall(&calls)),
+		WithLifecycleHandler(HookStop, recordLifecycleCall(&calls)),
+		WithLifecycleHandler(HookTeardown, recordLifecycleCall(&calls)),
+	)
+	require.NoError(t, err)
+
+	state := StateRequested
+	for _, hook := range []LifecycleHook{HookPrepareImage, HookStart, HookReadiness, HookStop, HookTeardown} {
+		result, err := adapter.Handle(context.Background(), LifecycleEvent{
+			RequestID: "req-1",
+			TenantID:  "tenant-1",
+			Namespace: "ns-1",
+			SessionID: "session-1",
+			Hook:      hook,
+			State:     state,
+			Metadata:  map[string]string{"safe": "value"},
+		})
+		require.NoError(t, err)
+		require.Nil(t, result.Error)
+		state = result.State
+	}
+
+	require.Equal(t, StateTerminated, state)
+	require.Len(t, calls, 5)
+	require.Equal(t, StateImagePreparing, calls[0].State)
+	require.Equal(t, StateStarting, calls[1].State)
+	require.Equal(t, StateReadinessProbing, calls[2].State)
+	require.Equal(t, StateStopping, calls[3].State)
+	require.Equal(t, StateTearingDown, calls[4].State)
+}
+
+func TestLifecycleAdapterSanitizesHandlerErrors(t *testing.T) {
+	adapter, err := NewLifecycleAdapter(WithLifecycleHandler(HookStart, func(context.Context, LifecycleEvent) error {
+		return errors.New("raw provider failure with bearer_token")
+	}))
+	require.NoError(t, err)
+
+	result, err := adapter.Handle(context.Background(), LifecycleEvent{
+		RequestID: "req-1",
+		TenantID:  "tenant-1",
+		Namespace: "ns-1",
+		SessionID: "session-1",
+		Hook:      HookStart,
+		State:     StateImagePrepared,
+	})
+
+	require.Error(t, err)
+	require.Equal(t, StateFailed, result.State)
+	require.NotNil(t, result.Error)
+	require.Equal(t, ErrorCodeLifecycleHookFailed, result.Error.Code)
+	require.NotContains(t, err.Error(), "bearer_token")
+}
+
+func TestLifecycleAdapterRejectsForbiddenMetadata(t *testing.T) {
+	adapter, err := NewLifecycleAdapter(WithLifecycleHandler(HookStart, func(context.Context, LifecycleEvent) error { return nil }))
+	require.NoError(t, err)
+
+	result, err := adapter.Handle(context.Background(), LifecycleEvent{
+		RequestID: "req-1",
+		TenantID:  "tenant-1",
+		Namespace: "ns-1",
+		SessionID: "session-1",
+		Hook:      HookStart,
+		State:     StateImagePrepared,
+		Metadata:  map[string]string{"aws_secret_access_key": "do-not-persist"},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, ErrorCodeForbiddenField, result.Error.Code)
+	require.Equal(t, StateFailed, result.State)
+}
+
+func TestLifecycleAdapterRunsFailureHook(t *testing.T) {
+	adapter, err := NewLifecycleAdapter(WithLifecycleHandler(HookFailure, func(context.Context, LifecycleEvent) error { return nil }))
+	require.NoError(t, err)
+
+	result, err := adapter.Handle(context.Background(), LifecycleEvent{
+		RequestID: "req-1",
+		TenantID:  "tenant-1",
+		Namespace: "ns-1",
+		SessionID: "session-1",
+		Hook:      HookFailure,
+		State:     StateStarting,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, StateFailed, result.State)
+	require.True(t, IsTerminalState(result.State))
+}
+
+func recordLifecycleCall(calls *[]LifecycleEvent) LifecycleHandler {
+	return func(_ context.Context, event LifecycleEvent) error {
+		*calls = append(*calls, event)
+		return nil
+	}
+}

--- a/runtime/microvm/safety.go
+++ b/runtime/microvm/safety.go
@@ -1,0 +1,57 @@
+package microvm
+
+import "strings"
+
+var forbiddenFieldNames = map[string]struct{}{ //nolint:gosec // Contract field names, not credentials.
+	"authorization":              {},
+	"aws_access_key_id":          {},
+	"aws_secret_access_key":      {},
+	"aws_session_token":          {},
+	"bearer_token":               {},
+	"raw_aws_credentials":        {},
+	"raw_lifecycle_hook_payload": {},
+	"raw_sdk_client":             {},
+	"session_token_plaintext":    {},
+	"x-amz-security-token":       {},
+}
+
+func forbiddenFieldName(name string) bool {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		return false
+	}
+	if _, ok := forbiddenFieldNames[key]; ok {
+		return true
+	}
+	key = strings.ReplaceAll(key, "-", "_")
+	_, ok := forbiddenFieldNames[key]
+	return ok
+}
+
+func validateSafeMetadata(metadata map[string]string, requestID string) error {
+	for key := range metadata {
+		if forbiddenFieldName(key) {
+			return safeError(
+				ErrorCodeForbiddenField,
+				"apptheory: microvm metadata contains forbidden field",
+				requestID,
+			)
+		}
+	}
+	return nil
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		out[trimmed] = value
+	}
+	return out
+}

--- a/runtime/microvm/session.go
+++ b/runtime/microvm/session.go
@@ -1,0 +1,168 @@
+package microvm
+
+import (
+	"strings"
+	"time"
+)
+
+// SessionKey identifies a MicroVM session by tenant, namespace, and session_id.
+type SessionKey struct {
+	TenantID  string `json:"tenant_id"`
+	Namespace string `json:"namespace"`
+	SessionID string `json:"session_id"`
+}
+
+// CreateSessionInput is the safe client input for creating a session.
+type CreateSessionInput struct {
+	RequestID           string      `json:"request_id"`
+	TenantID            string      `json:"tenant_id"`
+	Namespace           string      `json:"namespace"`
+	SessionID           string      `json:"session_id"`
+	ImageRef            string      `json:"image_ref"`
+	NetworkConnectorRef string      `json:"network_connector_ref"`
+	SessionSpec         SessionSpec `json:"session_spec"`
+	ControllerID        string      `json:"controller_id"`
+	AuthSubject         string      `json:"auth_subject"`
+	Now                 time.Time   `json:"now"`
+}
+
+// SessionCommandInput is the safe client input for start/stop commands.
+type SessionCommandInput struct {
+	RequestID    string         `json:"request_id"`
+	TenantID     string         `json:"tenant_id"`
+	Namespace    string         `json:"namespace"`
+	SessionID    string         `json:"session_id"`
+	ControllerID string         `json:"controller_id"`
+	AuthSubject  string         `json:"auth_subject"`
+	DesiredState LifecycleState `json:"desired_state"`
+	Now          time.Time      `json:"now"`
+}
+
+// SessionQueryInput is the safe client input for status/session queries.
+type SessionQueryInput struct {
+	RequestID   string `json:"request_id"`
+	TenantID    string `json:"tenant_id"`
+	Namespace   string `json:"namespace"`
+	SessionID   string `json:"session_id"`
+	AuthSubject string `json:"auth_subject"`
+}
+
+// SessionRecord is the safe durable-session shape AppTheory exposes to clients and registries.
+type SessionRecord struct {
+	TenantID            string            `json:"tenant_id"`
+	Namespace           string            `json:"namespace"`
+	SessionID           string            `json:"session_id"`
+	State               LifecycleState    `json:"state"`
+	DesiredState        LifecycleState    `json:"desired_state"`
+	ImageRef            string            `json:"image_ref"`
+	NetworkConnectorRef string            `json:"network_connector_ref,omitempty"`
+	ControllerID        string            `json:"controller_id"`
+	CreatedAt           time.Time         `json:"created_at"`
+	UpdatedAt           time.Time         `json:"updated_at"`
+	ExpiresAt           time.Time         `json:"expires_at"`
+	Generation          int64             `json:"generation"`
+	LastCommandID       string            `json:"last_command_id"`
+	AuthSubject         string            `json:"auth_subject"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
+}
+
+// SessionStatus is the safe controller status response from a constrained client.
+type SessionStatus struct {
+	TenantID        string         `json:"tenant_id"`
+	Namespace       string         `json:"namespace"`
+	SessionID       string         `json:"session_id"`
+	State           LifecycleState `json:"state"`
+	DesiredState    LifecycleState `json:"desired_state"`
+	LifecycleState  LifecycleState `json:"lifecycle_state"`
+	LastTransition  time.Time      `json:"last_transition"`
+	RegistryVersion int64          `json:"registry_version"`
+}
+
+// ValidateSessionRecord fails closed when a session record is incomplete or contains forbidden metadata.
+func ValidateSessionRecord(record SessionRecord) error {
+	record = normalizeSessionRecord(record)
+	if err := validateSessionRecordIdentity(record); err != nil {
+		return err
+	}
+	if err := validateSessionRecordRegistryFields(record); err != nil {
+		return err
+	}
+	if !validLifecycleState(record.State) || !validLifecycleState(record.DesiredState) {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session record state is unsupported", record.LastCommandID)
+	}
+	return validateSafeMetadata(record.Metadata, record.LastCommandID)
+}
+
+func validateSessionRecordIdentity(record SessionRecord) error {
+	if record.TenantID == "" || record.Namespace == "" || record.SessionID == "" || record.State == "" || record.DesiredState == "" {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session record is incomplete", record.LastCommandID)
+	}
+	if record.ImageRef == "" || record.ControllerID == "" || record.LastCommandID == "" || record.AuthSubject == "" {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session record is incomplete", record.LastCommandID)
+	}
+	return nil
+}
+
+func validateSessionRecordRegistryFields(record SessionRecord) error {
+	if record.CreatedAt.IsZero() || record.UpdatedAt.IsZero() || record.ExpiresAt.IsZero() || record.Generation <= 0 {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session record registry fields are incomplete", record.LastCommandID)
+	}
+	return nil
+}
+
+// ValidateSessionStatus fails closed when a status response is incomplete.
+func ValidateSessionStatus(status SessionStatus) error {
+	status = normalizeSessionStatus(status)
+	if status.TenantID == "" || status.Namespace == "" || status.SessionID == "" || status.State == "" || status.DesiredState == "" || status.LifecycleState == "" || status.LastTransition.IsZero() || status.RegistryVersion <= 0 {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session status is incomplete", "")
+	}
+	if !validLifecycleState(status.State) || !validLifecycleState(status.DesiredState) || !validLifecycleState(status.LifecycleState) {
+		return safeError(ErrorCodeSessionRegistryIncomplete, "apptheory: microvm session status state is unsupported", "")
+	}
+	return nil
+}
+
+// Key returns the tenant/namespace/session key for a session record.
+func (r SessionRecord) Key() SessionKey {
+	return SessionKey{TenantID: strings.TrimSpace(r.TenantID), Namespace: strings.TrimSpace(r.Namespace), SessionID: strings.TrimSpace(r.SessionID)}
+}
+
+// Key returns the tenant/namespace/session key for a status record.
+func (s SessionStatus) Key() SessionKey {
+	return SessionKey{TenantID: strings.TrimSpace(s.TenantID), Namespace: strings.TrimSpace(s.Namespace), SessionID: strings.TrimSpace(s.SessionID)}
+}
+
+func normalizeSessionRecord(record SessionRecord) SessionRecord {
+	record.TenantID = strings.TrimSpace(record.TenantID)
+	record.Namespace = strings.TrimSpace(record.Namespace)
+	record.SessionID = strings.TrimSpace(record.SessionID)
+	record.State = LifecycleState(strings.TrimSpace(string(record.State)))
+	record.DesiredState = LifecycleState(strings.TrimSpace(string(record.DesiredState)))
+	record.ImageRef = strings.TrimSpace(record.ImageRef)
+	record.NetworkConnectorRef = strings.TrimSpace(record.NetworkConnectorRef)
+	record.ControllerID = strings.TrimSpace(record.ControllerID)
+	record.LastCommandID = strings.TrimSpace(record.LastCommandID)
+	record.AuthSubject = strings.TrimSpace(record.AuthSubject)
+	record.Metadata = cloneStringMap(record.Metadata)
+	return record
+}
+
+func normalizeSessionStatus(status SessionStatus) SessionStatus {
+	status.TenantID = strings.TrimSpace(status.TenantID)
+	status.Namespace = strings.TrimSpace(status.Namespace)
+	status.SessionID = strings.TrimSpace(status.SessionID)
+	status.State = LifecycleState(strings.TrimSpace(string(status.State)))
+	status.DesiredState = LifecycleState(strings.TrimSpace(string(status.DesiredState)))
+	status.LifecycleState = LifecycleState(strings.TrimSpace(string(status.LifecycleState)))
+	return status
+}
+
+func validLifecycleState(state LifecycleState) bool {
+	state = LifecycleState(strings.TrimSpace(string(state)))
+	for _, valid := range requiredLifecycleStates() {
+		if state == valid {
+			return true
+		}
+	}
+	return false
+}

--- a/testkit/microvm/client.go
+++ b/testkit/microvm/client.go
@@ -1,0 +1,197 @@
+// Package microvm provides deterministic test doubles for AppTheory MicroVM controllers.
+package microvm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+)
+
+// Call records one fake client operation.
+type Call struct {
+	Command   runtimemicrovm.Command
+	RequestID string
+	TenantID  string
+	Namespace string
+	SessionID string
+}
+
+// FakeClient is an in-memory constrained MicroVM client for tests.
+type FakeClient struct {
+	mu       sync.Mutex
+	now      time.Time
+	sessions map[runtimemicrovm.SessionKey]runtimemicrovm.SessionRecord
+	calls    []Call
+}
+
+var _ runtimemicrovm.Client = (*FakeClient)(nil)
+
+// NewFakeClient creates a fake client with a deterministic starting clock.
+func NewFakeClient() *FakeClient {
+	return NewFakeClientWithTime(time.Unix(0, 0).UTC())
+}
+
+// NewFakeClientWithTime creates a fake client with the provided current time.
+func NewFakeClientWithTime(now time.Time) *FakeClient {
+	if now.IsZero() {
+		now = time.Unix(0, 0).UTC()
+	}
+	return &FakeClient{now: now.UTC(), sessions: map[runtimemicrovm.SessionKey]runtimemicrovm.SessionRecord{}}
+}
+
+// SetNow sets the fake client's current time.
+func (c *FakeClient) SetNow(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !now.IsZero() {
+		c.now = now.UTC()
+	}
+}
+
+// Calls returns a copy of recorded calls.
+func (c *FakeClient) Calls() []Call {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]Call(nil), c.calls...)
+}
+
+// Create creates a fake session record.
+func (c *FakeClient) Create(_ context.Context, input runtimemicrovm.CreateSessionInput) (runtimemicrovm.SessionRecord, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.recordCall(runtimemicrovm.CommandCreate, input.RequestID, input.TenantID, input.Namespace, input.SessionID)
+	now := coalesceTime(input.Now, c.now)
+	record := runtimemicrovm.SessionRecord{
+		TenantID:            input.TenantID,
+		Namespace:           input.Namespace,
+		SessionID:           input.SessionID,
+		State:               runtimemicrovm.StateRequested,
+		DesiredState:        runtimemicrovm.StateRequested,
+		ImageRef:            input.ImageRef,
+		NetworkConnectorRef: input.NetworkConnectorRef,
+		ControllerID:        input.ControllerID,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+		ExpiresAt:           now.Add(time.Hour),
+		Generation:          1,
+		LastCommandID:       input.RequestID,
+		AuthSubject:         input.AuthSubject,
+		Metadata:            input.SessionSpec.Metadata,
+	}
+	if err := runtimemicrovm.ValidateSessionRecord(record); err != nil {
+		return runtimemicrovm.SessionRecord{}, err
+	}
+	key := record.Key()
+	if _, exists := c.sessions[key]; exists {
+		return runtimemicrovm.SessionRecord{}, fmt.Errorf("session already exists")
+	}
+	c.sessions[key] = record
+	return cloneRecord(record), nil
+}
+
+// Start marks a fake session as starting toward started.
+func (c *FakeClient) Start(_ context.Context, input runtimemicrovm.SessionCommandInput) (runtimemicrovm.SessionRecord, error) {
+	return c.transition(input, runtimemicrovm.CommandStart, runtimemicrovm.StateStarting, runtimemicrovm.StateStarted)
+}
+
+// Stop marks a fake session as stopping toward stopped.
+func (c *FakeClient) Stop(_ context.Context, input runtimemicrovm.SessionCommandInput) (runtimemicrovm.SessionRecord, error) {
+	return c.transition(input, runtimemicrovm.CommandStop, runtimemicrovm.StateStopping, runtimemicrovm.StateStopped)
+}
+
+// Status returns fake session status.
+func (c *FakeClient) Status(_ context.Context, input runtimemicrovm.SessionQueryInput) (runtimemicrovm.SessionStatus, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.recordCall(runtimemicrovm.CommandStatus, input.RequestID, input.TenantID, input.Namespace, input.SessionID)
+	record, err := c.lookup(input.TenantID, input.Namespace, input.SessionID)
+	if err != nil {
+		return runtimemicrovm.SessionStatus{}, err
+	}
+	return runtimemicrovm.SessionStatus{
+		TenantID:        record.TenantID,
+		Namespace:       record.Namespace,
+		SessionID:       record.SessionID,
+		State:           record.State,
+		DesiredState:    record.DesiredState,
+		LifecycleState:  record.State,
+		LastTransition:  record.UpdatedAt,
+		RegistryVersion: record.Generation,
+	}, nil
+}
+
+// Session returns a fake session record.
+func (c *FakeClient) Session(_ context.Context, input runtimemicrovm.SessionQueryInput) (runtimemicrovm.SessionRecord, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.recordCall(runtimemicrovm.CommandSession, input.RequestID, input.TenantID, input.Namespace, input.SessionID)
+	record, err := c.lookup(input.TenantID, input.Namespace, input.SessionID)
+	if err != nil {
+		return runtimemicrovm.SessionRecord{}, err
+	}
+	return cloneRecord(record), nil
+}
+
+func (c *FakeClient) transition(
+	input runtimemicrovm.SessionCommandInput,
+	command runtimemicrovm.Command,
+	state runtimemicrovm.LifecycleState,
+	desired runtimemicrovm.LifecycleState,
+) (runtimemicrovm.SessionRecord, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.recordCall(command, input.RequestID, input.TenantID, input.Namespace, input.SessionID)
+	record, err := c.lookup(input.TenantID, input.Namespace, input.SessionID)
+	if err != nil {
+		return runtimemicrovm.SessionRecord{}, err
+	}
+	record.State = state
+	record.DesiredState = desired
+	record.ControllerID = input.ControllerID
+	record.AuthSubject = input.AuthSubject
+	record.LastCommandID = input.RequestID
+	record.UpdatedAt = coalesceTime(input.Now, c.now)
+	record.Generation++
+	if err := runtimemicrovm.ValidateSessionRecord(record); err != nil {
+		return runtimemicrovm.SessionRecord{}, err
+	}
+	c.sessions[record.Key()] = record
+	return cloneRecord(record), nil
+}
+
+func (c *FakeClient) lookup(tenantID, namespace, sessionID string) (runtimemicrovm.SessionRecord, error) {
+	key := runtimemicrovm.SessionKey{TenantID: tenantID, Namespace: namespace, SessionID: sessionID}
+	record, ok := c.sessions[key]
+	if !ok {
+		return runtimemicrovm.SessionRecord{}, fmt.Errorf("session not found")
+	}
+	return record, nil
+}
+
+func (c *FakeClient) recordCall(command runtimemicrovm.Command, requestID, tenantID, namespace, sessionID string) {
+	c.calls = append(c.calls, Call{Command: command, RequestID: requestID, TenantID: tenantID, Namespace: namespace, SessionID: sessionID})
+}
+
+func coalesceTime(value time.Time, fallback time.Time) time.Time {
+	if !value.IsZero() {
+		return value.UTC()
+	}
+	if !fallback.IsZero() {
+		return fallback.UTC()
+	}
+	return time.Unix(0, 0).UTC()
+}
+
+func cloneRecord(record runtimemicrovm.SessionRecord) runtimemicrovm.SessionRecord {
+	if len(record.Metadata) > 0 {
+		metadata := make(map[string]string, len(record.Metadata))
+		for key, value := range record.Metadata {
+			metadata[key] = value
+		}
+		record.Metadata = metadata
+	}
+	return record
+}

--- a/testkit/microvm/client_test.go
+++ b/testkit/microvm/client_test.go
@@ -1,0 +1,74 @@
+package microvm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+)
+
+func TestFakeClientControllerFlow(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	client := NewFakeClientWithTime(now)
+	controller, err := runtimemicrovm.NewController(
+		client,
+		runtimemicrovm.WithControllerID("controller-1"),
+		runtimemicrovm.WithControllerClock(fixedClock{now: now}),
+		runtimemicrovm.WithControllerIDGenerator(fixedIDs{id: "session-1"}),
+	)
+	require.NoError(t, err)
+
+	create, err := controller.Handle(context.Background(), request(runtimemicrovm.CommandCreate, "req-create", ""))
+	require.NoError(t, err)
+	require.Equal(t, "session-1", create.SessionID)
+	require.Equal(t, runtimemicrovm.StateRequested, create.State)
+	require.Equal(t, int64(1), create.RegistryVersion)
+
+	start, err := controller.Handle(context.Background(), request(runtimemicrovm.CommandStart, "req-start", create.SessionID))
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateStarting, start.State)
+	require.Equal(t, runtimemicrovm.StateStarted, start.DesiredState)
+
+	status, err := controller.Handle(context.Background(), request(runtimemicrovm.CommandStatus, "req-status", create.SessionID))
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateStarting, status.LifecycleState)
+
+	session, err := controller.Handle(context.Background(), request(runtimemicrovm.CommandSession, "req-session", create.SessionID))
+	require.NoError(t, err)
+	require.Equal(t, "tenant-1", session.TenantID)
+	require.Equal(t, "namespace-1", session.Namespace)
+
+	calls := client.Calls()
+	require.Len(t, calls, 4)
+	require.Equal(t, runtimemicrovm.CommandCreate, calls[0].Command)
+	require.Equal(t, runtimemicrovm.CommandSession, calls[3].Command)
+}
+
+type fixedClock struct{ now time.Time }
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+type fixedIDs struct{ id string }
+
+func (g fixedIDs) NewID() string { return g.id }
+
+func request(command runtimemicrovm.Command, requestID string, sessionID string) runtimemicrovm.ControllerRequest {
+	req := runtimemicrovm.ControllerRequest{
+		Command:   command,
+		RequestID: requestID,
+		TenantID:  "tenant-1",
+		Namespace: "namespace-1",
+		AuthContext: runtimemicrovm.AuthContext{
+			Subject:  "subject-1",
+			TenantID: "tenant-1",
+		},
+		SessionID: sessionID,
+	}
+	if command == runtimemicrovm.CommandCreate {
+		req.ImageRef = "image-ref"
+		req.NetworkConnectorRef = "network-ref"
+	}
+	return req
+}

--- a/testkit/microvm/client_test.go
+++ b/testkit/microvm/client_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 )
 

--- a/testkit/microvm/client_test.go
+++ b/testkit/microvm/client_test.go
@@ -73,3 +73,68 @@ func request(command runtimemicrovm.Command, requestID string, sessionID string)
 	}
 	return req
 }
+
+func TestFakeClientStopDuplicateAndMissing(t *testing.T) {
+	client := NewFakeClient()
+	client.SetNow(time.Unix(200, 0).UTC())
+
+	input := runtimemicrovm.CreateSessionInput{
+		RequestID:           "req-create",
+		TenantID:            "tenant-1",
+		Namespace:           "namespace-1",
+		SessionID:           "session-1",
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+		ControllerID:        "controller-1",
+		AuthSubject:         "subject-1",
+	}
+	record, err := client.Create(context.Background(), input)
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateRequested, record.State)
+	_, err = client.Create(context.Background(), input)
+	require.Error(t, err)
+
+	stopped, err := client.Stop(context.Background(), runtimemicrovm.SessionCommandInput{
+		RequestID:    "req-stop",
+		TenantID:     "tenant-1",
+		Namespace:    "namespace-1",
+		SessionID:    "session-1",
+		ControllerID: "controller-1",
+		AuthSubject:  "subject-1",
+		DesiredState: runtimemicrovm.StateStopped,
+	})
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateStopping, stopped.State)
+
+	_, err = client.Session(context.Background(), runtimemicrovm.SessionQueryInput{
+		RequestID: "req-missing",
+		TenantID:  "tenant-1",
+		Namespace: "namespace-1",
+		SessionID: "missing",
+	})
+	require.Error(t, err)
+
+	client.SetNow(time.Time{})
+	require.NotEmpty(t, client.Calls())
+}
+
+func TestFakeClientInvalidCreateAndHelpers(t *testing.T) {
+	client := NewFakeClientWithTime(time.Time{})
+	_, err := client.Create(context.Background(), runtimemicrovm.CreateSessionInput{
+		RequestID: "req-create",
+		TenantID:  "tenant-1",
+		Namespace: "namespace-1",
+		SessionID: "session-1",
+		ImageRef:  "image-ref",
+		SessionSpec: runtimemicrovm.SessionSpec{
+			Metadata: map[string]string{"bearer_token": "secret"},
+		},
+		ControllerID: "controller-1",
+		AuthSubject:  "subject-1",
+	})
+	require.Error(t, err)
+
+	require.False(t, coalesceTime(time.Time{}, time.Time{}).IsZero())
+	record := cloneRecord(runtimemicrovm.SessionRecord{})
+	require.Nil(t, record.Metadata)
+}


### PR DESCRIPTION
## Milestone
M15 Go MicroVM Runtime — make Go pass the new lifecycle and controller contracts first.

## Linear
https://linear.app/theorycloud/project/first-class-aws-lambda-microvm-support-1aac7b7874c3/overview

## Tasks
- [x] THE-2146 Implement Go lifecycle adapters
- [x] THE-2147 Implement Go control-plane primitives

## Contract impact
- Adds the Go `runtime/microvm` lifecycle vocabulary and adapter surface.
- Adds constrained Go controller/client/session APIs plus `testkit/microvm` fake client.
- Updates `api-snapshots/go.txt` for exported Go surface changes.
- Routes M15 Go lifecycle and controller/session fixtures through runtime adapters/fake client.

## Invariants preserved
- No raw AWS SDK escape hatch.
- No raw lifecycle hook bypass.
- No unauthenticated controller default.
- No persistence or echo of raw AWS credentials, bearer tokens, or raw lifecycle payloads.

## Validation
Commands run on final commit `ed8b5c1e400aa80110fa68caf1739f0484de3489`:
- `go test ./runtime/microvm ./testkit/microvm ./contract-tests/runners/go` — PASS
- `go run ./contract-tests/runners/go` — PASS (133 fixtures)
- `./scripts/verify-contract-tests.sh` — PASS (Go/TS/Py, 133 fixtures each)
- `./scripts/verify-api-snapshots.sh` — PASS
- `make test` — PASS (`version-alignment: PASS (1.13.2)`)
- `make lint` — PASS
- `make build` — PASS
- `make rubric` — PASS (29 pass / 0 fail / 0 blocked; Go coverage total 90.2%)

## Issue closure
Closes THE-2146
Closes THE-2147

## Cross-repo notes
None. This milestone is Go runtime/testkit only; no TypeScript/Python parity, CDK, deploy, TableTheory registry, examples, docs, or release version changes.