### PR TITLE
docs(microvm): document first-class MicroVM support

### DIFF
--- a/docs/_concepts.yaml
+++ b/docs/_concepts.yaml
@@ -184,6 +184,36 @@ concepts:
       - docs/features/jobs-ledger.md
       - examples/cdk/import-pipeline/README.md
 
+  lambda_microvm_support:
+    type: component
+    purpose: "Fixture-backed AWS Lambda MicroVM lifecycle, controller, durable session registry, and CDK deployment primitive."
+    provides:
+      - sanitized_microvm_lifecycle_hooks
+      - constrained_microvm_controller
+      - protected_controller_routes
+      - tenant_bound_session_registry
+      - cdk_network_connector_image_controller_constructs
+      - evidence_bounded_synth_example
+    configuration:
+      - contract-tests/fixtures/m15/
+      - runtime/microvm/
+      - ts/src/microvm.ts
+      - py/src/apptheory/microvm.py
+      - cdk/lib/microvm-network-connector.ts
+      - cdk/lib/microvm-image.ts
+      - cdk/lib/microvm-controller.ts
+      - examples/cdk/microvm-controller/
+    docs:
+      - docs/features/lambda-microvm-contract-foundation.md
+      - docs/cdk/lambda-microvm.md
+      - docs/reference/contract-fixtures.md
+    failure_modes:
+      - "Raw AWS SDK escape hatches bypass the constrained controller/client contract."
+      - "Raw lifecycle hook payloads bypass sanitized MicroVMLifecycleEvent handling."
+      - "Unauthenticated controller routes violate the fail-closed auth posture."
+      - "Ad-hoc session storage drifts from the TableTheory/DynamoDB pk/sk/ttl registry shape."
+      - "Hidden VPC/account/network mutation violates the caller-provided network boundary."
+
   import_pipeline_support_pack:
     type: workflow
     purpose: "AWS-native import pipeline primitives (S3 ingest + job ledger + optional batch runner) intended to be assembled into production workloads."

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -40,7 +40,7 @@ groups:
     items:
       - { id: feature-events,         title: Event Workload Contracts, url: /features/event-workloads/,  icon: shuffle,      tag: ga }
       - { id: feature-jobs,           title: Jobs Ledger,             url: /features/jobs-ledger/,       icon: list-checks }
-      - { id: feature-microvm-contract, title: MicroVM Contract,       url: /features/lambda-microvm-contract-foundation/, icon: cpu, tag: new }
+      - { id: feature-microvm-contract, title: Lambda MicroVM,         url: /features/lambda-microvm-contract-foundation/, icon: cpu, tag: new }
 
   - label: MCP
     items:
@@ -60,6 +60,7 @@ groups:
       - { id: cdk-mcp-protected,      title: MCP Protected Resource,  url: /cdk/mcp-protected-resource/,                   icon: lock,         surface: mcp }
       - { id: cdk-import-pipeline,    title: Import Pipeline,         url: /cdk/import-pipeline/,                          icon: layers }
       - { id: cdk-kinesis-cwl,        title: Kinesis + CloudWatch Logs, url: /cdk/kinesis-cloudwatch-logs/,                icon: activity }
+      - { id: cdk-microvm,            title: Lambda MicroVM,          url: /cdk/lambda-microvm/,                          icon: cpu,          tag: new }
       - { id: cdk-rest-streaming,     title: REST API Streaming,      url: /cdk/rest-api-router-streaming/,                icon: zap }
       - { id: cdk-appsync,            title: AppSync Lambda Resolvers, url: /cdk/appsync-lambda-resolvers/,                icon: git-branch }
 
@@ -112,6 +113,7 @@ order:
   - cdk-mcp-protected
   - cdk-import-pipeline
   - cdk-kinesis-cwl
+  - cdk-microvm
   - cdk-rest-streaming
   - cdk-appsync
   - mig-from-lift
@@ -157,6 +159,7 @@ url_to_id:
   /cdk/mcp-protected-resource/:                 cdk-mcp-protected
   /cdk/import-pipeline/:                        cdk-import-pipeline
   /cdk/kinesis-cloudwatch-logs/:                cdk-kinesis-cwl
+  /cdk/lambda-microvm/:                         cdk-microvm
   /cdk/rest-api-router-streaming/:              cdk-rest-streaming
   /cdk/appsync-lambda-resolvers/:               cdk-appsync
   /migration/from-lift/:                        mig-from-lift

--- a/docs/_decisions.yaml
+++ b/docs/_decisions.yaml
@@ -116,3 +116,30 @@ decisions:
         if_no:
           choice: "Use TierP2 + fail-closed policy"
           reason: "Prefer strict enforcement when limits are a security boundary."
+
+  choose_microvm_surface:
+    question: "How should I wire AWS Lambda MicroVM support?"
+    decision_tree:
+      - condition: "You need first-class Lambda MicroVM lifecycle and controller support."
+        check: "Can you use the AppTheory lifecycle adapter, constrained controller, durable session registry, and CDK constructs together?"
+        if_yes:
+          choice: "Use the MicroVM golden path"
+          reason: "M15 evidence covers fixture-backed runtime/CDK/example docs for the single AppTheory path."
+          example: |
+            AppTheoryMicrovmNetworkConnector -> AppTheoryMicrovmImage -> AppTheoryMicrovmController
+            MicroVMController + TableTheoryMicroVMSessionRegistry
+        if_no:
+          choice: "Grow the AppTheory contract before shipping"
+          reason: "Raw SDK calls, raw lifecycle hook bypasses, unauthenticated controllers, or ad-hoc registries fragment the contract."
+          example: |
+            TODO: add fixtures and cross-runtime parity before adding a new MicroVM capability.
+      - condition: "You only have demo or synth-time credentials and placeholder networking."
+        check: "Are you using the example only to prove construct shape?"
+        if_yes:
+          choice: "Keep the claim evidence-bounded"
+          reason: "The example is synth-only and demo authorizers are not production authentication proof."
+          example: |
+            Document this as fixture-backed/runtime/CDK/example evidence, not live deployment proof.
+        if_no:
+          choice: "Provide production auth and caller-owned network context"
+          reason: "Controller routes must stay protected and the VPC/subnet/security-group boundary must be explicit."

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -156,3 +156,38 @@ patterns:
         consequences:
           - "Double processing"
           - "Inconsistent job state"
+
+  lambda_microvm_golden_path:
+    name: "Use the AppTheory MicroVM golden path end to end"
+    problem: "MicroVM lifecycle, controller, network, and session-state behavior drifts when teams hand-roll pieces around the framework."
+    solution: "Use AppTheory lifecycle adapters, constrained MicroVM controllers, the TableTheory-shaped session registry, and the AppTheory CDK network/image/controller constructs together. Controller routes stay authorizer-protected and fail closed by default."
+    correct_example: |
+      # CORRECT: compose the blessed AppTheory surfaces.
+      AppTheoryMicrovmNetworkConnector -> AppTheoryMicrovmImage -> AppTheoryMicrovmController
+      controller handler -> MicroVMController + TableTheoryMicroVMSessionRegistry
+      lifecycle handlers -> MicroVMLifecycleAdapter
+    anti_patterns:
+      - name: "Raw MicroVM control plane calls"
+        why: "Raw SDK clients bypass AppTheory's constrained command envelope, sanitized errors, tenant binding, and registry validation."
+        incorrect_example: |
+          # INCORRECT
+          lambdaClient.runMicrovm(rawRequest)
+        consequences:
+          - "Cross-language behavior drift"
+          - "Unbounded AWS credential or bearer-token exposure"
+      - name: "Unauthenticated controller routes"
+        why: "The controller contract requires auth.required=true and default=deny; demo authorizers are not production proof."
+        incorrect_example: |
+          # INCORRECT
+          new AppTheoryMicrovmController(stack, "Controller", { controller, microvmImage, egressNetworkConnectors })
+        consequences:
+          - "Fail-open controller access"
+          - "Tenant-bound session state bypass"
+      - name: "Ad-hoc session tables"
+        why: "Controller/session routes must use the canonical TableTheory/DynamoDB pk/sk/ttl registry shape."
+        incorrect_example: |
+          # INCORRECT
+          putItem({ id: sessionId, status: "ready" })
+        consequences:
+          - "Session lookup drift"
+          - "TTL and tenant-bound key mismatch"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -331,6 +331,26 @@ SDK.
 
 Guide: [Object Store Helper](./features/object-store.md)
 
+### AWS Lambda MicroVM support
+
+The M15 MicroVM surface is fixture-backed across Go, TypeScript, and Python. It is a constrained AppTheory primitive,
+not a raw AWS SDK escape hatch.
+
+- Go: `runtime/microvm` exports lifecycle adapters, constrained controllers, safe session records, TableTheory session
+  registry helpers, and test fakes.
+- TypeScript: `MicroVMLifecycleAdapter`, `MicroVMController`, `TableTheoryMicroVMSessionRegistry`,
+  `createAWSLambdaMicroVMClient`, `createMicroVMLifecycleAdapter`, `createMicroVMController`, and related validators.
+- Python: `MicroVMLifecycleAdapter`, `MicroVMController`, `TableTheoryMicroVMSessionRegistry`,
+  `create_aws_lambda_microvm_client`, `create_microvm_lifecycle_adapter`, `create_microvm_controller`, and related
+  validators.
+
+The golden path requires sanitized lifecycle events, protected controller routes, and the TableTheory/DynamoDB-style
+session registry with `pk`, `sk`, and `ttl`. It does not provide live deployment proof, customer workload proof,
+generalized account vending, unauthenticated controllers, raw SDK access, or raw lifecycle hook bypasses.
+
+Guide: [First-class AWS Lambda MicroVM Support](./features/lambda-microvm-contract-foundation.md)
+CDK guide: [Lambda MicroVM CDK Constructs](./cdk/lambda-microvm.md)
+
 ## Migration and configuration notes
 
 Confirmed migration surface:
@@ -391,6 +411,9 @@ includes:
 - `AppTheoryKinesisStream`
 - `AppTheoryKinesisStreamMapping`
 - `AppTheoryCloudWatchLogsDestination`
+- `AppTheoryMicrovmNetworkConnector`
+- `AppTheoryMicrovmImage`
+- `AppTheoryMicrovmController`
 
 Start with:
 
@@ -398,6 +421,7 @@ Start with:
 - [CDK API Reference](./cdk/api-reference.md)
 - [Kinesis + CloudWatch Logs](./cdk/kinesis-cloudwatch-logs.md)
 - [CDK Import Pipeline Guides](./cdk/import-pipeline.md)
+- [Lambda MicroVM CDK Constructs](./cdk/lambda-microvm.md)
 
 Package-local docs remain available under `ts/docs/`, `py/docs/`, and `cdk/docs/` for language-specific examples, but
 they should not be treated as the canonical external root.

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -20,6 +20,7 @@ patterns and treat `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts` as the 
 - [MCP Protected Resource Metadata](./mcp-protected-resource.md)
 - [Import Pipeline Constructs](./import-pipeline.md)
 - [Kinesis + CloudWatch Logs](./kinesis-cloudwatch-logs.md)
+- [Lambda MicroVM CDK Constructs](./lambda-microvm.md)
 
 ## Scope
 
@@ -33,5 +34,6 @@ These pages cover the canonical user-facing CDK patterns for:
 - import-pipeline infrastructure primitives
 - EventBridge bus and rule-target transport primitives
 - Kinesis stream, stream mapping, and CloudWatch Logs destination transport primitives
+- Lambda MicroVM network connector, image, protected controller, and durable session-registry wiring
 
 Package-local authoring docs may still exist outside `docs/cdk/`, but canonical external guidance lives here.

--- a/docs/cdk/api-reference.md
+++ b/docs/cdk/api-reference.md
@@ -28,6 +28,11 @@ constructs, read `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts`.
 - `AppTheoryCloudWatchLogsSubscription`: source-side CloudWatch Logs subscription attachment for a caller-provided log
   group, destination ARN, filter pattern, and optional delivery role
 - `AppTheoryHttpIngestionEndpoint`: authenticated HTTP API v2 ingestion endpoint with Lambda request authorizer
+- `AppTheoryMicrovmNetworkConnector`: caller-owned VPC/subnet/security-group wiring for Lambda MicroVM egress
+- `AppTheoryMicrovmImage`: `AWS::Lambda::MicrovmImage` deployment with AppTheory hook, logging, resource, and connector
+  validation
+- `AppTheoryMicrovmController`: protected controller routes, controller Lambda, IAM grants, and durable `pk`/`sk`/`ttl`
+  session registry table
 - `AppTheorySsrSite`: FaceTheory-first CloudFront + S3 + Lambda URL deployment for SSR, SSG, and ISR
 - `AppTheoryQueue`, `AppTheoryQueueConsumer`, `AppTheoryQueueProcessor`: SQS queue and consumer patterns
 
@@ -52,6 +57,8 @@ constructs, read `cdk/.jsii`, `cdk/lib/index.ts`, and `cdk/lib/*.d.ts`.
 - Use `AppTheoryRemoteMcpServer` plus `AppTheoryMcpProtectedResource` for Claude Remote MCP
 - Use `AppTheorySsrSite` when you need the canonical FaceTheory-first SSR/SSG/ISR deployment story
 - Use `AppTheoryJobsTable`, `AppTheoryS3Ingest`, and `AppTheoryCodeBuildJobRunner` for import pipelines
+- Use `AppTheoryMicrovmNetworkConnector`, `AppTheoryMicrovmImage`, and `AppTheoryMicrovmController` together for the
+  first-class AWS Lambda MicroVM golden path. The controller requires an authorizer and fails closed when omitted.
 
 Event workload wiring:
 
@@ -79,6 +86,11 @@ Kinesis guide and example:
 Guide:
 
 - [FaceTheory-First SSR Site](./ssr-site.md)
+
+MicroVM guide and example:
+
+- [Lambda MicroVM CDK Constructs](./lambda-microvm.md)
+- `examples/cdk/microvm-controller`
 
 ## AppSync note
 

--- a/docs/cdk/lambda-microvm.md
+++ b/docs/cdk/lambda-microvm.md
@@ -1,0 +1,179 @@
+---
+title: Lambda MicroVM CDK Constructs
+description: The AppTheory CDK golden path for AWS Lambda MicroVM network, image, controller, and session-registry wiring.
+---
+
+# Lambda MicroVM CDK Constructs
+
+AppTheory's MicroVM CDK surface is the deployment side of the M15 MicroVM contract. Use these constructs together:
+
+- `AppTheoryMicrovmNetworkConnector` for caller-owned VPC egress connector wiring;
+- `AppTheoryMicrovmImage` for the `AWS::Lambda::MicrovmImage` resource and hook configuration;
+- `AppTheoryMicrovmController` for protected controller routes, the controller Lambda, IAM grants, and the durable
+  session registry table.
+
+This is the single AppTheory deployment path for MicroVM applications. Do not drop to raw CDK resources or raw AWS SDK
+calls to bypass controller auth, lifecycle validation, registry shape, or network-boundary requirements.
+
+## Construct sequence
+
+1. Import or pass the caller-owned `ec2.IVpc`, selected subnets, and explicit security groups.
+2. Create `AppTheoryMicrovmNetworkConnector` with that network context.
+3. Create `AppTheoryMicrovmImage` with a caller-provided base image, build role, artifact URI, hook configuration,
+   logging posture, resources, and the connector reference.
+4. Create `AppTheoryMicrovmController` with controller Lambda packaging, a Lambda request authorizer, the image
+   reference, connector references, and optional session-table settings.
+5. Implement the controller Lambda with AppTheory MicroVM runtime/controller primitives and the session registry table
+   name from `APPTHEORY_MICROVM_SESSION_REGISTRY_TABLE`.
+
+The synth-only reference stack lives at `examples/cdk/microvm-controller`. It demonstrates construct wiring without live
+AWS lookups or deployment.
+
+## Network connector boundary
+
+`AppTheoryMicrovmNetworkConnector` requires the network boundary to be explicit:
+
+| Prop | Required | Notes |
+| --- | --- | --- |
+| `vpc` | yes | Caller-provided `ec2.IVpc`. AppTheory does not synthesize or look up a VPC for you. |
+| `subnets` | yes | One to sixteen caller-provided subnets. |
+| `securityGroups` | yes | One to five caller-provided security groups. No default-security-group fallback. |
+| `networkProtocol` | no | Defaults to `AppTheoryMicrovmNetworkProtocol.IPV4`; `DUAL_STACK` is explicit. |
+| `operatorRole` | no | Existing role Lambda can assume to manage connector ENIs. |
+| `operatorRoleName` | no | Used only when AppTheory creates the operator role; cannot be combined with `operatorRole`. |
+
+When AppTheory creates the operator role, it scopes the ENI policy to the supplied subnet and security-group IDs. The
+construct creates the `AWS::Lambda::NetworkConnector` resource but does not vend accounts, mutate unrelated networks, or
+invent a hidden connector.
+
+## Image resource and hooks
+
+`AppTheoryMicrovmImage` creates the `AWS::Lambda::MicrovmImage` resource from caller-provided inputs:
+
+| Prop | Required | Notes |
+| --- | --- | --- |
+| `name`, `description` | yes | Image name and version description. |
+| `baseImageArn`, `baseImageVersion` | yes | Caller-selected base image reference. |
+| `buildRoleArn` | yes | Caller-provided IAM build role ARN. |
+| `codeArtifact.uri` | yes | Artifact URI, such as an S3 path or ECR image URI. |
+| `egressNetworkConnectors` | yes | One to ten `IAppTheoryMicrovmNetworkConnector` references. |
+| `hooks` | yes | Hook enablement for image-build and runtime MicroVM hooks. |
+| `logging` | yes | Exactly one of CloudWatch logging or `disabled: true`. |
+| `resources` | yes | Exactly one resource entry; `minimumMemoryInMiB` is required. |
+| `additionalOsCapabilities` | no | Defaults to `[ALL]`. |
+| `cpuConfigurations` | no | Defaults to ARM64; M15 does not broaden this into arbitrary architectures. |
+
+Hook fields on the image construct configure AWS resource integration:
+
+- `hooks.microvmImageHooks.ready` and `hooks.microvmImageHooks.validate` for image-build hooks;
+- `hooks.microvmHooks.resume`, `run`, `suspend`, and `terminate` for runtime MicroVM hooks;
+- timeout fields alongside each hook when the AWS resource should enforce a hook timeout.
+
+Application lifecycle behavior still belongs to AppTheory runtime lifecycle adapters. The image construct is not a raw
+lifecycle hook bypass.
+
+## Controller deployment
+
+`AppTheoryMicrovmController` provisions:
+
+- an HTTP API v2 API and stage;
+- a controller Lambda created from caller-supplied `lambda.FunctionProps`;
+- a Lambda request authorizer attached to every controller route;
+- the durable TableTheory-shaped DynamoDB session table;
+- IAM grants for the constrained Lambda MicroVM control-plane actions, listed MicroVM image, supplied network connector
+  ARNs, and optional execution role pass-through;
+- fail-closed environment wiring for the controller Lambda.
+
+Required props:
+
+| Prop | Required | Notes |
+| --- | --- | --- |
+| `controller` | yes | Lambda packaging/configuration. Handler code must use AppTheory MicroVM runtime/controller primitives. |
+| `authorizer` | yes | Lambda request authorizer. Omission fails closed; unauthenticated routes are not synthesized. |
+| `microvmImage` | yes | `IAppTheoryMicrovmImage` reference the controller may run. |
+| `egressNetworkConnectors` | yes | Connector references the controller may pass to Lambda MicroVMs. |
+
+Controller routes are fixed:
+
+| Method | Path | Command |
+| --- | --- | --- |
+| `POST` | `/microvms` | `create` |
+| `POST` | `/microvms/{session_id}/start` | `start` |
+| `POST` | `/microvms/{session_id}/stop` | `stop` |
+| `GET` | `/microvms/{session_id}/status` | `status` |
+| `GET` | `/microvms/{session_id}` | `session` |
+
+The construct sets these controller environment variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `APPTHEORY_MICROVM_CONTRACT_NAME` | `apptheory.lambda_microvm` |
+| `APPTHEORY_MICROVM_CONTRACT_VERSION` | `m15.microvm/v1` |
+| `APPTHEORY_MICROVM_CONTROLLER_ENDPOINT` | Synthesized `/microvms` base endpoint. |
+| `APPTHEORY_MICROVM_CONTROLLER_AUTH_REQUIRED` | Always `true`. |
+| `APPTHEORY_MICROVM_CONTROLLER_AUTH_DEFAULT` | Always `deny`. |
+| `APPTHEORY_MICROVM_SESSION_REGISTRY_TABLE` | Durable session table name. |
+| `APPTHEORY_MICROVM_IMAGE_REF` | Permitted MicroVM image ARN/reference. |
+| `APPTHEORY_MICROVM_NETWORK_CONNECTOR_REFS` | Comma-separated permitted connector ARNs. |
+| `APPTHEORY_MICROVM_EXECUTION_ROLE_ARN` | Present only when an execution role is supplied. |
+
+Reserved environment variables cannot be overridden through `controller.environment`.
+
+## Session table shape
+
+The controller-created table is the canonical durable session registry:
+
+- partition key: `pk` (`STRING`);
+- sort key: `sk` (`STRING`);
+- TTL attribute: `ttl`;
+- default billing: `PAY_PER_REQUEST`;
+- default removal policy: `RETAIN`;
+- point-in-time recovery enabled by default;
+- AWS-managed encryption by default, with customer-managed KMS supported only when a key is supplied.
+
+Records use the TableTheory/DynamoDB key shape:
+
+| Field | Canonical value |
+| --- | --- |
+| `pk` | `TENANT#<tenant_id>#NAMESPACE#<namespace>` |
+| `sk` | `SESSION#<session_id>` |
+| `ttl` | Unix expiry derived from `expires_at` |
+
+Controller/session handlers must use this registry table rather than route-local memory, ad-hoc tables, or raw SDK
+storage. The durable record is tenant-bound and includes session state, desired state, image/network refs, controller ID,
+creation/update/expiry fields, generation/version fields, last command metadata, auth subject, and optional safe
+metadata.
+
+## Authentication posture
+
+Controller routes are protected and fail closed by default. A production authorizer must bind the caller to the tenant,
+namespace, subject, and entitlements expected by the controller envelope. The example's demo token authorizer is only a
+synth-time shape example; it is not production auth proof.
+
+The authorizer result cache defaults to `Duration.seconds(0)`. Increase it only when your tenant-bound authorization
+model can tolerate cached decisions.
+
+## Evidence boundary and non-goals
+
+The CDK docs and example demonstrate synth-time wiring for the AppTheory construct surface. They do not prove live AWS
+deployment, customer workload behavior, cloud mutation, account vending, VPC creation, or that unauthenticated
+controllers are acceptable.
+
+M15 intentionally does not add:
+
+- raw AWS SDK escape hatches;
+- raw lifecycle hook bypasses;
+- unauthenticated controller defaults;
+- hidden account, VPC, subnet, security-group, or network connector mutation;
+- a deployment path outside AppTheory CDK constructs.
+
+## Validation
+
+For this docs surface, ordinary repository validation is:
+
+```bash
+make test
+```
+
+When changing runtime-visible behavior or exported API, also run the contract and snapshot gates described in
+[Contract Fixtures](../reference/contract-fixtures.md).

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,7 +17,7 @@ contract.
 - [Jobs Ledger](./jobs-ledger.md)
 - [Event Workload Contracts](./event-workloads.md)
 - [Object Store Helper](./object-store.md)
-- [Lambda MicroVM Contract Foundation](./lambda-microvm-contract-foundation.md)
+- [First-class AWS Lambda MicroVM Support](./lambda-microvm-contract-foundation.md)
 
 ## Boundary
 

--- a/docs/features/lambda-microvm-contract-foundation.md
+++ b/docs/features/lambda-microvm-contract-foundation.md
@@ -1,69 +1,180 @@
 ---
-title: Lambda MicroVM Contract Foundation
-description: M15 fixture-backed vocabulary for future first-class AWS Lambda MicroVM support.
+title: First-class AWS Lambda MicroVM Support
+description: The M15 golden path for fixture-backed Lambda MicroVM lifecycle, controller, registry, and CDK deployment support.
 ---
 
-# Lambda MicroVM Contract Foundation
+# First-class AWS Lambda MicroVM Support
 
-M15 introduces the **contract foundation** for first-class AWS Lambda MicroVM support in AppTheory. This is not a
-runtime implementation, CDK deployment surface, or deployment proof. It is the fixture-backed vocabulary that later
-milestones must implement consistently across Go, TypeScript, and Python before MicroVM deployments are considered
-shippable.
+M15 grows the Lambda MicroVM work from a contract foundation into an **evidence-bounded golden path** for AppTheory
+applications that need first-class AWS Lambda MicroVM primitives. The path is still AppTheory's path: fixture-backed
+runtime vocabulary, constrained controllers, durable TableTheory-shaped session records, and CDK constructs that wire the
+deployment surface without introducing raw AWS SDK or raw lifecycle-hook bypasses.
 
 The contract name is `apptheory.lambda_microvm`; the fixture version is `m15.microvm/v1`. Fixtures live under
 `contract-tests/fixtures/m15/` and are validated by the Go, TypeScript, and Python contract runners.
 
-## What M15 pins
+## What the M15 feature line proves
 
-The M15 fixtures define:
+M15 provides evidence for the AppTheory framework surface only:
 
-- lifecycle hook vocabulary for `prepare_image`, `start`, `readiness`, `stop`, `teardown`, and `failure`;
-- lifecycle states from `requested` through image preparation, start, readiness, stop, teardown, `terminated`, and
-  `failed`;
-- controller command vocabulary for `create`, `start`, `stop`, `status`, and `session` interactions;
-- controller envelope requirements for `command`, `request_id`, `tenant_id`, and `auth_context`;
-- safe error-envelope fields for controller responses;
-- durable session registry guidance using a TableTheory-patterned, tenant-and-namespace-bound record shape;
-- explicit denial fixtures for raw AWS SDK escape hatches, raw lifecycle hook bypasses, and unauthenticated controller
-  defaults.
+- shared fixtures for lifecycle vocabulary, controller/session command envelopes, durable session-registry requirements,
+  and denial cases;
+- Go, TypeScript, and Python runtime primitives for lifecycle adapters, constrained MicroVM controllers, fake clients,
+  AWS adapter factories, and durable registry adapters;
+- CDK constructs for the MicroVM network connector, image resource, and protected controller deployment surface;
+- a synth-only controller example that demonstrates how the constructs are assembled.
 
-## Security posture
+This evidence does **not** claim live deployment proof, cloud mutation proof, customer workload proof, generalized
+account vending, or proof that unauthenticated controllers are acceptable. Demo-only authorizers and placeholder example
+values are examples of shape, not production authentication or deployment evidence.
 
-The contract grows AppTheory's single path rather than adding a bypass. Later runtime and CDK work must preserve these
-M15 invariants:
+## Golden path
 
-- no raw AWS SDK escape hatch for callers;
-- no raw lifecycle hook bypass outside the AppTheory lifecycle contract;
-- no unauthenticated controller default;
-- session records remain tenant and namespace scoped;
-- session registries must not persist raw AWS credentials, bearer tokens, or raw lifecycle hook payloads.
+Use these pieces together. Do not replace one piece with an ad-hoc implementation.
 
-## What this does not ship yet
+1. **Model lifecycle through the AppTheory lifecycle adapter.** Handlers receive a sanitized `MicroVMLifecycleEvent` and
+   return through the adapter's safe result/error envelope. They do not receive raw AWS hook payloads and they do not get
+   a raw SDK client.
+2. **Deploy network and image resources through AppTheory CDK constructs.** The network connector is bound to
+   caller-provided VPC, subnet, and security-group context. The image references that connector and declares lifecycle
+   hook enablement, logging, resources, base image, build role, and artifact URI.
+3. **Expose the controller through `AppTheoryMicrovmController`.** The controller HTTP routes are fixed, protected by a
+   Lambda request authorizer, and backed by the construct-created durable session table.
+4. **Persist controller state through the durable session registry.** Controller and session routes use the registry
+   table shape rather than ad-hoc storage.
 
-This milestone intentionally does **not** provide:
+## Lifecycle hooks
 
-- Go lifecycle adapters or control-plane runtime APIs;
-- TypeScript or Python runtime parity implementation;
-- a durable TableTheory-backed session registry implementation;
-- `AppTheoryMicrovm*` CDK constructs;
-- example applications;
-- any cloud deployment, live AWS receipt, account mutation, DNS mutation, or IAM mutation.
+The runtime lifecycle contract is language-neutral. All three runtimes validate the same hook/state vocabulary:
 
-Those items belong to follow-up milestones. Until they land with fixture-backed parity, AppTheory documentation should
-describe MicroVM support as contract foundation only.
+| Hook | Active state | Success state | Failure state | Purpose |
+| --- | --- | --- | --- | --- |
+| `prepare_image` | `image_preparing` | `image_prepared` | `failed` | Prepare image-specific session state before start. |
+| `start` | `starting` | `started` | `failed` | Start the MicroVM session through the constrained client. |
+| `readiness` | `readiness_probing` | `ready` | `failed` | Confirm the session is ready before callers treat it as usable. |
+| `stop` | `stopping` | `stopped` | `failed` | Stop a running session. |
+| `teardown` | `tearing_down` | `terminated` | `failed` | Tear down session state and end the lifecycle. |
+| `failure` | `failed` | `failed` | `failed` | Record terminal failure without widening the contract. |
 
-## Validating the foundation
+The event shape is intentionally small: `request_id`, `tenant_id`, `namespace`, `session_id`, `hook`, `state`, and safe
+string metadata. The adapter fails closed for missing handlers, malformed events, unsupported transitions, forbidden
+metadata, or explicit `raw_lifecycle_hook_bypass` requests.
 
-Run the shared contract runners:
+The CDK image construct also exposes AWS Lambda MicroVM hook **configuration** fields:
+
+| CDK hook group | Fields | Boundary |
+| --- | --- | --- |
+| `microvmImageHooks` | `ready`, `validate` | Enables or disables image-build hook integration for `AWS::Lambda::MicrovmImage`. |
+| `microvmHooks` | `resume`, `run`, `suspend`, `terminate` | Enables or disables runtime MicroVM hook integration for the image resource. |
+
+Those CDK fields configure the AWS resource. Application behavior still goes through the AppTheory runtime lifecycle
+adapter and its sanitized event/result contract.
+
+## Controller routes
+
+`AppTheoryMicrovmController` exposes the fixed M15 controller surface under `/microvms`:
+
+| Command | Method | Route | Required request fields | Registry use |
+| --- | --- | --- | --- | --- |
+| `create` | `POST` | `/microvms` | `image_ref`, `network_connector_ref`, `session_spec` | Creates the tenant-bound session record. |
+| `start` | `POST` | `/microvms/{session_id}/start` | `session_id` | Loads and updates the existing session record. |
+| `stop` | `POST` | `/microvms/{session_id}/stop` | `session_id` | Loads and updates the existing session record. |
+| `status` | `GET` | `/microvms/{session_id}/status` | `session_id` | Reads status through the session registry/client boundary. |
+| `session` | `GET` | `/microvms/{session_id}` | `session_id` | Returns the durable tenant-bound session record. |
+
+The controller request envelope requires `command`, `request_id`, `tenant_id`, `namespace`, and `auth_context`. Safe
+errors expose only `code`, `message`, and `request_id`. The envelope and durable records forbid raw AWS credentials,
+raw SDK clients, bearer tokens, raw lifecycle hook payloads, and plaintext session tokens.
+
+## Authentication posture
+
+Controller routes are **protected and fail closed by default**:
+
+- `AppTheoryMicrovmController` requires an `authorizer` Lambda function and attaches it to every fixed route.
+- The construct sets `APPTHEORY_MICROVM_CONTROLLER_AUTH_REQUIRED=true` and
+  `APPTHEORY_MICROVM_CONTROLLER_AUTH_DEFAULT=deny` for the controller Lambda.
+- The authorizer result cache defaults to `Duration.seconds(0)` so stale decisions do not silently broaden controller
+  access.
+- The runtime controller requires authenticated, tenant-bound requests. `tenant_id`, `namespace`, and `auth_context`
+  must agree with the caller's authorization model.
+
+The synth-only example uses a `DemoOnlyTokenAuthorizer` to prove route wiring. That authorizer is not production auth
+proof and must be replaced with a tenant-bound AppTheory authorizer before deployment.
+
+## VPC and network boundary
+
+AppTheory does not hide account or network mutation behind the MicroVM primitive.
+
+`AppTheoryMicrovmNetworkConnector` requires caller-provided network context:
+
+- `vpc`: the application's VPC boundary;
+- `subnets`: one to sixteen caller-selected subnets where Lambda may attach connector ENIs;
+- `securityGroups`: one to five explicit security groups;
+- optional `operatorRole` or an AppTheory-created operator role scoped to the supplied subnet/security-group IDs.
+
+The construct does not synthesize a VPC, select a default security group, vend an AWS account, mutate sibling accounts,
+or perform live AWS lookups. The controller and image constructs receive network connector references from this boundary;
+there is no hidden fallback connector.
+
+## Durable session registry shape
+
+The durable registry is TableTheory/DynamoDB-shaped and tenant-bound. `AppTheoryMicrovmController` creates a DynamoDB
+session table with:
+
+- partition key `pk` (`STRING`);
+- sort key `sk` (`STRING`);
+- TTL attribute `ttl`;
+- point-in-time recovery enabled by default;
+- `RemovalPolicy.RETAIN` by default.
+
+Canonical keys are derived from tenant and session identity:
+
+| Field | Canonical value |
+| --- | --- |
+| `pk` | `TENANT#<tenant_id>#NAMESPACE#<namespace>` |
+| `sk` | `SESSION#<session_id>` |
+| `ttl` | Unix expiry derived from `expires_at` |
+
+Canonical durable records include `tenant_id`, `namespace`, `session_id`, `state`, `desired_state`, `image_ref`,
+`network_connector_ref`, `controller_id`, `created_at`, `updated_at`, `expires_at`, `generation`, `version`,
+`last_action`, `last_command_id`, `auth_subject`, and optional `endpoint`, `microvm_id`, and safe metadata.
+
+The session and controller routes must use this registry shape. Do not replace it with route-local memory, an ad-hoc
+DynamoDB schema, raw SDK calls, or per-controller private storage.
+
+## Explicit out of scope
+
+M15 does not provide or prove:
+
+- live AWS deployment success;
+- cloud mutation receipts or customer workload execution;
+- generalized account vending, VPC vending, or network mutation outside caller-provided VPC/subnet/security-group
+  inputs;
+- permission to expose unauthenticated controller routes;
+- raw AWS SDK access from application code;
+- raw lifecycle hook payload access or a hook bypass path;
+- a TypeScript-only, Python-only, or Go-only MicroVM behavior variant;
+- registry-published packages or a deployment path outside GitHub Releases and AppTheory CDK constructs.
+
+If one of those capabilities becomes necessary, grow the AppTheory contract first with fixtures and cross-runtime parity.
+Do not add a private escape hatch.
+
+## Related docs and examples
+
+- [MicroVM CDK constructs](../cdk/lambda-microvm.md)
+- [Contract fixtures](../reference/contract-fixtures.md)
+- `examples/cdk/microvm-controller`
+
+## Validation
+
+Run the shared contract runners when changing runtime-visible behavior:
 
 ```bash
 ./scripts/verify-contract-tests.sh
 ```
 
-For focused debugging of only the fixture validators, run the three language runners directly:
+Run the repository gate for ordinary validation:
 
 ```bash
-go run ./contract-tests/runners/go
-node contract-tests/runners/ts/run.cjs
-python3 contract-tests/runners/py/run.py
+make test
 ```

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -47,7 +47,7 @@ The 133 fixtures span (counts approximate; see `contract-tests/fixtures/` for th
 | Kinesis | Partial-batch response, stream routing, fail-closed for unregistered streams, CloudWatch Logs subscription envelope decoding. |
 | Remote MCP path dispatch | API Gateway REST proxy path normalization for Remote MCP and protected-resource metadata routes. The shared fixtures do **not** cover MCP JSON-RPC methods, session stores, DCR, PKCE, bearer-token validation, or OAuth challenges. |
 | Sanitization | Token-like value redaction, JSON/XML safe-logging output. |
-| Lambda MicroVM foundation | M15 validation-only lifecycle hooks/states, controller command envelopes, TableTheory-patterned session-record guidance, and denial fixtures for raw SDK escape hatches, lifecycle bypass, and unauthenticated controller defaults. |
+| Lambda MicroVM support | M15 lifecycle hooks/states, controller command envelopes, TableTheory-patterned session-record guidance, and denial fixtures for raw SDK escape hatches, lifecycle bypass, and unauthenticated controller defaults. The feature line is evidence-bounded to fixture-backed runtime/CDK/example docs, not live deployment or unauthenticated-controller proof. |
 
 ## Running the fixtures
 
@@ -98,5 +98,7 @@ Snapshot diffs are intentional signals: a moved snapshot says "a public contract
 
 - [HTTP Runtime](../features/http-runtime.md) — what the HTTP fixtures pin
 - [Event Shape Dispatch](event-shapes.md) — what `HandleLambda` detection fixtures pin
+- [First-class AWS Lambda MicroVM Support](../features/lambda-microvm-contract-foundation.md) — the M15 MicroVM
+  golden path and evidence boundary
 - [MCP Method Surface](../integrations/mcp.md) — Go runtime MCP behavior; the shared fixtures only pin Remote MCP/protected-resource API Gateway path dispatch
 - [Development Guidelines](../development-guidelines.md) — the contract-only scope


### PR DESCRIPTION
Closes THE-2157

## Scope
- Documents the M15 Lambda MicroVM golden path across lifecycle hooks, protected controller routes, authentication posture, caller-owned VPC/network connector boundaries, and durable session registry shape.
- Adds the CDK MicroVM guide for `AppTheoryMicrovmNetworkConnector`, `AppTheoryMicrovmImage`, and `AppTheoryMicrovmController`.
- Updates docs navigation, API/reference coverage, and docs metadata patterns/decisions for the MicroVM primitive.

## Validation
- `make test` — PASS (`version-alignment: PASS (1.13.2)`)
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' docs/_concepts.yaml docs/_patterns.yaml docs/_decisions.yaml docs/_data/nav.yml && git diff --check` — PASS

## Evidence boundary / non-goals
This documents fixture-backed runtime/CDK/example evidence only. It does not claim live deployment proof, cloud mutation proof, customer workload proof, generalized account vending, or that unauthenticated controllers are acceptable. Controller routes remain protected/fail closed by default; demo-only authorizers are not production auth proof.