### PR TITLE
test(microvm): cover final gate session paths

### DIFF
--- a/runtime/microvm/registry_test.go
+++ b/runtime/microvm/registry_test.go
@@ -2,6 +2,7 @@ package microvm
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -94,6 +95,106 @@ func TestMemorySessionRegistryAndRegistryClient(t *testing.T) {
 	require.NoError(t, registry.Delete(context.Background(), created.Key()))
 	_, err = registry.Get(context.Background(), created.Key())
 	require.Error(t, err)
+}
+
+func TestRegistryClientStopSessionAndFailClosedPaths(t *testing.T) {
+	ctx := context.TODO()
+
+	_, err := NewRegistryClient(nil)
+	require.Error(t, err)
+
+	registry := NewMemorySessionRegistry()
+	client, err := NewRegistryClient(registry, nil, WithRegistryClientTTL(0))
+	require.NoError(t, err)
+
+	created, err := client.Create(ctx, CreateSessionInput{
+		RequestID:           "req-create",
+		TenantID:            "tenant-1",
+		Namespace:           "namespace-1",
+		SessionID:           "session-1",
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+		SessionSpec:         SessionSpec{Metadata: map[string]string{"safe": "ok"}},
+		ControllerID:        "controller-1",
+		AuthSubject:         "subject-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, time.Unix(0, 0).UTC().Add(time.Hour), created.ExpiresAt)
+
+	stopped, err := client.Stop(ctx, SessionCommandInput{
+		RequestID:    "req-stop",
+		TenantID:     "tenant-1",
+		Namespace:    "namespace-1",
+		SessionID:    "session-1",
+		ControllerID: "controller-1",
+		AuthSubject:  "subject-1",
+		DesiredState: StateStopped,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateStopping, stopped.State)
+	require.Equal(t, StateStopped, stopped.DesiredState)
+	require.Equal(t, CommandStop, stopped.LastAction)
+	require.Equal(t, int64(2), stopped.Generation)
+
+	session, err := client.Session(ctx, SessionQueryInput{
+		RequestID:   "req-session",
+		TenantID:    "tenant-1",
+		Namespace:   "namespace-1",
+		SessionID:   "session-1",
+		AuthSubject: "subject-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, CommandStop, session.LastAction)
+
+	var nilClient *RegistryClient
+	_, err = nilClient.Create(ctx, CreateSessionInput{RequestID: "req-create"})
+	require.Error(t, err)
+	_, err = nilClient.Stop(ctx, SessionCommandInput{RequestID: "req-stop"})
+	require.Error(t, err)
+	_, err = nilClient.Session(ctx, SessionQueryInput{RequestID: "req-session"})
+	require.Error(t, err)
+}
+
+func TestMemorySessionRegistryNilAndInvalidKeysFailClosed(t *testing.T) {
+	var nilRegistry *MemorySessionRegistry
+	_, err := nilRegistry.Put(context.Background(), registryTestRecord(time.Unix(250, 0).UTC()))
+	require.Error(t, err)
+	_, err = nilRegistry.Get(context.Background(), SessionKey{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1"})
+	require.Error(t, err)
+	require.Error(t, nilRegistry.Delete(context.Background(), SessionKey{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1"}))
+
+	registry := NewMemorySessionRegistry()
+	_, err = registry.Get(context.Background(), SessionKey{TenantID: "", Namespace: "namespace-1", SessionID: "session-1"})
+	require.Error(t, err)
+	require.Error(t, registry.Delete(context.Background(), SessionKey{TenantID: "tenant-1", Namespace: "", SessionID: "session-1"}))
+}
+
+func TestTableTheorySessionRegistryFailClosedPaths(t *testing.T) {
+	_, err := NewTableTheorySessionRegistry(nil)
+	require.Error(t, err)
+
+	key := SessionKey{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1"}
+	var nilStore *TableTheorySessionRegistry
+	_, err = nilStore.Put(context.Background(), registryTestRecord(time.Unix(500, 0).UTC()))
+	require.Error(t, err)
+	_, err = nilStore.Get(context.Background(), key)
+	require.Error(t, err)
+	require.Error(t, nilStore.Delete(context.Background(), key))
+
+	db := new(tablemocks.MockDB)
+	q := new(tablemocks.MockQuery)
+	db.On("Model", mock.Anything).Return(q).Once()
+	q.On("WithContext", mock.Anything).Return(q).Once()
+	q.On("CreateOrUpdate").Return(errors.New("raw table failure")).Once()
+
+	store, err := NewTableTheorySessionRegistry(db)
+	require.NoError(t, err)
+	_, err = store.Put(context.Background(), registryTestRecord(time.Unix(501, 0).UTC()))
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "raw table failure")
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
 }
 
 func TestTableTheorySessionRegistryUsesCanonicalModel(t *testing.T) {

--- a/ts/test/microvm.test.mjs
+++ b/ts/test/microvm.test.mjs
@@ -17,21 +17,32 @@ import {
   MicroVMHook,
   MicroVMSafeError,
   MicroVMState,
+  MICROVM_SESSION_REGISTRY_TABLE_ENV,
   createAWSLambdaMicroVMClient,
   createFakeMicroVMClient,
+  createMemoryMicroVMSessionRegistry,
   createMicroVMController,
   createMicroVMLifecycleAdapter,
+  createMicroVMRegistryClient,
+  createTableTheoryMicroVMSessionRegistry,
   defaultMicroVMControllerContract,
   defaultMicroVMLifecycleContract,
   defaultMicroVMSessionRegistryContract,
   isMicroVMTerminalState,
+  microVMSessionFromRegistryRecord,
   microVMSessionKey,
+  microVMSessionRecordToRegistryRecord,
+  microVMSessionRegistryModel,
+  microVMSessionRegistryPartitionKey,
+  microVMSessionRegistrySortKey,
+  microVMSessionRegistryTableName,
   validateMicroVMControllerContract,
   validateMicroVMControllerRequest,
   validateMicroVMEscapeHatches,
   validateMicroVMLifecycleContract,
   validateMicroVMSessionRecord,
   validateMicroVMSessionRegistryContract,
+  validateMicroVMSessionRegistryRecord,
   validateMicroVMSessionStatus,
 } from "../dist/index.js";
 
@@ -536,6 +547,195 @@ test("microvm controller flow and fake client preserve constrained API", async (
     })).error?.code,
     MICROVM_ERROR_CONTROLLER_COMMAND_FAILED,
   );
+});
+
+
+test("microvm session registry conversions keep TableTheory shape", () => {
+  const previousTableName = process.env[MICROVM_SESSION_REGISTRY_TABLE_ENV];
+  try {
+    delete process.env[MICROVM_SESSION_REGISTRY_TABLE_ENV];
+    assert.equal(microVMSessionRegistryTableName(), "apptheory-microvm-sessions");
+
+    process.env[MICROVM_SESSION_REGISTRY_TABLE_ENV] = " custom-microvm-sessions ";
+    assert.equal(microVMSessionRegistryTableName(), "custom-microvm-sessions");
+  } finally {
+    if (previousTableName === undefined) {
+      delete process.env[MICROVM_SESSION_REGISTRY_TABLE_ENV];
+    } else {
+      process.env[MICROVM_SESSION_REGISTRY_TABLE_ENV] = previousTableName;
+    }
+  }
+
+  assert.equal(
+    microVMSessionRegistryPartitionKey(" tenant-1 ", " namespace-1 "),
+    "TENANT#tenant-1#NAMESPACE#namespace-1",
+  );
+  assert.equal(microVMSessionRegistryPartitionKey("", "namespace-1"), "");
+  assert.equal(microVMSessionRegistrySortKey(" session-1 "), "SESSION#session-1");
+  assert.equal(microVMSessionRegistrySortKey(""), "");
+
+  const model = microVMSessionRegistryModel("microvm-table");
+  assert.equal(model.tableName, "microvm-table");
+  assert.equal(model.schema.keys.partition.attribute, "pk");
+  assert.equal(model.schema.keys.sort.attribute, "sk");
+
+  const record = validRecord({
+    endpoint: "https://microvm.example.test/session-1",
+    microvm_id: "microvm-1",
+    metadata: { safe: "ok" },
+  });
+  const registry = microVMSessionRecordToRegistryRecord(record);
+  assert.equal(registry.pk, "TENANT#tenant-1#NAMESPACE#namespace-1");
+  assert.equal(registry.sk, "SESSION#session-1");
+  assert.equal(registry.ttl, Math.trunc(record.expires_at.getTime() / 1000));
+  assert.equal(registry.version, record.generation);
+  validateMicroVMSessionRegistryRecord(registry);
+
+  const roundTrip = microVMSessionFromRegistryRecord(registry);
+  assert.equal(roundTrip.endpoint, record.endpoint);
+  assert.equal(roundTrip.microvm_id, record.microvm_id);
+  assert.deepEqual(roundTrip.metadata, { safe: "ok" });
+
+  for (const bad of [
+    { ...registry, pk: "TENANT#other#NAMESPACE#namespace-1" },
+    { ...registry, ttl: registry.ttl + 1 },
+    { ...registry, version: 0 },
+    { ...registry, metadata: { bearer_token: "secret" } },
+  ]) {
+    assert.throws(
+      () => validateMicroVMSessionRegistryRecord(bad),
+      (err) =>
+        err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE ||
+        err?.code === MICROVM_ERROR_FORBIDDEN_FIELD,
+    );
+  }
+});
+
+test("microvm memory registry client preserves durable session flow", async () => {
+  assert.throws(
+    () => createMicroVMRegistryClient(null),
+    (err) => err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE,
+  );
+
+  const registry = createMemoryMicroVMSessionRegistry();
+  await assert.rejects(
+    () => registry.get({ tenant_id: "tenant-1", namespace: "namespace-1", session_id: "missing" }),
+    (err) => err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE,
+  );
+
+  const client = createMicroVMRegistryClient(registry, { ttl_ms: 30 * 60 * 1000 });
+  const created = await client.create(createInput());
+  assert.equal(created.state, MicroVMState.Requested);
+  assert.equal(created.expires_at.valueOf() - created.created_at.valueOf(), 30 * 60 * 1000);
+
+  const started = await client.start(commandInput({ request_id: "req-start" }));
+  assert.equal(started.state, MicroVMState.Starting);
+  assert.equal(started.desired_state, MicroVMState.Started);
+  assert.equal(started.last_action, MicroVMCommand.Start);
+
+  const status = await client.status(queryInput({ request_id: "req-status" }));
+  assert.equal(status.lifecycle_state, MicroVMState.Starting);
+  assert.equal(status.registry_version, 2);
+
+  const session = await client.session(queryInput({ request_id: "req-session" }));
+  assert.equal(session.session_id, "session-1");
+
+  const stopped = await client.stop(
+    commandInput({
+      request_id: "req-stop",
+      desired_state: MicroVMState.Stopped,
+      now: new Date(3000),
+    }),
+  );
+  assert.equal(stopped.state, MicroVMState.Stopping);
+  assert.equal(stopped.desired_state, MicroVMState.Stopped);
+  assert.equal(stopped.last_action, MicroVMCommand.Stop);
+  assert.equal(stopped.generation, 3);
+
+  await registry.delete(microVMSessionKey(stopped));
+  await assert.rejects(
+    () => registry.get(microVMSessionKey(stopped)),
+    (err) => err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE,
+  );
+  await assert.rejects(
+    () => registry.delete({ tenant_id: "", namespace: "namespace-1", session_id: "session-1" }),
+    (err) => err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE,
+  );
+});
+
+test("microvm TableTheory registry adapter uses constrained storage model", async () => {
+  const registered = [];
+  const saved = [];
+  const deleted = [];
+  const db = {
+    register(model) {
+      registered.push(model);
+    },
+    async save(modelName, item) {
+      saved.push({ modelName, item });
+    },
+    async get(modelName, key) {
+      assert.equal(modelName, "MicroVMCustomModel");
+      assert.deepEqual(key, {
+        pk: "TENANT#tenant-1#NAMESPACE#namespace-1",
+        sk: "SESSION#session-1",
+      });
+      return saved[0].item;
+    },
+    async delete(modelName, key) {
+      deleted.push({ modelName, key });
+    },
+  };
+
+  const registry = createTableTheoryMicroVMSessionRegistry(db, {
+    table_name: "microvm-table",
+    model_name: "MicroVMCustomModel",
+  });
+  assert.equal(registered[0].tableName, "microvm-table");
+
+  const stored = await registry.put(validRecord({ metadata: { safe: "ok" } }));
+  assert.equal(stored.session_id, "session-1");
+  assert.equal(saved[0].modelName, "MicroVMCustomModel");
+  assert.equal(saved[0].item.pk, "TENANT#tenant-1#NAMESPACE#namespace-1");
+  assert.equal(saved[0].item.created_at, new Date(1000).toISOString());
+  assert.deepEqual(saved[0].item.metadata, { safe: "ok" });
+
+  const got = await registry.get(microVMSessionKey(stored));
+  assert.equal(got.last_action, MicroVMCommand.Create);
+  await registry.delete(microVMSessionKey(stored));
+  assert.equal(deleted[0].modelName, "MicroVMCustomModel");
+
+  assert.throws(
+    () => createTableTheoryMicroVMSessionRegistry(null),
+    (err) => err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE,
+  );
+
+  const failingRegistry = createTableTheoryMicroVMSessionRegistry(
+    {
+      async save() {
+        throw new Error("raw table failure");
+      },
+      async get() {
+        throw new Error("raw table failure");
+      },
+      async delete() {
+        throw new Error("raw table failure");
+      },
+    },
+    { auto_register: false },
+  );
+  for (const op of [
+    () => failingRegistry.put(validRecord()),
+    () => failingRegistry.get(microVMSessionKey(validRecord())),
+    () => failingRegistry.delete(microVMSessionKey(validRecord())),
+  ]) {
+    await assert.rejects(
+      op,
+      (err) =>
+        err?.code === MICROVM_ERROR_SESSION_REGISTRY_INCOMPLETE &&
+        !String(err.message).includes("raw table failure"),
+    );
+  }
 });
 
 test("microvm AWS Lambda client factory fails closed without SDK support", async () => {

--- a/ts/test/microvm.test.mjs
+++ b/ts/test/microvm.test.mjs
@@ -113,6 +113,7 @@ function validRecord(overrides = {}) {
     updated_at: new Date(1000),
     expires_at: new Date(3_601_000),
     generation: 1,
+    last_action: MicroVMCommand.Create,
     last_command_id: "req-record",
     auth_subject: "subject-1",
     ...overrides,
@@ -127,6 +128,7 @@ function validStatus(overrides = {}) {
     state: MicroVMState.Requested,
     desired_state: MicroVMState.Requested,
     lifecycle_state: MicroVMState.Requested,
+    last_action: MicroVMCommand.Create,
     last_transition: new Date(1000),
     registry_version: 1,
     ...overrides,
@@ -330,6 +332,7 @@ test("microvm controller, registry, record, and request contracts fail closed", 
   for (const record of [
     validRecord({ session_id: "" }),
     validRecord({ created_at: new Date(Number.NaN) }),
+    validRecord({ last_action: "" }),
     validRecord({ state: "unknown" }),
     validRecord({ metadata: { "bearer-token": "secret" } }),
   ]) {
@@ -341,6 +344,7 @@ test("microvm controller, registry, record, and request contracts fail closed", 
 
   for (const status of [
     validStatus({ session_id: "" }),
+    validStatus({ last_action: "" }),
     validStatus({ state: "unknown" }),
   ]) {
     assert.throws(


### PR DESCRIPTION
Refs THE-2158

## Failure summary

`make rubric` had progressed past the TypeScript session-record completeness failure from the prior commit, but QUA-3 still failed on coverage:

- Go total coverage: `89.9% < 90%`
- TypeScript line coverage: `88.50% < 90%`
- Python coverage: PASS (`90.6%`)

## Fix / coverage summary

- Added Go MicroVM registry-client tests for stop/session durable paths, nil-registry fail-closed handling, memory registry invalid-key denials, and TableTheory registry sanitized operation failure handling.
- Added TypeScript MicroVM tests for session registry conversion helpers, memory registry + registry client durable flow, and TableTheory registry adapter storage/error paths.
- Test-only change: no production source, fixtures, Python, docs, package/version/release/CI, or gov-infra/evidence files changed.

## Validation output

### Targeted tests and coverage

```text
$ go test ./runtime/microvm ./testkit/microvm
ok  	github.com/theory-cloud/apptheory/runtime/microvm	0.003s
ok  	github.com/theory-cloud/apptheory/testkit/microvm	(cached)

$ ./scripts/verify-go-lint.sh
0 issues.
go-lint: PASS

$ go test -buildvcs=false $(./scripts/list-go-packages.sh | grep -Ev '^./(cdk-go|examples|contract-tests|scripts|cmd)(/|$)') -coverprofile=/tmp/apptheory-go-cover-after2.out
runtime/microvm coverage: 87.9% of statements
testkit/microvm coverage: 90.5% of statements
total: (statements) 90.1%

$ NO_COLOR=1 node --test ts/test/microvm.test.mjs
tests 9; pass 9; fail 0

$ NO_COLOR=1 node --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-include="ts/dist/**/*.js" contract-tests/runners/ts/fixtures.test.cjs ts/test/*.test.mjs
all files | line 90.53% | branch 71.57% | funcs 92.65%
```

### Full THE-2158 gate chain

```text
$ make test && ./scripts/verify-contract-tests.sh && ./scripts/verify-api-snapshots.sh && make rubric
make test: PASS
version-alignment: PASS (1.13.2)
contract-tests(go): PASS (133 fixtures)
contract-tests(ts): PASS (133 fixtures)
contract-tests(py): PASS (133 fixtures)
contract-tests: PASS
api-snapshots: PASS

=== GovTheory Rubric Verifier ===
Project: AppTheory
Report written to: gov-infra/evidence/gov-rubric-report.json

=== Summary ===
Status: PASS
Pass: 29
Fail: 0
Blocked: 0
rubric: PASS

QUA-3 evidence summary:
Go total coverage: 90.1% >= 90%
TypeScript all files line coverage: 90.55% >= 90%
Python coverage: PASS
```

## Commit signature status

Verified with `git log --show-signature --format=fuller --reverse origin/factory/m15-aws-lambda-microvm-support..HEAD`:

```text
ce45d3e5cb61088ddd607334968a942c7d5c1257 fix(microvm): require complete TypeScript session records
Good "git" signature for aron23@gmail.com with ED25519 key SHA256:q7HPwpHpeTN3JDe9vzuMxby+Nc1n4trLrVNWUL7pzE8

7fea25981cb5900bd4a8be9bbb92fcd08545cc24 test(microvm): cover final gate session paths
Good "git" signature for aron23@gmail.com with ED25519 key SHA256:q7HPwpHpeTN3JDe9vzuMxby+Nc1n4trLrVNWUL7pzE8
```

## Evidence-bound note

`make rubric` produced local GovTheory evidence under `gov-infra/evidence`, but no evidence report/log files are included in this PR. The final worktree was clean before opening this PR.
