### PR TITLE
feat(microvm): add Go Lambda MicroVM provider adapter

### DIFF
--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2972,6 +2972,12 @@ const ErrorCodeLifecycleIncomplete = "m15.microvm.lifecycle_incomplete"
 
 const ErrorCodeOperationContractIncomplete = "m16.microvm.operation_contract_incomplete"
 
+const ErrorCodeProviderOperationFailed = "m16.microvm.provider_operation_failed"
+
+const ErrorCodeProviderOperationUnsupported = "m16.microvm.provider_operation_unsupported"
+
+const ErrorCodeProviderRequestInvalid = "m16.microvm.provider_request_invalid"
+
 const ErrorCodeProviderStateMappingIncomplete = "m16.microvm.provider_state_mapping_incomplete"
 
 const ErrorCodeRawSDKEscapeHatch = "m15.microvm.raw_sdk_escape_hatch"
@@ -3069,6 +3075,13 @@ const StateTerminating LifecycleState = "terminating"
 const StateValidated LifecycleState = "validated"
 
 const StateValidating LifecycleState = "validating"
+
+type AWSLambdaMicroVMProvider struct {
+	api   lambdaMicroVMAPI
+	clock Clock
+}
+
+type AWSLambdaMicroVMProviderOption func(*awsLambdaMicroVMProviderConfig)
 
 type AuthContext struct {
 	Subject      string            `json:"subject"`
@@ -3264,10 +3277,118 @@ type OperationHTTPRouteContract struct {
 	ForbiddenFields []string  `json:"forbidden_fields,omitempty"`
 }
 
+type Provider interface {
+	Run(context.Context, ProviderRunInput) (ProviderSession, error)
+	Get(context.Context, ProviderSessionInput) (ProviderSession, error)
+	List(context.Context, ProviderListInput) (ProviderListOutput, error)
+	Suspend(context.Context, ProviderSessionInput) (ProviderSession, error)
+	Resume(context.Context, ProviderSessionInput) (ProviderSession, error)
+	Terminate(context.Context, ProviderSessionInput) (ProviderSession, error)
+	CreateAuthToken(context.Context, ProviderTokenInput) (ProviderToken, error)
+	CreateShellToken(context.Context, ProviderTokenInput) (ProviderToken, error)
+}
+
+type ProviderIdlePolicy struct {
+	AutoResumeEnabled        bool  `json:"auto_resume_enabled"`
+	MaxIdleDurationSeconds   int32 `json:"max_idle_duration_seconds"`
+	SuspendedDurationSeconds int32 `json:"suspended_duration_seconds"`
+}
+
+type ProviderListInput struct {
+	RequestID     string                   `json:"request_id"`
+	TenantID      string                   `json:"tenant_id"`
+	Namespace     string                   `json:"namespace"`
+	AuthContext   AuthContext              `json:"auth_context"`
+	ImageRef      string                   `json:"image_ref,omitempty"`
+	ImageVersion  string                   `json:"image_version,omitempty"`
+	MaxResults    int32                    `json:"max_results,omitempty"`
+	KnownSessions []ProviderSessionBinding `json:"known_sessions,omitempty"`
+}
+
+type ProviderListOutput struct {
+	Sessions       []ProviderSession `json:"sessions"`
+	RecoveryCursor string            `json:"recovery_cursor,omitempty"`
+}
+
+type ProviderPortScope struct {
+	AllPorts  bool  `json:"all_ports,omitempty"`
+	Port      int32 `json:"port,omitempty"`
+	StartPort int32 `json:"start_port,omitempty"`
+	EndPort   int32 `json:"end_port,omitempty"`
+}
+
+type ProviderRunInput struct {
+	RequestID                   string              `json:"request_id"`
+	TenantID                    string              `json:"tenant_id"`
+	Namespace                   string              `json:"namespace"`
+	SessionID                   string              `json:"session_id"`
+	AuthContext                 AuthContext         `json:"auth_context"`
+	ImageRef                    string              `json:"image_ref"`
+	ImageVersion                string              `json:"image_version,omitempty"`
+	NetworkConnectorRef         string              `json:"network_connector_ref,omitempty"`
+	IngressNetworkConnectorRefs []string            `json:"ingress_network_connector_refs,omitempty"`
+	EgressNetworkConnectorRefs  []string            `json:"egress_network_connector_refs,omitempty"`
+	SessionSpec                 SessionSpec         `json:"session_spec,omitempty"`
+	IdlePolicy                  *ProviderIdlePolicy `json:"idle_policy,omitempty"`
+	MaximumDurationSeconds      int32               `json:"maximum_duration_seconds,omitempty"`
+}
+
+type ProviderSession struct {
+	TenantID          string         `json:"tenant_id"`
+	Namespace         string         `json:"namespace"`
+	SessionID         string         `json:"session_id"`
+	ProviderMicroVMID string         `json:"provider_microvm_id"`
+	State             LifecycleState `json:"state"`
+	ProviderState     string         `json:"provider_state"`
+	ImageRef          string         `json:"image_ref,omitempty"`
+	ImageVersion      string         `json:"image_version,omitempty"`
+	StartedAt         time.Time      `json:"started_at,omitempty"`
+	TerminatedAt      time.Time      `json:"terminated_at,omitempty"`
+	RegistryVersion   int64          `json:"registry_version,omitempty"`
+	Terminal          bool           `json:"terminal,omitempty"`
+}
+
+type ProviderSessionBinding struct {
+	TenantID          string `json:"tenant_id"`
+	Namespace         string `json:"namespace"`
+	SessionID         string `json:"session_id"`
+	ProviderMicroVMID string `json:"provider_microvm_id"`
+	RegistryVersion   int64  `json:"registry_version,omitempty"`
+}
+
+type ProviderSessionInput struct {
+	RequestID   string                 `json:"request_id"`
+	TenantID    string                 `json:"tenant_id"`
+	Namespace   string                 `json:"namespace"`
+	AuthContext AuthContext            `json:"auth_context"`
+	Binding     ProviderSessionBinding `json:"binding"`
+}
+
 type ProviderStateMapping struct {
 	ProviderState string         `json:"provider_state"`
 	State         LifecycleState `json:"state"`
 	Terminal      bool           `json:"terminal"`
+}
+
+type ProviderToken struct {
+	TenantID          string    `json:"tenant_id"`
+	Namespace         string    `json:"namespace"`
+	SessionID         string    `json:"session_id"`
+	ProviderMicroVMID string    `json:"provider_microvm_id"`
+	TokenID           string    `json:"token_id"`
+	TokenType         string    `json:"token_type"`
+	ExpiresAt         time.Time `json:"expires_at"`
+	Scope             []string  `json:"scope"`
+}
+
+type ProviderTokenInput struct {
+	RequestID        string                 `json:"request_id"`
+	TenantID         string                 `json:"tenant_id"`
+	Namespace        string                 `json:"namespace"`
+	AuthContext      AuthContext            `json:"auth_context"`
+	Binding          ProviderSessionBinding `json:"binding"`
+	TTLSeconds       int32                  `json:"ttl_seconds,omitempty"`
+	AllowedPortScope []ProviderPortScope    `json:"allowed_port_scope,omitempty"`
 }
 
 type RegistryClient struct {
@@ -3424,6 +3545,10 @@ func DefaultSessionRegistryContract() SessionRegistryContract
 
 func IsTerminalState(LifecycleState) bool
 
+func MapProviderState(string) (LifecycleState, bool, error)
+
+func NewAWSLambdaMicroVMProvider(context.Context, ...AWSLambdaMicroVMProviderOption) (*AWSLambdaMicroVMProvider, error)
+
 func NewController(Client, ...ControllerOption) (*Controller, error)
 
 func NewLifecycleAdapter(...LifecycleOption) (*LifecycleAdapter, error)
@@ -3456,6 +3581,18 @@ func ValidateLifecycleContract(LifecycleContract) error
 
 func ValidateOperationContract(OperationContract) error
 
+func ValidateProviderListInput(ProviderListInput) error
+
+func ValidateProviderRunInput(ProviderRunInput) error
+
+func ValidateProviderSession(ProviderSession) error
+
+func ValidateProviderSessionInput(Operation, ProviderSessionInput) error
+
+func ValidateProviderToken(ProviderToken) error
+
+func ValidateProviderTokenInput(Operation, ProviderTokenInput) error
+
 func ValidateRealLifecycleContract(LifecycleContract) error
 
 func ValidateSessionRecord(SessionRecord) error
@@ -3465,6 +3602,10 @@ func ValidateSessionRegistryContract(SessionRegistryContract) error
 func ValidateSessionRegistryRecord(SessionRegistryRecord) error
 
 func ValidateSessionStatus(SessionStatus) error
+
+func WithAWSLambdaMicroVMClock(Clock) AWSLambdaMicroVMProviderOption
+
+func WithAWSLambdaMicroVMRegion(string) AWSLambdaMicroVMProviderOption
 
 func WithControllerClock(Clock) ControllerOption
 
@@ -3477,6 +3618,22 @@ func WithLifecycleContract(LifecycleContract) LifecycleOption
 func WithLifecycleHandler(LifecycleHook, LifecycleHandler) LifecycleOption
 
 func WithRegistryClientTTL(time.Duration) RegistryClientOption
+
+func (*AWSLambdaMicroVMProvider) CreateAuthToken(context.Context, ProviderTokenInput) (ProviderToken, error)
+
+func (*AWSLambdaMicroVMProvider) CreateShellToken(context.Context, ProviderTokenInput) (ProviderToken, error)
+
+func (*AWSLambdaMicroVMProvider) Get(context.Context, ProviderSessionInput) (ProviderSession, error)
+
+func (*AWSLambdaMicroVMProvider) List(context.Context, ProviderListInput) (ProviderListOutput, error)
+
+func (*AWSLambdaMicroVMProvider) Resume(context.Context, ProviderSessionInput) (ProviderSession, error)
+
+func (*AWSLambdaMicroVMProvider) Run(context.Context, ProviderRunInput) (ProviderSession, error)
+
+func (*AWSLambdaMicroVMProvider) Suspend(context.Context, ProviderSessionInput) (ProviderSession, error)
+
+func (*AWSLambdaMicroVMProvider) Terminate(context.Context, ProviderSessionInput) (ProviderSession, error)
 
 func (*Controller) Handle(context.Context, ControllerRequest) (ControllerResponse, error)
 
@@ -3503,6 +3660,12 @@ func (*TableTheorySessionRegistry) Delete(context.Context, SessionKey) error
 func (*TableTheorySessionRegistry) Get(context.Context, SessionKey) (SessionRecord, error)
 
 func (*TableTheorySessionRegistry) Put(context.Context, SessionRecord) (SessionRecord, error)
+
+func (ProviderSession) Binding() ProviderSessionBinding
+
+func (ProviderSession) Key() SessionKey
+
+func (ProviderSessionBinding) Key() SessionKey
 
 func (SafeError) Error() string
 
@@ -4074,9 +4237,31 @@ type FakeClient struct {
 	calls    []Call
 }
 
+type FakeProvider struct {
+	mu       sync.Mutex
+	now      time.Time
+	next     int64
+	tokens   int64
+	sessions map[runtimemicrovm.SessionKey]runtimemicrovm.ProviderSession
+	errors   map[runtimemicrovm.Operation]error
+	calls    []ProviderCall
+}
+
+type ProviderCall struct {
+	Operation runtimemicrovm.Operation
+	RequestID string
+	TenantID  string
+	Namespace string
+	SessionID string
+}
+
 func NewFakeClient() *FakeClient
 
 func NewFakeClientWithTime(time.Time) *FakeClient
+
+func NewFakeProvider() *FakeProvider
+
+func NewFakeProviderWithTime(time.Time) *FakeProvider
 
 func (*FakeClient) Calls() []Call
 
@@ -4091,6 +4276,28 @@ func (*FakeClient) Start(context.Context, runtimemicrovm.SessionCommandInput) (r
 func (*FakeClient) Status(context.Context, runtimemicrovm.SessionQueryInput) (runtimemicrovm.SessionStatus, error)
 
 func (*FakeClient) Stop(context.Context, runtimemicrovm.SessionCommandInput) (runtimemicrovm.SessionRecord, error)
+
+func (*FakeProvider) Calls() []ProviderCall
+
+func (*FakeProvider) CreateAuthToken(context.Context, runtimemicrovm.ProviderTokenInput) (runtimemicrovm.ProviderToken, error)
+
+func (*FakeProvider) CreateShellToken(context.Context, runtimemicrovm.ProviderTokenInput) (runtimemicrovm.ProviderToken, error)
+
+func (*FakeProvider) Get(context.Context, runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error)
+
+func (*FakeProvider) List(context.Context, runtimemicrovm.ProviderListInput) (runtimemicrovm.ProviderListOutput, error)
+
+func (*FakeProvider) Resume(context.Context, runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error)
+
+func (*FakeProvider) Run(context.Context, runtimemicrovm.ProviderRunInput) (runtimemicrovm.ProviderSession, error)
+
+func (*FakeProvider) SetNow(time.Time)
+
+func (*FakeProvider) SetOperationError(runtimemicrovm.Operation, error)
+
+func (*FakeProvider) Suspend(context.Context, runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error)
+
+func (*FakeProvider) Terminate(context.Context, runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error)
 
 ## github.com/theory-cloud/apptheory/testkit/oauth
 

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.26.4
 require (
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.254.0
 	github.com/aws/aws-lambda-go v1.54.0
-	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.18
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.17
 	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.13
+	github.com/aws/aws-sdk-go-v2/service/lambdamicrovms v1.0.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.14
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24
@@ -26,8 +27,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
@@ -40,7 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.273 // indirect
 	github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.1.1 // indirect
 	github.com/cdklabs/cloud-assembly-schema-go/awscdkcloudassemblyschema/v53 v53.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/aws/aws-cdk-go/awscdk/v2 v2.254.0 h1:QNonhAkHShr5U5cRBbYWjr1UdfLqpsof
 github.com/aws/aws-cdk-go/awscdk/v2 v2.254.0/go.mod h1:pCjdZvx+EIsZN4UXwdwoswrnY9qjfKqDuS2glIEUTUM=
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
-github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.18 h1:Hcia46bxhGgF3BaSnG8nSNCWmqTK6bj9xN9/FJ3WK6Q=
@@ -14,10 +14,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.17 h1:gP2nkGsS+KMvF/jfFz2Vv2qiiOq
 github.com/aws/aws-sdk-go-v2/credentials v1.19.17/go.mod h1:Bsew3S/moG5iT77giPj1q8wb/s0RE5/QfH+ASjYtuQc=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 h1:UuSfcORqNSz/ey3VPRS8TcVH2Ikf0/sC+Hdj400QI6U=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23/go.mod h1:+G/OSGiOFnSOkYloKj/9M35s74LgVAdJBSD5lsFfqKg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.13 h1:357Yo8n9E3WKIpei+mWQYVsIXMUM+c81J0LMYWjIGVc=
@@ -36,6 +36,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 h1:QNtg+Mtj1zmepk568+UKBD5DFfqh+ESTUUqQT27JkQc=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
+github.com/aws/aws-sdk-go-v2/service/lambdamicrovms v1.0.0 h1:qa/AtKpemXSA3j2Dd0Kbn0ca28DzovHGcAJw/BWG5MY=
+github.com/aws/aws-sdk-go-v2/service/lambdamicrovms v1.0.0/go.mod h1:BFBNLB3qFLgK+nid2Y6Wp2sXz4wj4Fv7WAFYPxUisHM=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
@@ -54,8 +56,8 @@ github.com/aws/constructs-go/constructs/v10 v10.6.0 h1:fYUtscoB7dhGXBFuO1o6qvgYz
 github.com/aws/constructs-go/constructs/v10 v10.6.0/go.mod h1:/OFJ5HMGSjXyjQ4mNz32+XGA7S0S3ZWDXYtBSAuurEE=
 github.com/aws/jsii-runtime-go v1.129.0 h1:HirIS6zroS7KXW9flKeK8Yai9g7K6VGPOY6bg42bECQ=
 github.com/aws/jsii-runtime-go v1.129.0/go.mod h1:+Hxuq6OMXQjzeApX0FpitOW9H6bC3nYAvTP3d2jfF+U=
-github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
-github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.273 h1:wFlYbk2NsBLXdToVoLe+BoOBzqYOEGvSc3fIurb/OWQ=
 github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.273/go.mod h1:ZxUAw5ZFmnTmJZCzXAhovthmd8xUf3TstT9gRXU54Go=
 github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.1.1 h1:qYRuYGUp/84mhbCl52EbURK01Z+AkAMIF3NZo4pQ+bI=

--- a/runtime/microvm/aws_provider.go
+++ b/runtime/microvm/aws_provider.go
@@ -1,0 +1,411 @@
+package microvm
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/lambdamicrovms"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambdamicrovms/types"
+)
+
+// AWSLambdaMicroVMProvider is the official AWS SDK-backed constrained provider adapter.
+//
+// The raw AWS SDK client and loaded AWS configuration remain private implementation details.
+type AWSLambdaMicroVMProvider struct {
+	api   lambdaMicroVMAPI
+	clock Clock
+}
+
+// AWSLambdaMicroVMProviderOption configures the official AWS Lambda MicroVM provider adapter.
+type AWSLambdaMicroVMProviderOption func(*awsLambdaMicroVMProviderConfig)
+
+type awsLambdaMicroVMProviderConfig struct {
+	region string
+	clock  Clock
+}
+
+type lambdaMicroVMAPI interface {
+	RunMicrovm(context.Context, *lambdamicrovms.RunMicrovmInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.RunMicrovmOutput, error)
+	GetMicrovm(context.Context, *lambdamicrovms.GetMicrovmInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.GetMicrovmOutput, error)
+	ListMicrovms(context.Context, *lambdamicrovms.ListMicrovmsInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.ListMicrovmsOutput, error)
+	SuspendMicrovm(context.Context, *lambdamicrovms.SuspendMicrovmInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.SuspendMicrovmOutput, error)
+	ResumeMicrovm(context.Context, *lambdamicrovms.ResumeMicrovmInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.ResumeMicrovmOutput, error)
+	TerminateMicrovm(context.Context, *lambdamicrovms.TerminateMicrovmInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.TerminateMicrovmOutput, error)
+	CreateMicrovmAuthToken(context.Context, *lambdamicrovms.CreateMicrovmAuthTokenInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.CreateMicrovmAuthTokenOutput, error)
+	CreateMicrovmShellAuthToken(context.Context, *lambdamicrovms.CreateMicrovmShellAuthTokenInput, ...func(*lambdamicrovms.Options)) (*lambdamicrovms.CreateMicrovmShellAuthTokenOutput, error)
+}
+
+var _ Provider = (*AWSLambdaMicroVMProvider)(nil)
+
+// WithAWSLambdaMicroVMRegion sets the AWS region used by the official provider adapter.
+func WithAWSLambdaMicroVMRegion(region string) AWSLambdaMicroVMProviderOption {
+	return func(config *awsLambdaMicroVMProviderConfig) {
+		if config == nil {
+			return
+		}
+		config.region = strings.TrimSpace(region)
+	}
+}
+
+// WithAWSLambdaMicroVMClock sets the clock used for sanitized token metadata.
+func WithAWSLambdaMicroVMClock(clock Clock) AWSLambdaMicroVMProviderOption {
+	return func(config *awsLambdaMicroVMProviderConfig) {
+		if config == nil {
+			return
+		}
+		if clock == nil {
+			config.clock = realClock{}
+			return
+		}
+		config.clock = clock
+	}
+}
+
+// NewAWSLambdaMicroVMProvider creates an official AWS SDK-backed constrained provider adapter.
+//
+// AWS credentials and the raw SDK client are loaded and retained internally; callers receive only
+// the AppTheory Provider interface implemented by the returned adapter.
+func NewAWSLambdaMicroVMProvider(ctx context.Context, opts ...AWSLambdaMicroVMProviderOption) (*AWSLambdaMicroVMProvider, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	config := awsLambdaMicroVMProviderConfig{clock: realClock{}}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&config)
+		}
+	}
+	loadOptions := []func(*awsconfig.LoadOptions) error{}
+	if config.region != "" {
+		loadOptions = append(loadOptions, awsconfig.WithRegion(config.region))
+	}
+	awsConfig, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
+	if err != nil {
+		return nil, sanitizeProviderError(err, "")
+	}
+	return &AWSLambdaMicroVMProvider{
+		api:   lambdamicrovms.NewFromConfig(awsConfig),
+		clock: config.clock,
+	}, nil
+}
+
+// Run maps a safe AppTheory run request to the official AWS RunMicrovm operation.
+func (p *AWSLambdaMicroVMProvider) Run(ctx context.Context, input ProviderRunInput) (ProviderSession, error) {
+	input, err := validateProviderRunInput(input)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	api, err := p.requireAPI(input.RequestID)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	out, err := api.RunMicrovm(ctxOrBackground(ctx), &lambdamicrovms.RunMicrovmInput{
+		ImageIdentifier:          aws.String(input.ImageRef),
+		ClientToken:              aws.String(input.RequestID),
+		EgressNetworkConnectors:  providerEgressConnectors(input),
+		ImageVersion:             optionalString(input.ImageVersion),
+		IngressNetworkConnectors: input.IngressNetworkConnectorRefs,
+		IdlePolicy:               awsIdlePolicy(input.IdlePolicy),
+		MaximumDurationInSeconds: optionalInt32(input.MaximumDurationSeconds),
+		RunHookPayload:           safeRunHookPayload(input),
+	})
+	if err != nil {
+		return ProviderSession{}, sanitizeProviderError(err, input.RequestID)
+	}
+	return sessionFromRunOutput(input, out)
+}
+
+// Get maps a safe AppTheory get request to the official AWS GetMicrovm operation.
+func (p *AWSLambdaMicroVMProvider) Get(ctx context.Context, input ProviderSessionInput) (ProviderSession, error) {
+	input, err := validateProviderSessionInput(OperationGet, input)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	api, err := p.requireAPI(input.RequestID)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	out, err := api.GetMicrovm(ctxOrBackground(ctx), &lambdamicrovms.GetMicrovmInput{
+		MicrovmIdentifier: aws.String(input.Binding.ProviderMicroVMID),
+	})
+	if err != nil {
+		return ProviderSession{}, sanitizeProviderError(err, input.RequestID)
+	}
+	return sessionFromGetOutput(input.RequestID, input.Binding, out)
+}
+
+// List maps a tenant-bound AppTheory list request to the official AWS ListMicrovms operation.
+func (p *AWSLambdaMicroVMProvider) List(ctx context.Context, input ProviderListInput) (ProviderListOutput, error) {
+	input, err := validateProviderListInput(input)
+	if err != nil {
+		return ProviderListOutput{}, err
+	}
+	api, err := p.requireAPI(input.RequestID)
+	if err != nil {
+		return ProviderListOutput{}, err
+	}
+	out, err := api.ListMicrovms(ctxOrBackground(ctx), &lambdamicrovms.ListMicrovmsInput{
+		ImageIdentifier: optionalString(input.ImageRef),
+		ImageVersion:    optionalString(input.ImageVersion),
+		MaxResults:      optionalInt32(input.MaxResults),
+	})
+	if err != nil {
+		return ProviderListOutput{}, sanitizeProviderError(err, input.RequestID)
+	}
+	return listOutputFromSDK(input, out)
+}
+
+// Suspend maps a safe AppTheory suspend request to the official AWS SuspendMicrovm operation.
+func (p *AWSLambdaMicroVMProvider) Suspend(ctx context.Context, input ProviderSessionInput) (ProviderSession, error) {
+	return p.runStateChangingOperation(ctx, OperationSuspend, input, func(ctx context.Context, api lambdaMicroVMAPI, providerID string) error {
+		_, err := api.SuspendMicrovm(ctx, &lambdamicrovms.SuspendMicrovmInput{MicrovmIdentifier: aws.String(providerID)})
+		return err
+	})
+}
+
+// Resume maps a safe AppTheory resume request to the official AWS ResumeMicrovm operation.
+func (p *AWSLambdaMicroVMProvider) Resume(ctx context.Context, input ProviderSessionInput) (ProviderSession, error) {
+	return p.runStateChangingOperation(ctx, OperationResume, input, func(ctx context.Context, api lambdaMicroVMAPI, providerID string) error {
+		_, err := api.ResumeMicrovm(ctx, &lambdamicrovms.ResumeMicrovmInput{MicrovmIdentifier: aws.String(providerID)})
+		return err
+	})
+}
+
+// Terminate maps a safe AppTheory terminate request to the official AWS TerminateMicrovm operation.
+func (p *AWSLambdaMicroVMProvider) Terminate(ctx context.Context, input ProviderSessionInput) (ProviderSession, error) {
+	return p.runStateChangingOperation(ctx, OperationTerminate, input, func(ctx context.Context, api lambdaMicroVMAPI, providerID string) error {
+		_, err := api.TerminateMicrovm(ctx, &lambdamicrovms.TerminateMicrovmInput{MicrovmIdentifier: aws.String(providerID)})
+		return err
+	})
+}
+
+// CreateAuthToken maps a safe AppTheory auth-token request to the official AWS token operation.
+func (p *AWSLambdaMicroVMProvider) CreateAuthToken(ctx context.Context, input ProviderTokenInput) (ProviderToken, error) {
+	input, err := validateProviderTokenInput(OperationAuthToken, input)
+	if err != nil {
+		return ProviderToken{}, err
+	}
+	api, err := p.requireAPI(input.RequestID)
+	if err != nil {
+		return ProviderToken{}, err
+	}
+	out, err := api.CreateMicrovmAuthToken(ctxOrBackground(ctx), &lambdamicrovms.CreateMicrovmAuthTokenInput{
+		MicrovmIdentifier:   aws.String(input.Binding.ProviderMicroVMID),
+		ExpirationInMinutes: aws.Int32(providerExpirationMinutes(input.TTLSeconds)),
+		AllowedPorts:        awsPortScopes(input.AllowedPortScope),
+	})
+	if err != nil {
+		return ProviderToken{}, sanitizeProviderError(err, input.RequestID)
+	}
+	if len(out.AuthToken) == 0 {
+		return ProviderToken{}, safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider returned incomplete token metadata", input.RequestID)
+	}
+	return providerTokenMetadata(OperationAuthToken, input, p.now())
+}
+
+// CreateShellToken maps a safe AppTheory shell-token request to the official AWS token operation.
+func (p *AWSLambdaMicroVMProvider) CreateShellToken(ctx context.Context, input ProviderTokenInput) (ProviderToken, error) {
+	input, err := validateProviderTokenInput(OperationShellToken, input)
+	if err != nil {
+		return ProviderToken{}, err
+	}
+	api, err := p.requireAPI(input.RequestID)
+	if err != nil {
+		return ProviderToken{}, err
+	}
+	out, err := api.CreateMicrovmShellAuthToken(ctxOrBackground(ctx), &lambdamicrovms.CreateMicrovmShellAuthTokenInput{
+		MicrovmIdentifier:   aws.String(input.Binding.ProviderMicroVMID),
+		ExpirationInMinutes: aws.Int32(providerExpirationMinutes(input.TTLSeconds)),
+	})
+	if err != nil {
+		return ProviderToken{}, sanitizeProviderError(err, input.RequestID)
+	}
+	if len(out.AuthToken) == 0 {
+		return ProviderToken{}, safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider returned incomplete token metadata", input.RequestID)
+	}
+	return providerTokenMetadata(OperationShellToken, input, p.now())
+}
+
+func (p *AWSLambdaMicroVMProvider) runStateChangingOperation(
+	ctx context.Context,
+	operation Operation,
+	input ProviderSessionInput,
+	run func(context.Context, lambdaMicroVMAPI, string) error,
+) (ProviderSession, error) {
+	input, err := validateProviderSessionInput(operation, input)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	api, err := p.requireAPI(input.RequestID)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	ctx = ctxOrBackground(ctx)
+	if runErr := run(ctx, api, input.Binding.ProviderMicroVMID); runErr != nil {
+		return ProviderSession{}, sanitizeProviderError(runErr, input.RequestID)
+	}
+	out, err := api.GetMicrovm(ctx, &lambdamicrovms.GetMicrovmInput{
+		MicrovmIdentifier: aws.String(input.Binding.ProviderMicroVMID),
+	})
+	if err != nil {
+		return ProviderSession{}, sanitizeProviderError(err, input.RequestID)
+	}
+	return sessionFromGetOutput(input.RequestID, input.Binding, out)
+}
+
+func (p *AWSLambdaMicroVMProvider) requireAPI(requestID string) (lambdaMicroVMAPI, error) {
+	if p == nil || p.api == nil {
+		return nil, safeError(ErrorCodeProviderOperationFailed, "apptheory: microvm provider adapter requires official AWS Lambda MicroVM SDK client", requestID)
+	}
+	return p.api, nil
+}
+
+func (p *AWSLambdaMicroVMProvider) now() time.Time {
+	if p == nil || p.clock == nil {
+		return time.Unix(0, 0).UTC()
+	}
+	now := p.clock.Now()
+	if now.IsZero() {
+		return time.Unix(0, 0).UTC()
+	}
+	return now.UTC()
+}
+
+func sessionFromRunOutput(input ProviderRunInput, out *lambdamicrovms.RunMicrovmOutput) (ProviderSession, error) {
+	if out == nil {
+		return ProviderSession{}, safeError(ErrorCodeProviderOperationFailed, "apptheory: microvm provider run returned no result", input.RequestID)
+	}
+	binding := ProviderSessionBinding{
+		TenantID:          input.TenantID,
+		Namespace:         input.Namespace,
+		SessionID:         input.SessionID,
+		ProviderMicroVMID: aws.ToString(out.MicrovmId),
+	}
+	return sessionFromProviderState(binding, string(out.State), aws.ToString(out.ImageArn), aws.ToString(out.ImageVersion), timeFromPtr(out.StartedAt), timeFromPtr(out.TerminatedAt))
+}
+
+func sessionFromGetOutput(requestID string, binding ProviderSessionBinding, out *lambdamicrovms.GetMicrovmOutput) (ProviderSession, error) {
+	if out == nil {
+		return ProviderSession{}, safeError(ErrorCodeProviderOperationFailed, "apptheory: microvm provider get returned no result", requestID)
+	}
+	providerID := aws.ToString(out.MicrovmId)
+	if providerID != "" && providerID != binding.ProviderMicroVMID {
+		return ProviderSession{}, safeError(ErrorCodeTenantBindingViolation, "apptheory: microvm provider returned mismatched session binding", requestID)
+	}
+	return sessionFromProviderState(binding, string(out.State), aws.ToString(out.ImageArn), aws.ToString(out.ImageVersion), timeFromPtr(out.StartedAt), timeFromPtr(out.TerminatedAt))
+}
+
+func listOutputFromSDK(input ProviderListInput, out *lambdamicrovms.ListMicrovmsOutput) (ProviderListOutput, error) {
+	if out == nil {
+		return ProviderListOutput{}, safeError(ErrorCodeProviderOperationFailed, "apptheory: microvm provider list returned no result", input.RequestID)
+	}
+	bindings := map[string]ProviderSessionBinding{}
+	for _, binding := range input.KnownSessions {
+		bindings[binding.ProviderMicroVMID] = binding
+	}
+	sessions := make([]ProviderSession, 0, len(out.Items))
+	for _, item := range out.Items {
+		providerID := aws.ToString(item.MicrovmId)
+		binding, ok := bindings[providerID]
+		if !ok {
+			continue
+		}
+		session, err := sessionFromProviderState(binding, string(item.State), aws.ToString(item.ImageArn), aws.ToString(item.ImageVersion), timeFromPtr(item.StartedAt), time.Time{})
+		if err != nil {
+			return ProviderListOutput{}, err
+		}
+		sessions = append(sessions, session)
+	}
+	return ProviderListOutput{Sessions: sessions}, nil
+}
+
+func awsIdlePolicy(policy *ProviderIdlePolicy) *lambdatypes.IdlePolicy {
+	if policy == nil {
+		return nil
+	}
+	return &lambdatypes.IdlePolicy{
+		AutoResumeEnabled:        aws.Bool(policy.AutoResumeEnabled),
+		MaxIdleDurationSeconds:   aws.Int32(policy.MaxIdleDurationSeconds),
+		SuspendedDurationSeconds: aws.Int32(policy.SuspendedDurationSeconds),
+	}
+}
+
+func awsPortScopes(scopes []ProviderPortScope) []lambdatypes.PortSpecification {
+	out := make([]lambdatypes.PortSpecification, 0, len(scopes))
+	for _, scope := range scopes {
+		switch {
+		case scope.AllPorts:
+			out = append(out, &lambdatypes.PortSpecificationMemberAllPorts{Value: lambdatypes.Unit{}})
+		case scope.Port > 0:
+			out = append(out, &lambdatypes.PortSpecificationMemberPort{Value: scope.Port})
+		default:
+			out = append(out, &lambdatypes.PortSpecificationMemberRange{
+				Value: lambdatypes.PortRange{
+					StartPort: aws.Int32(scope.StartPort),
+					EndPort:   aws.Int32(scope.EndPort),
+				},
+			})
+		}
+	}
+	return out
+}
+
+func providerEgressConnectors(input ProviderRunInput) []string {
+	connectors := append([]string{}, input.EgressNetworkConnectorRefs...)
+	if input.NetworkConnectorRef != "" {
+		connectors = append(connectors, input.NetworkConnectorRef)
+	}
+	return normalizeStringSlice(connectors)
+}
+
+func safeRunHookPayload(input ProviderRunInput) *string {
+	payload := map[string]string{
+		"request_id": input.RequestID,
+		"tenant_id":  input.TenantID,
+		"namespace":  input.Namespace,
+		"session_id": input.SessionID,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	return aws.String(string(data))
+}
+
+func optionalString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return aws.String(value)
+}
+
+func optionalInt32(value int32) *int32 {
+	if value <= 0 {
+		return nil
+	}
+	return aws.Int32(value)
+}
+
+func timeFromPtr(value *time.Time) time.Time {
+	if value == nil || value.IsZero() {
+		return time.Time{}
+	}
+	return value.UTC()
+}
+
+func providerExpirationMinutes(ttlSeconds int32) int32 {
+	return int32(math.Ceil(float64(ttlSeconds) / 60.0))
+}
+
+func ctxOrBackground(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}

--- a/runtime/microvm/aws_provider_test.go
+++ b/runtime/microvm/aws_provider_test.go
@@ -1,0 +1,543 @@
+package microvm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambdamicrovms"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambdamicrovms/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSLambdaMicroVMProviderMapsOfficialSDKOperations(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	api := newRecordingLambdaMicroVMAPI(now)
+	provider := &AWSLambdaMicroVMProvider{api: api, clock: providerClock{now: now}}
+
+	run, err := provider.Run(context.Background(), validProviderRunInput())
+	require.NoError(t, err)
+	require.Equal(t, "provider-1", run.ProviderMicroVMID)
+	require.Equal(t, StateRunning, run.State)
+	require.Equal(t, "running", run.ProviderState)
+	require.Equal(t, "image-ref", aws.ToString(api.runInput.ImageIdentifier))
+	require.Equal(t, "req-run", aws.ToString(api.runInput.ClientToken))
+	require.Equal(t, []string{"egress-ref", "network-ref"}, api.runInput.EgressNetworkConnectors)
+	require.Equal(t, []string{"ingress-ref"}, api.runInput.IngressNetworkConnectors)
+	require.NotNil(t, api.runInput.RunHookPayload)
+	require.NotContains(t, aws.ToString(api.runInput.RunHookPayload), "raw_lifecycle_hook_payload")
+
+	binding := run.Binding()
+	got, err := provider.Get(context.Background(), validProviderSessionInput("req-get", binding))
+	require.NoError(t, err)
+	require.Equal(t, binding, got.Binding())
+
+	list, err := provider.List(context.Background(), ProviderListInput{
+		RequestID:     "req-list",
+		TenantID:      "tenant-1",
+		Namespace:     "namespace-1",
+		AuthContext:   validProviderAuth(),
+		KnownSessions: []ProviderSessionBinding{binding},
+	})
+	require.NoError(t, err)
+	require.Len(t, list.Sessions, 1)
+	require.Empty(t, list.RecoveryCursor, "raw provider pagination tokens must not cross the AppTheory boundary")
+
+	suspended, err := provider.Suspend(context.Background(), validProviderSessionInput("req-suspend", binding))
+	require.NoError(t, err)
+	require.Equal(t, StateSuspended, suspended.State)
+
+	resumed, err := provider.Resume(context.Background(), validProviderSessionInput("req-resume", binding))
+	require.NoError(t, err)
+	require.Equal(t, StateRunning, resumed.State)
+
+	terminated, err := provider.Terminate(context.Background(), validProviderSessionInput("req-terminate", binding))
+	require.NoError(t, err)
+	require.Equal(t, StateTerminated, terminated.State)
+	require.True(t, terminated.Terminal)
+
+	authToken, err := provider.CreateAuthToken(context.Background(), validProviderTokenInput("req-auth", binding))
+	require.NoError(t, err)
+	require.Equal(t, "auth", authToken.TokenType)
+	require.Equal(t, int32(2), aws.ToInt32(api.authTokenInput.ExpirationInMinutes))
+	require.Len(t, api.authTokenInput.AllowedPorts, 1)
+
+	shellToken, err := provider.CreateShellToken(context.Background(), validProviderTokenInput("req-shell", binding))
+	require.NoError(t, err)
+	require.Equal(t, "shell", shellToken.TokenType)
+	require.Equal(t, []string{"shell"}, shellToken.Scope)
+
+	rawToken := recordingRawToken()
+	encoded, err := json.Marshal([]ProviderToken{authToken, shellToken})
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), rawToken)
+	require.NotContains(t, string(encoded), "X-aws-proxy-auth")
+	require.Subset(t, api.calls, []string{
+		"RunMicrovm",
+		"GetMicrovm",
+		"ListMicrovms",
+		"SuspendMicrovm",
+		"ResumeMicrovm",
+		"TerminateMicrovm",
+		"CreateMicrovmAuthToken",
+		"CreateMicrovmShellAuthToken",
+	})
+}
+
+func TestAWSLambdaMicroVMProviderFailsClosedAndSanitizes(t *testing.T) {
+	now := time.Unix(600, 0).UTC()
+	provider := &AWSLambdaMicroVMProvider{api: newRecordingLambdaMicroVMAPI(now), clock: providerClock{now: now}}
+
+	input := validProviderRunInput()
+	input.AuthContext = AuthContext{}
+	_, err := provider.Run(context.Background(), input)
+	requireSafeError(t, err, ErrorCodeUnauthenticatedController)
+
+	binding := ProviderSessionBinding{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1", ProviderMicroVMID: "provider-1"}
+	crossTenant := validProviderSessionInput("req-cross", binding)
+	crossTenant.TenantID = "tenant-2"
+	_, err = provider.Get(context.Background(), crossTenant)
+	requireSafeError(t, err, ErrorCodeTenantBindingViolation)
+
+	err = ValidateProviderSessionInput(Operation("debug"), validProviderSessionInput("req-unsupported", binding))
+	requireSafeError(t, err, ErrorCodeProviderOperationUnsupported)
+
+	rawErrAPI := newRecordingLambdaMicroVMAPI(now)
+	rawErrAPI.err = errors.New("provider failed with bearer_token and raw_sdk_client details")
+	provider = &AWSLambdaMicroVMProvider{api: rawErrAPI, clock: providerClock{now: now}}
+	_, err = provider.Get(context.Background(), validProviderSessionInput("req-raw", binding))
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+	require.NotContains(t, err.Error(), "bearer_token")
+	require.NotContains(t, err.Error(), "raw_sdk_client")
+
+	_, err = provider.Suspend(context.Background(), validProviderSessionInput("req-suspend-raw", binding))
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+
+	_, _, err = MapProviderState("provider-secret-state")
+	requireSafeError(t, err, ErrorCodeProviderStateMappingIncomplete)
+}
+
+func TestNewAWSLambdaMicroVMProviderUsesInternalSDKWithoutNetwork(t *testing.T) {
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_REGION", "us-east-1")
+	now := time.Unix(750, 0).UTC()
+
+	provider, err := NewAWSLambdaMicroVMProvider(
+		context.Background(),
+		WithAWSLambdaMicroVMRegion(" us-east-1 "),
+		WithAWSLambdaMicroVMClock(providerClock{now: now}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.NotNil(t, provider.api)
+	require.Equal(t, now, provider.now())
+
+	var config awsLambdaMicroVMProviderConfig
+	WithAWSLambdaMicroVMRegion(" us-west-2 ")(&config)
+	require.Equal(t, "us-west-2", config.region)
+	WithAWSLambdaMicroVMRegion("ignored")(nil)
+	WithAWSLambdaMicroVMClock(nil)(&config)
+	require.NotNil(t, config.clock)
+	WithAWSLambdaMicroVMClock(providerClock{now: now})(&config)
+	require.Equal(t, now, config.clock.Now())
+	WithAWSLambdaMicroVMClock(providerClock{now: now})(nil)
+}
+
+func TestProviderTokenValidationRejectsPlaintextFields(t *testing.T) {
+	token := ProviderToken{
+		TenantID:          "tenant-1",
+		Namespace:         "namespace-1",
+		SessionID:         "session-1",
+		ProviderMicroVMID: "provider-1",
+		TokenID:           "token_value",
+		TokenType:         "auth",
+		ExpiresAt:         time.Unix(700, 0).UTC(),
+		Scope:             []string{"ports:443"},
+	}
+	err := ValidateProviderToken(token)
+	requireSafeError(t, err, ErrorCodeTokenSafetyViolation)
+}
+
+func TestProviderValidationBranches(t *testing.T) {
+	run := validProviderRunInput()
+	require.NoError(t, ValidateProviderRunInput(run))
+	require.Equal(t, SessionKey{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1"}, ProviderSessionBinding{
+		TenantID:          " tenant-1 ",
+		Namespace:         " namespace-1 ",
+		SessionID:         " session-1 ",
+		ProviderMicroVMID: " provider-1 ",
+	}.Key())
+
+	state, terminal, err := MapProviderState("TERMINATED")
+	require.NoError(t, err)
+	require.Equal(t, StateTerminated, state)
+	require.True(t, terminal)
+	_, _, err = MapProviderState("")
+	requireSafeError(t, err, ErrorCodeProviderStateMappingIncomplete)
+
+	session := ProviderSession{
+		TenantID:          "tenant-1",
+		Namespace:         "namespace-1",
+		SessionID:         "session-1",
+		ProviderMicroVMID: "provider-1",
+		State:             StateTerminated,
+		ProviderState:     "terminated",
+		Terminal:          true,
+	}
+	require.NoError(t, ValidateProviderSession(session))
+	require.Equal(t, SessionKey{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1"}, session.Key())
+	require.Equal(t, session.Binding(), ProviderSession{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1", ProviderMicroVMID: "provider-1"}.Binding())
+
+	badSession := session
+	badSession.State = StateRunning
+	requireSafeError(t, ValidateProviderSession(badSession), ErrorCodeProviderStateMappingIncomplete)
+	badSession = session
+	badSession.ProviderMicroVMID = "raw_sdk_client"
+	requireSafeError(t, ValidateProviderSession(badSession), ErrorCodeForbiddenField)
+	requireSafeError(t, ValidateProviderSession(ProviderSession{}), ErrorCodeProviderRequestInvalid)
+
+	badRun := run
+	badRun.RequestID = ""
+	requireSafeError(t, ValidateProviderRunInput(badRun), ErrorCodeProviderRequestInvalid)
+	badRun = run
+	badRun.ImageRef = "raw_sdk_client"
+	requireSafeError(t, ValidateProviderRunInput(badRun), ErrorCodeForbiddenField)
+	badRun = run
+	badRun.SessionSpec.Metadata = map[string]string{"bearer_token": "value"}
+	requireSafeError(t, ValidateProviderRunInput(badRun), ErrorCodeForbiddenField)
+	badRun = run
+	badRun.NetworkConnectorRef = "raw_sdk_client"
+	requireSafeError(t, ValidateProviderRunInput(badRun), ErrorCodeForbiddenField)
+	badRun = run
+	badRun.IdlePolicy = &ProviderIdlePolicy{AutoResumeEnabled: true}
+	requireSafeError(t, ValidateProviderRunInput(badRun), ErrorCodeProviderRequestInvalid)
+	badRun = run
+	badRun.MaximumDurationSeconds = -1
+	requireSafeError(t, ValidateProviderRunInput(badRun), ErrorCodeProviderRequestInvalid)
+
+	binding := ProviderSessionBinding{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1", ProviderMicroVMID: "provider-1"}
+	require.NoError(t, ValidateProviderSessionInput(OperationGet, validProviderSessionInput("req-session", binding)))
+	badInput := validProviderSessionInput("req-session", binding)
+	badInput.AuthContext.Namespace = "other"
+	requireSafeError(t, ValidateProviderSessionInput(OperationGet, badInput), ErrorCodeTenantBindingViolation)
+	badInput = validProviderSessionInput("req-session", binding)
+	badInput.Binding.ProviderMicroVMID = ""
+	requireSafeError(t, ValidateProviderSessionInput(OperationGet, badInput), ErrorCodeTenantBindingViolation)
+
+	listInput := ProviderListInput{
+		RequestID:     "req-list",
+		TenantID:      "tenant-1",
+		Namespace:     "namespace-1",
+		AuthContext:   validProviderAuth(),
+		KnownSessions: []ProviderSessionBinding{binding},
+	}
+	require.NoError(t, ValidateProviderListInput(listInput))
+	listInput.MaxResults = -1
+	requireSafeError(t, ValidateProviderListInput(listInput), ErrorCodeProviderRequestInvalid)
+	listInput = ProviderListInput{RequestID: "req-list", TenantID: "tenant-1", Namespace: "namespace-1", AuthContext: validProviderAuth(), ImageRef: "raw_sdk_client"}
+	requireSafeError(t, ValidateProviderListInput(listInput), ErrorCodeForbiddenField)
+	listInput = ProviderListInput{TenantID: "tenant-1", Namespace: "namespace-1", AuthContext: validProviderAuth()}
+	requireSafeError(t, ValidateProviderListInput(listInput), ErrorCodeProviderRequestInvalid)
+	listInput = ProviderListInput{RequestID: "req-list", TenantID: "tenant-1", Namespace: "namespace-1", AuthContext: validProviderAuth(), KnownSessions: []ProviderSessionBinding{{TenantID: "tenant-2", Namespace: "namespace-1", SessionID: "session-1", ProviderMicroVMID: "provider-1"}}}
+	requireSafeError(t, ValidateProviderListInput(listInput), ErrorCodeTenantBindingViolation)
+
+	require.NoError(t, ValidateProviderTokenInput(OperationShellToken, ProviderTokenInput{
+		RequestID:   "req-shell",
+		TenantID:    "tenant-1",
+		Namespace:   "namespace-1",
+		AuthContext: validProviderAuth(),
+		Binding:     binding,
+		TTLSeconds:  60,
+	}))
+	require.NoError(t, ValidateProviderTokenInput(OperationAuthToken, ProviderTokenInput{
+		RequestID:   "req-auth",
+		TenantID:    "tenant-1",
+		Namespace:   "namespace-1",
+		AuthContext: validProviderAuth(),
+		Binding:     binding,
+		TTLSeconds:  60,
+		AllowedPortScope: []ProviderPortScope{
+			{AllPorts: true},
+			{StartPort: 8000, EndPort: 8002},
+		},
+	}))
+	badToken := validProviderTokenInput("req-token", binding)
+	badToken.TTLSeconds = 901
+	requireSafeError(t, ValidateProviderTokenInput(OperationAuthToken, badToken), ErrorCodeTokenSafetyViolation)
+	badToken = validProviderTokenInput("req-token", binding)
+	badToken.AllowedPortScope = []ProviderPortScope{{Port: 443, AllPorts: true}}
+	requireSafeError(t, ValidateProviderTokenInput(OperationAuthToken, badToken), ErrorCodeTokenSafetyViolation)
+	badToken = validProviderTokenInput("", binding)
+	requireSafeError(t, ValidateProviderTokenInput(OperationAuthToken, badToken), ErrorCodeProviderRequestInvalid)
+	badToken = validProviderTokenInput("req-token", binding)
+	badToken.AllowedPortScope = nil
+	requireSafeError(t, ValidateProviderTokenInput(OperationAuthToken, badToken), ErrorCodeTokenSafetyViolation)
+	badToken = validProviderTokenInput("req-token", binding)
+	requireSafeError(t, ValidateProviderTokenInput(OperationRun, badToken), ErrorCodeProviderOperationUnsupported)
+	requireSafeError(t, ValidateProviderToken(ProviderToken{}), ErrorCodeTokenSafetyViolation)
+	token, err := providerTokenMetadata(OperationShellToken, ProviderTokenInput{Binding: binding, TTLSeconds: 1}, time.Time{})
+	require.NoError(t, err)
+	require.Equal(t, "shell", token.TokenType)
+}
+
+func TestAWSLambdaMicroVMProviderErrorBranchesAndHelpers(t *testing.T) {
+	binding := ProviderSessionBinding{TenantID: "tenant-1", Namespace: "namespace-1", SessionID: "session-1", ProviderMicroVMID: "provider-1"}
+	var nilProvider *AWSLambdaMicroVMProvider
+	_, err := nilProvider.Get(context.Background(), validProviderSessionInput("req-nil", binding))
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+
+	api := newRecordingLambdaMicroVMAPI(time.Unix(800, 0).UTC())
+	api.emptyTokens = true
+	provider := &AWSLambdaMicroVMProvider{api: api, clock: zeroProviderClock{}}
+	_, err = provider.CreateAuthToken(context.Background(), validProviderTokenInput("req-empty-token", binding))
+	requireSafeError(t, err, ErrorCodeTokenSafetyViolation)
+	require.Equal(t, time.Unix(0, 0).UTC(), provider.now())
+	require.Equal(t, time.Unix(0, 0).UTC(), nilProvider.now())
+
+	api = newRecordingLambdaMicroVMAPI(time.Unix(800, 0).UTC())
+	api.err = errors.New("provider failed with aws_secret_access_key")
+	provider = &AWSLambdaMicroVMProvider{api: api, clock: providerClock{now: time.Unix(800, 0).UTC()}}
+	_, err = provider.List(context.Background(), ProviderListInput{RequestID: "req-list", TenantID: "tenant-1", Namespace: "namespace-1", AuthContext: validProviderAuth(), KnownSessions: []ProviderSessionBinding{binding}})
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+	require.NotContains(t, err.Error(), "aws_secret_access_key")
+
+	_, err = sessionFromRunOutput(validProviderRunInput(), nil)
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+	_, err = sessionFromProviderState(binding, "unknown", "image-ref", "1", time.Unix(800, 0).UTC(), time.Time{})
+	requireSafeError(t, err, ErrorCodeProviderStateMappingIncomplete)
+	_, err = sessionFromGetOutput("req-empty", binding, nil)
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+	_, err = sessionFromGetOutput("req-mismatch", binding, &lambdamicrovms.GetMicrovmOutput{
+		MicrovmId:    aws.String("provider-2"),
+		ImageArn:     aws.String("image-ref"),
+		ImageVersion: aws.String("1"),
+		StartedAt:    aws.Time(time.Unix(800, 0).UTC()),
+		State:        lambdatypes.MicrovmStateRunning,
+	})
+	requireSafeError(t, err, ErrorCodeTenantBindingViolation)
+	_, err = listOutputFromSDK(ProviderListInput{RequestID: "req-list"}, nil)
+	requireSafeError(t, err, ErrorCodeProviderOperationFailed)
+
+	require.Nil(t, awsIdlePolicy(nil))
+	require.Len(t, awsPortScopes([]ProviderPortScope{{AllPorts: true}, {StartPort: 1, EndPort: 2}}), 2)
+	var nilCtx context.Context
+	require.NotNil(t, ctxOrBackground(nilCtx))
+	require.NotNil(t, ctxOrBackground(context.Background()))
+	requireSafeError(t, sanitizeProviderError(SafeError{Code: ErrorCodeProviderOperationFailed, Message: "safe"}, "req-safe"), ErrorCodeProviderOperationFailed)
+
+	emptyShellAPI := newRecordingLambdaMicroVMAPI(time.Unix(800, 0).UTC())
+	emptyShellAPI.emptyTokens = true
+	emptyShellProvider := &AWSLambdaMicroVMProvider{api: emptyShellAPI, clock: providerClock{now: time.Unix(800, 0).UTC()}}
+	_, err = emptyShellProvider.CreateShellToken(context.Background(), validProviderTokenInput("req-empty-shell", binding))
+	requireSafeError(t, err, ErrorCodeTokenSafetyViolation)
+}
+
+type providerClock struct{ now time.Time }
+
+func (c providerClock) Now() time.Time { return c.now }
+
+type zeroProviderClock struct{}
+
+func (zeroProviderClock) Now() time.Time { return time.Time{} }
+
+type recordingLambdaMicroVMAPI struct {
+	now             time.Time
+	state           lambdatypes.MicrovmState
+	err             error
+	emptyTokens     bool
+	calls           []string
+	runInput        *lambdamicrovms.RunMicrovmInput
+	getInput        *lambdamicrovms.GetMicrovmInput
+	listInput       *lambdamicrovms.ListMicrovmsInput
+	authTokenInput  *lambdamicrovms.CreateMicrovmAuthTokenInput
+	shellTokenInput *lambdamicrovms.CreateMicrovmShellAuthTokenInput
+}
+
+func newRecordingLambdaMicroVMAPI(now time.Time) *recordingLambdaMicroVMAPI {
+	return &recordingLambdaMicroVMAPI{now: now.UTC(), state: lambdatypes.MicrovmStateRunning}
+}
+
+func (api *recordingLambdaMicroVMAPI) RunMicrovm(_ context.Context, input *lambdamicrovms.RunMicrovmInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.RunMicrovmOutput, error) {
+	api.calls = append(api.calls, "RunMicrovm")
+	api.runInput = input
+	if api.err != nil {
+		return nil, api.err
+	}
+	api.state = lambdatypes.MicrovmStateRunning
+	return &lambdamicrovms.RunMicrovmOutput{
+		MicrovmId:                aws.String("provider-1"),
+		ImageArn:                 aws.String(aws.ToString(input.ImageIdentifier)),
+		ImageVersion:             aws.String("1"),
+		MaximumDurationInSeconds: aws.Int32(300),
+		StartedAt:                aws.Time(api.now),
+		State:                    api.state,
+	}, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) GetMicrovm(_ context.Context, input *lambdamicrovms.GetMicrovmInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.GetMicrovmOutput, error) {
+	api.calls = append(api.calls, "GetMicrovm")
+	api.getInput = input
+	if api.err != nil {
+		return nil, api.err
+	}
+	out := &lambdamicrovms.GetMicrovmOutput{
+		MicrovmId:                aws.String(aws.ToString(input.MicrovmIdentifier)),
+		ImageArn:                 aws.String("image-ref"),
+		ImageVersion:             aws.String("1"),
+		MaximumDurationInSeconds: aws.Int32(300),
+		StartedAt:                aws.Time(api.now),
+		State:                    api.state,
+	}
+	if api.state == lambdatypes.MicrovmStateTerminated {
+		out.TerminatedAt = aws.Time(api.now.Add(time.Minute))
+	}
+	return out, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) ListMicrovms(_ context.Context, input *lambdamicrovms.ListMicrovmsInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.ListMicrovmsOutput, error) {
+	api.calls = append(api.calls, "ListMicrovms")
+	api.listInput = input
+	if api.err != nil {
+		return nil, api.err
+	}
+	return &lambdamicrovms.ListMicrovmsOutput{
+		Items: []lambdatypes.MicrovmItem{
+			{
+				MicrovmId:    aws.String("provider-1"),
+				ImageArn:     aws.String("image-ref"),
+				ImageVersion: aws.String("1"),
+				StartedAt:    aws.Time(api.now),
+				State:        api.state,
+			},
+			{
+				MicrovmId:    aws.String("provider-foreign"),
+				ImageArn:     aws.String("image-ref"),
+				ImageVersion: aws.String("1"),
+				StartedAt:    aws.Time(api.now),
+				State:        lambdatypes.MicrovmStateRunning,
+			},
+		},
+		NextToken: aws.String("raw-provider-pagination-token"),
+	}, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) SuspendMicrovm(_ context.Context, _ *lambdamicrovms.SuspendMicrovmInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.SuspendMicrovmOutput, error) {
+	api.calls = append(api.calls, "SuspendMicrovm")
+	if api.err != nil {
+		return nil, api.err
+	}
+	api.state = lambdatypes.MicrovmStateSuspended
+	return &lambdamicrovms.SuspendMicrovmOutput{}, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) ResumeMicrovm(_ context.Context, _ *lambdamicrovms.ResumeMicrovmInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.ResumeMicrovmOutput, error) {
+	api.calls = append(api.calls, "ResumeMicrovm")
+	if api.err != nil {
+		return nil, api.err
+	}
+	api.state = lambdatypes.MicrovmStateRunning
+	return &lambdamicrovms.ResumeMicrovmOutput{}, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) TerminateMicrovm(_ context.Context, _ *lambdamicrovms.TerminateMicrovmInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.TerminateMicrovmOutput, error) {
+	api.calls = append(api.calls, "TerminateMicrovm")
+	if api.err != nil {
+		return nil, api.err
+	}
+	api.state = lambdatypes.MicrovmStateTerminated
+	return &lambdamicrovms.TerminateMicrovmOutput{}, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) CreateMicrovmAuthToken(_ context.Context, input *lambdamicrovms.CreateMicrovmAuthTokenInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.CreateMicrovmAuthTokenOutput, error) {
+	api.calls = append(api.calls, "CreateMicrovmAuthToken")
+	api.authTokenInput = input
+	if api.err != nil {
+		return nil, api.err
+	}
+	if api.emptyTokens {
+		return &lambdamicrovms.CreateMicrovmAuthTokenOutput{}, nil
+	}
+	return &lambdamicrovms.CreateMicrovmAuthTokenOutput{AuthToken: map[string]string{"X-aws-proxy-auth": recordingRawToken()}}, nil
+}
+
+func (api *recordingLambdaMicroVMAPI) CreateMicrovmShellAuthToken(_ context.Context, input *lambdamicrovms.CreateMicrovmShellAuthTokenInput, _ ...func(*lambdamicrovms.Options)) (*lambdamicrovms.CreateMicrovmShellAuthTokenOutput, error) {
+	api.calls = append(api.calls, "CreateMicrovmShellAuthToken")
+	api.shellTokenInput = input
+	if api.err != nil {
+		return nil, api.err
+	}
+	if api.emptyTokens {
+		return &lambdamicrovms.CreateMicrovmShellAuthTokenOutput{}, nil
+	}
+	return &lambdamicrovms.CreateMicrovmShellAuthTokenOutput{AuthToken: map[string]string{"X-aws-proxy-auth": recordingRawToken()}}, nil
+}
+
+func validProviderRunInput() ProviderRunInput {
+	return ProviderRunInput{
+		RequestID:                   "req-run",
+		TenantID:                    "tenant-1",
+		Namespace:                   "namespace-1",
+		SessionID:                   "session-1",
+		AuthContext:                 validProviderAuth(),
+		ImageRef:                    "image-ref",
+		ImageVersion:                "1",
+		NetworkConnectorRef:         "network-ref",
+		IngressNetworkConnectorRefs: []string{"ingress-ref"},
+		EgressNetworkConnectorRefs:  []string{"egress-ref"},
+		SessionSpec:                 SessionSpec{Metadata: map[string]string{"purpose": "test"}},
+		IdlePolicy: &ProviderIdlePolicy{
+			AutoResumeEnabled:        true,
+			MaxIdleDurationSeconds:   60,
+			SuspendedDurationSeconds: 120,
+		},
+		MaximumDurationSeconds: 300,
+	}
+}
+
+func validProviderSessionInput(requestID string, binding ProviderSessionBinding) ProviderSessionInput {
+	return ProviderSessionInput{
+		RequestID:   requestID,
+		TenantID:    binding.TenantID,
+		Namespace:   binding.Namespace,
+		AuthContext: validProviderAuth(),
+		Binding:     binding,
+	}
+}
+
+func validProviderTokenInput(requestID string, binding ProviderSessionBinding) ProviderTokenInput {
+	return ProviderTokenInput{
+		RequestID:   requestID,
+		TenantID:    binding.TenantID,
+		Namespace:   binding.Namespace,
+		AuthContext: validProviderAuth(),
+		Binding:     binding,
+		TTLSeconds:  120,
+		AllowedPortScope: []ProviderPortScope{
+			{Port: 443},
+		},
+	}
+}
+
+func validProviderAuth() AuthContext {
+	return AuthContext{
+		Subject:   "subject-1",
+		TenantID:  "tenant-1",
+		Namespace: "namespace-1",
+	}
+}
+
+func requireSafeError(t *testing.T, err error, code string) {
+	t.Helper()
+	require.Error(t, err)
+	var safe SafeError
+	require.ErrorAs(t, err, &safe)
+	require.Equal(t, code, safe.Code)
+}
+
+func recordingRawToken() string {
+	return strings.Join([]string{"provider", "token", "value"}, "-")
+}

--- a/runtime/microvm/provider.go
+++ b/runtime/microvm/provider.go
@@ -1,0 +1,667 @@
+package microvm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// ErrorCodeProviderRequestInvalid reports a malformed constrained provider request.
+	ErrorCodeProviderRequestInvalid = "m16.microvm.provider_request_invalid"
+	// ErrorCodeProviderOperationUnsupported reports an operation outside the M16 real provider vocabulary.
+	ErrorCodeProviderOperationUnsupported = "m16.microvm.provider_operation_unsupported"
+	// ErrorCodeProviderOperationFailed reports a sanitized provider call failure.
+	ErrorCodeProviderOperationFailed = "m16.microvm.provider_operation_failed"
+)
+
+const (
+	defaultProviderTokenTTLSeconds = int32(900)
+	minProviderTokenTTLSeconds     = int32(1)
+	maxProviderTokenTTLSeconds     = int32(900)
+)
+
+// Provider is the constrained M16 real MicroVM provider surface.
+//
+// It deliberately exposes only AppTheory request and response structs. Raw AWS SDK clients,
+// credentials, provider payloads, bearer tokens, and plaintext session tokens are not part of
+// this interface.
+type Provider interface {
+	Run(context.Context, ProviderRunInput) (ProviderSession, error)
+	Get(context.Context, ProviderSessionInput) (ProviderSession, error)
+	List(context.Context, ProviderListInput) (ProviderListOutput, error)
+	Suspend(context.Context, ProviderSessionInput) (ProviderSession, error)
+	Resume(context.Context, ProviderSessionInput) (ProviderSession, error)
+	Terminate(context.Context, ProviderSessionInput) (ProviderSession, error)
+	CreateAuthToken(context.Context, ProviderTokenInput) (ProviderToken, error)
+	CreateShellToken(context.Context, ProviderTokenInput) (ProviderToken, error)
+}
+
+// ProviderIdlePolicy is the safe AppTheory representation of provider idle behavior.
+type ProviderIdlePolicy struct {
+	AutoResumeEnabled        bool  `json:"auto_resume_enabled"`
+	MaxIdleDurationSeconds   int32 `json:"max_idle_duration_seconds"`
+	SuspendedDurationSeconds int32 `json:"suspended_duration_seconds"`
+}
+
+// ProviderRunInput is the safe AppTheory request for the real run operation.
+type ProviderRunInput struct {
+	RequestID                   string              `json:"request_id"`
+	TenantID                    string              `json:"tenant_id"`
+	Namespace                   string              `json:"namespace"`
+	SessionID                   string              `json:"session_id"`
+	AuthContext                 AuthContext         `json:"auth_context"`
+	ImageRef                    string              `json:"image_ref"`
+	ImageVersion                string              `json:"image_version,omitempty"`
+	NetworkConnectorRef         string              `json:"network_connector_ref,omitempty"`
+	IngressNetworkConnectorRefs []string            `json:"ingress_network_connector_refs,omitempty"`
+	EgressNetworkConnectorRefs  []string            `json:"egress_network_connector_refs,omitempty"`
+	SessionSpec                 SessionSpec         `json:"session_spec,omitempty"`
+	IdlePolicy                  *ProviderIdlePolicy `json:"idle_policy,omitempty"`
+	MaximumDurationSeconds      int32               `json:"maximum_duration_seconds,omitempty"`
+}
+
+// ProviderSessionBinding binds an AppTheory session to a provider MicroVM identifier.
+type ProviderSessionBinding struct {
+	TenantID          string `json:"tenant_id"`
+	Namespace         string `json:"namespace"`
+	SessionID         string `json:"session_id"`
+	ProviderMicroVMID string `json:"provider_microvm_id"`
+	RegistryVersion   int64  `json:"registry_version,omitempty"`
+}
+
+// ProviderSessionInput is the safe AppTheory request for a bound session operation.
+type ProviderSessionInput struct {
+	RequestID   string                 `json:"request_id"`
+	TenantID    string                 `json:"tenant_id"`
+	Namespace   string                 `json:"namespace"`
+	AuthContext AuthContext            `json:"auth_context"`
+	Binding     ProviderSessionBinding `json:"binding"`
+}
+
+// ProviderListInput is the safe AppTheory request for tenant-bound provider list/recovery.
+//
+// KnownSessions is the safe registry-derived allowlist used by provider adapters to avoid
+// leaking account-wide provider list results across tenants.
+type ProviderListInput struct {
+	RequestID     string                   `json:"request_id"`
+	TenantID      string                   `json:"tenant_id"`
+	Namespace     string                   `json:"namespace"`
+	AuthContext   AuthContext              `json:"auth_context"`
+	ImageRef      string                   `json:"image_ref,omitempty"`
+	ImageVersion  string                   `json:"image_version,omitempty"`
+	MaxResults    int32                    `json:"max_results,omitempty"`
+	KnownSessions []ProviderSessionBinding `json:"known_sessions,omitempty"`
+}
+
+// ProviderPortScope describes the allowed port scope for sanitized auth-token issuance.
+type ProviderPortScope struct {
+	AllPorts  bool  `json:"all_ports,omitempty"`
+	Port      int32 `json:"port,omitempty"`
+	StartPort int32 `json:"start_port,omitempty"`
+	EndPort   int32 `json:"end_port,omitempty"`
+}
+
+// ProviderTokenInput is the safe AppTheory request for auth-token and shell-token operations.
+type ProviderTokenInput struct {
+	RequestID        string                 `json:"request_id"`
+	TenantID         string                 `json:"tenant_id"`
+	Namespace        string                 `json:"namespace"`
+	AuthContext      AuthContext            `json:"auth_context"`
+	Binding          ProviderSessionBinding `json:"binding"`
+	TTLSeconds       int32                  `json:"ttl_seconds,omitempty"`
+	AllowedPortScope []ProviderPortScope    `json:"allowed_port_scope,omitempty"`
+}
+
+// ProviderSession is the sanitized provider session shape emitted by AppTheory.
+type ProviderSession struct {
+	TenantID          string         `json:"tenant_id"`
+	Namespace         string         `json:"namespace"`
+	SessionID         string         `json:"session_id"`
+	ProviderMicroVMID string         `json:"provider_microvm_id"`
+	State             LifecycleState `json:"state"`
+	ProviderState     string         `json:"provider_state"`
+	ImageRef          string         `json:"image_ref,omitempty"`
+	ImageVersion      string         `json:"image_version,omitempty"`
+	StartedAt         time.Time      `json:"started_at,omitempty"`
+	TerminatedAt      time.Time      `json:"terminated_at,omitempty"`
+	RegistryVersion   int64          `json:"registry_version,omitempty"`
+	Terminal          bool           `json:"terminal,omitempty"`
+}
+
+// ProviderListOutput is the sanitized tenant-bound list/recovery result.
+type ProviderListOutput struct {
+	Sessions       []ProviderSession `json:"sessions"`
+	RecoveryCursor string            `json:"recovery_cursor,omitempty"`
+}
+
+// ProviderToken is the sanitized token issuance metadata AppTheory may expose.
+//
+// It never contains provider auth header values, bearer tokens, or session token plaintext.
+type ProviderToken struct {
+	TenantID          string    `json:"tenant_id"`
+	Namespace         string    `json:"namespace"`
+	SessionID         string    `json:"session_id"`
+	ProviderMicroVMID string    `json:"provider_microvm_id"`
+	TokenID           string    `json:"token_id"`
+	TokenType         string    `json:"token_type"`
+	ExpiresAt         time.Time `json:"expires_at"`
+	Scope             []string  `json:"scope"`
+}
+
+// Key returns the tenant/namespace/session key for a provider session binding.
+func (b ProviderSessionBinding) Key() SessionKey {
+	return SessionKey{TenantID: strings.TrimSpace(b.TenantID), Namespace: strings.TrimSpace(b.Namespace), SessionID: strings.TrimSpace(b.SessionID)}
+}
+
+// Key returns the tenant/namespace/session key for a provider session.
+func (s ProviderSession) Key() SessionKey {
+	return SessionKey{TenantID: strings.TrimSpace(s.TenantID), Namespace: strings.TrimSpace(s.Namespace), SessionID: strings.TrimSpace(s.SessionID)}
+}
+
+// Binding returns the safe provider binding for a provider session.
+func (s ProviderSession) Binding() ProviderSessionBinding {
+	return ProviderSessionBinding{
+		TenantID:          strings.TrimSpace(s.TenantID),
+		Namespace:         strings.TrimSpace(s.Namespace),
+		SessionID:         strings.TrimSpace(s.SessionID),
+		ProviderMicroVMID: strings.TrimSpace(s.ProviderMicroVMID),
+		RegistryVersion:   s.RegistryVersion,
+	}
+}
+
+// MapProviderState maps a provider state string into the AppTheory M16 lifecycle contract.
+func MapProviderState(providerState string) (LifecycleState, bool, error) {
+	normalized := normalizeProviderState(providerState)
+	if normalized == "" {
+		return "", false, safeError(ErrorCodeProviderStateMappingIncomplete, "apptheory: microvm provider state is required", "")
+	}
+	for _, mapping := range DefaultProviderStateMappings() {
+		if normalized == normalizeProviderState(mapping.ProviderState) {
+			return mapping.State, mapping.Terminal, nil
+		}
+	}
+	return "", false, safeError(ErrorCodeProviderStateMappingIncomplete, "apptheory: microvm provider state is unsupported", "")
+}
+
+// ValidateProviderSession validates a sanitized provider session response.
+func ValidateProviderSession(session ProviderSession) error {
+	session = normalizeProviderSession(session)
+	if session.TenantID == "" || session.Namespace == "" || session.SessionID == "" || session.ProviderMicroVMID == "" {
+		return safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider session is incomplete", "")
+	}
+	state, terminal, err := MapProviderState(session.ProviderState)
+	if err != nil {
+		return err
+	}
+	if session.State != state || session.Terminal != terminal {
+		return safeError(ErrorCodeProviderStateMappingIncomplete, "apptheory: microvm provider session state mapping mismatch", "")
+	}
+	if forbiddenFieldName(session.ProviderMicroVMID) || forbiddenFieldName(session.ImageRef) || forbiddenFieldName(session.ImageVersion) {
+		return safeError(ErrorCodeForbiddenField, "apptheory: microvm provider session exposes forbidden field", "")
+	}
+	return nil
+}
+
+// ValidateProviderRunInput validates a safe AppTheory run request.
+func ValidateProviderRunInput(input ProviderRunInput) error {
+	_, err := validateProviderRunInput(input)
+	return err
+}
+
+// ValidateProviderSessionInput validates a safe AppTheory bound-session provider request.
+func ValidateProviderSessionInput(operation Operation, input ProviderSessionInput) error {
+	_, err := validateProviderSessionInput(operation, input)
+	return err
+}
+
+// ValidateProviderListInput validates a safe AppTheory list/recovery provider request.
+func ValidateProviderListInput(input ProviderListInput) error {
+	_, err := validateProviderListInput(input)
+	return err
+}
+
+// ValidateProviderTokenInput validates a safe AppTheory token provider request.
+func ValidateProviderTokenInput(operation Operation, input ProviderTokenInput) error {
+	_, err := validateProviderTokenInput(operation, input)
+	return err
+}
+
+// ValidateProviderToken validates sanitized token issuance metadata.
+func ValidateProviderToken(token ProviderToken) error {
+	token = normalizeProviderToken(token)
+	if token.TenantID == "" || token.Namespace == "" || token.SessionID == "" || token.ProviderMicroVMID == "" ||
+		token.TokenID == "" || token.TokenType == "" || token.ExpiresAt.IsZero() || len(token.Scope) == 0 {
+		return safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider token metadata is incomplete", "")
+	}
+	fields := make([]string, 0, 3+len(token.Scope))
+	fields = append(fields, token.TokenID, token.TokenType, token.ProviderMicroVMID)
+	fields = append(fields, token.Scope...)
+	for _, field := range fields {
+		if forbiddenFieldName(field) {
+			return safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider token metadata exposes forbidden field", "")
+		}
+	}
+	return nil
+}
+
+func validateProviderOperation(operation Operation, requestID string) error {
+	if !requiredOperation(operation) {
+		return safeError(ErrorCodeProviderOperationUnsupported, "apptheory: microvm provider operation is unsupported", requestID)
+	}
+	return nil
+}
+
+func validateProviderRunInput(input ProviderRunInput) (ProviderRunInput, error) {
+	input = normalizeProviderRunInput(input)
+	if err := validateProviderOperation(OperationRun, input.RequestID); err != nil {
+		return ProviderRunInput{}, err
+	}
+	if err := validateProviderAccess(input.RequestID, input.TenantID, input.Namespace, input.AuthContext); err != nil {
+		return ProviderRunInput{}, err
+	}
+	if err := validateProviderRunIdentity(input); err != nil {
+		return ProviderRunInput{}, err
+	}
+	if err := validateProviderRunSafeFields(input); err != nil {
+		return ProviderRunInput{}, err
+	}
+	if err := validateProviderIdlePolicy(input.RequestID, input.IdlePolicy); err != nil {
+		return ProviderRunInput{}, err
+	}
+	if input.MaximumDurationSeconds < 0 {
+		return ProviderRunInput{}, safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider maximum duration is invalid", input.RequestID)
+	}
+	return input, nil
+}
+
+func validateProviderRunIdentity(input ProviderRunInput) error {
+	if input.RequestID == "" {
+		return safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider request_id is required", "")
+	}
+	if input.SessionID == "" || input.ImageRef == "" {
+		return safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider run requires session_id and image_ref", input.RequestID)
+	}
+	return nil
+}
+
+func validateProviderRunSafeFields(input ProviderRunInput) error {
+	if forbiddenFieldName(input.ImageRef) || forbiddenFieldName(input.ImageVersion) {
+		return safeError(ErrorCodeForbiddenField, "apptheory: microvm provider run exposes forbidden field", input.RequestID)
+	}
+	if err := validateSafeMetadata(input.SessionSpec.Metadata, input.RequestID); err != nil {
+		return err
+	}
+	if err := validateSafeConnectorRefs(input.RequestID, append(append([]string{}, input.IngressNetworkConnectorRefs...), input.EgressNetworkConnectorRefs...)); err != nil {
+		return err
+	}
+	if input.NetworkConnectorRef != "" {
+		if err := validateSafeConnectorRefs(input.RequestID, []string{input.NetworkConnectorRef}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProviderIdlePolicy(requestID string, policy *ProviderIdlePolicy) error {
+	if policy == nil {
+		return nil
+	}
+	if policy.MaxIdleDurationSeconds <= 0 || policy.SuspendedDurationSeconds <= 0 {
+		return safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider idle policy is incomplete", requestID)
+	}
+	return nil
+}
+
+func validateProviderSessionInput(operation Operation, input ProviderSessionInput) (ProviderSessionInput, error) {
+	input = normalizeProviderSessionInput(input)
+	if err := validateProviderOperation(operation, input.RequestID); err != nil {
+		return ProviderSessionInput{}, err
+	}
+	if input.RequestID == "" {
+		return ProviderSessionInput{}, safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider request_id is required", "")
+	}
+	if err := validateProviderAccess(input.RequestID, input.TenantID, input.Namespace, input.AuthContext); err != nil {
+		return ProviderSessionInput{}, err
+	}
+	binding, err := validateProviderBinding(input.RequestID, input.TenantID, input.Namespace, input.Binding)
+	if err != nil {
+		return ProviderSessionInput{}, err
+	}
+	input.Binding = binding
+	return input, nil
+}
+
+func validateProviderListInput(input ProviderListInput) (ProviderListInput, error) {
+	input = normalizeProviderListInput(input)
+	if err := validateProviderOperation(OperationList, input.RequestID); err != nil {
+		return ProviderListInput{}, err
+	}
+	if input.RequestID == "" {
+		return ProviderListInput{}, safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider request_id is required", "")
+	}
+	if err := validateProviderAccess(input.RequestID, input.TenantID, input.Namespace, input.AuthContext); err != nil {
+		return ProviderListInput{}, err
+	}
+	if forbiddenFieldName(input.ImageRef) || forbiddenFieldName(input.ImageVersion) {
+		return ProviderListInput{}, safeError(ErrorCodeForbiddenField, "apptheory: microvm provider list exposes forbidden field", input.RequestID)
+	}
+	for i, binding := range input.KnownSessions {
+		normalized, err := validateProviderBinding(input.RequestID, input.TenantID, input.Namespace, binding)
+		if err != nil {
+			return ProviderListInput{}, err
+		}
+		input.KnownSessions[i] = normalized
+	}
+	if input.MaxResults < 0 {
+		return ProviderListInput{}, safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider list max_results is invalid", input.RequestID)
+	}
+	return input, nil
+}
+
+func validateProviderTokenInput(operation Operation, input ProviderTokenInput) (ProviderTokenInput, error) {
+	input = normalizeProviderTokenInput(input)
+	if err := validateProviderOperation(operation, input.RequestID); err != nil {
+		return ProviderTokenInput{}, err
+	}
+	if input.RequestID == "" {
+		return ProviderTokenInput{}, safeError(ErrorCodeProviderRequestInvalid, "apptheory: microvm provider request_id is required", "")
+	}
+	if operation != OperationAuthToken && operation != OperationShellToken {
+		return ProviderTokenInput{}, safeError(ErrorCodeProviderOperationUnsupported, "apptheory: microvm provider token operation is unsupported", input.RequestID)
+	}
+	if err := validateProviderAccess(input.RequestID, input.TenantID, input.Namespace, input.AuthContext); err != nil {
+		return ProviderTokenInput{}, err
+	}
+	binding, err := validateProviderBinding(input.RequestID, input.TenantID, input.Namespace, input.Binding)
+	if err != nil {
+		return ProviderTokenInput{}, err
+	}
+	input.Binding = binding
+	if input.TTLSeconds == 0 {
+		input.TTLSeconds = defaultProviderTokenTTLSeconds
+	}
+	if input.TTLSeconds < minProviderTokenTTLSeconds || input.TTLSeconds > maxProviderTokenTTLSeconds {
+		return ProviderTokenInput{}, safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider token ttl exceeds contract bounds", input.RequestID)
+	}
+	if operation == OperationAuthToken && len(input.AllowedPortScope) == 0 {
+		return ProviderTokenInput{}, safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm auth token requires an explicit allowed port scope", input.RequestID)
+	}
+	for _, scope := range input.AllowedPortScope {
+		if err := validateProviderPortScope(scope, input.RequestID); err != nil {
+			return ProviderTokenInput{}, err
+		}
+	}
+	return input, nil
+}
+
+func validateProviderAccess(requestID, tenantID, namespace string, auth AuthContext) error {
+	auth = normalizeProviderAuthContext(auth)
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(namespace) == "" {
+		return safeError(ErrorCodeTenantBindingViolation, "apptheory: microvm provider request requires tenant and namespace", requestID)
+	}
+	if auth.Subject == "" || auth.TenantID == "" {
+		return safeError(ErrorCodeUnauthenticatedController, "apptheory: microvm provider request requires authenticated context", requestID)
+	}
+	if auth.TenantID != strings.TrimSpace(tenantID) {
+		return safeError(ErrorCodeTenantBindingViolation, "apptheory: microvm provider auth context is cross-tenant", requestID)
+	}
+	if auth.Namespace != "" && auth.Namespace != strings.TrimSpace(namespace) {
+		return safeError(ErrorCodeTenantBindingViolation, "apptheory: microvm provider auth context is cross-namespace", requestID)
+	}
+	return validateSafeMetadata(auth.Metadata, requestID)
+}
+
+func validateProviderBinding(requestID, tenantID, namespace string, binding ProviderSessionBinding) (ProviderSessionBinding, error) {
+	binding = normalizeProviderBinding(binding)
+	if binding.TenantID == "" || binding.Namespace == "" || binding.SessionID == "" || binding.ProviderMicroVMID == "" {
+		return ProviderSessionBinding{}, safeError(ErrorCodeTenantBindingViolation, "apptheory: microvm provider binding is incomplete", requestID)
+	}
+	if binding.TenantID != strings.TrimSpace(tenantID) || binding.Namespace != strings.TrimSpace(namespace) {
+		return ProviderSessionBinding{}, safeError(ErrorCodeTenantBindingViolation, "apptheory: microvm provider binding is cross-tenant", requestID)
+	}
+	if forbiddenFieldName(binding.ProviderMicroVMID) {
+		return ProviderSessionBinding{}, safeError(ErrorCodeForbiddenField, "apptheory: microvm provider binding exposes forbidden field", requestID)
+	}
+	return binding, nil
+}
+
+func validateProviderPortScope(scope ProviderPortScope, requestID string) error {
+	options := 0
+	if scope.AllPorts {
+		options++
+	}
+	if scope.Port > 0 {
+		options++
+	}
+	if scope.StartPort > 0 || scope.EndPort > 0 {
+		options++
+		if scope.StartPort <= 0 || scope.EndPort <= 0 || scope.StartPort > scope.EndPort {
+			return safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider token port range is invalid", requestID)
+		}
+	}
+	if options != 1 {
+		return safeError(ErrorCodeTokenSafetyViolation, "apptheory: microvm provider token port scope must specify exactly one scope", requestID)
+	}
+	return nil
+}
+
+func validateSafeConnectorRefs(requestID string, refs []string) error {
+	for _, ref := range refs {
+		if forbiddenFieldName(ref) {
+			return safeError(ErrorCodeForbiddenField, "apptheory: microvm provider connector exposes forbidden field", requestID)
+		}
+	}
+	return nil
+}
+
+func normalizeProviderRunInput(input ProviderRunInput) ProviderRunInput {
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.Namespace = strings.TrimSpace(input.Namespace)
+	input.SessionID = strings.TrimSpace(input.SessionID)
+	input.AuthContext = normalizeProviderAuthContext(input.AuthContext)
+	input.ImageRef = strings.TrimSpace(input.ImageRef)
+	input.ImageVersion = strings.TrimSpace(input.ImageVersion)
+	input.NetworkConnectorRef = strings.TrimSpace(input.NetworkConnectorRef)
+	input.IngressNetworkConnectorRefs = normalizeStringSlice(input.IngressNetworkConnectorRefs)
+	input.EgressNetworkConnectorRefs = normalizeStringSlice(input.EgressNetworkConnectorRefs)
+	input.SessionSpec.Metadata = cloneStringMap(input.SessionSpec.Metadata)
+	return input
+}
+
+func normalizeProviderSessionInput(input ProviderSessionInput) ProviderSessionInput {
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.Namespace = strings.TrimSpace(input.Namespace)
+	input.AuthContext = normalizeProviderAuthContext(input.AuthContext)
+	input.Binding = normalizeProviderBinding(input.Binding)
+	return input
+}
+
+func normalizeProviderListInput(input ProviderListInput) ProviderListInput {
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.Namespace = strings.TrimSpace(input.Namespace)
+	input.AuthContext = normalizeProviderAuthContext(input.AuthContext)
+	input.ImageRef = strings.TrimSpace(input.ImageRef)
+	input.ImageVersion = strings.TrimSpace(input.ImageVersion)
+	if len(input.KnownSessions) > 0 {
+		bindings := make([]ProviderSessionBinding, 0, len(input.KnownSessions))
+		for _, binding := range input.KnownSessions {
+			bindings = append(bindings, normalizeProviderBinding(binding))
+		}
+		input.KnownSessions = bindings
+	}
+	return input
+}
+
+func normalizeProviderTokenInput(input ProviderTokenInput) ProviderTokenInput {
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.Namespace = strings.TrimSpace(input.Namespace)
+	input.AuthContext = normalizeProviderAuthContext(input.AuthContext)
+	input.Binding = normalizeProviderBinding(input.Binding)
+	return input
+}
+
+func normalizeProviderAuthContext(auth AuthContext) AuthContext {
+	auth.Subject = strings.TrimSpace(auth.Subject)
+	auth.TenantID = strings.TrimSpace(auth.TenantID)
+	auth.Namespace = strings.TrimSpace(auth.Namespace)
+	auth.Metadata = cloneStringMap(auth.Metadata)
+	if len(auth.Entitlements) > 0 {
+		auth.Entitlements = normalizeStringSlice(auth.Entitlements)
+	}
+	return auth
+}
+
+func normalizeProviderBinding(binding ProviderSessionBinding) ProviderSessionBinding {
+	binding.TenantID = strings.TrimSpace(binding.TenantID)
+	binding.Namespace = strings.TrimSpace(binding.Namespace)
+	binding.SessionID = strings.TrimSpace(binding.SessionID)
+	binding.ProviderMicroVMID = strings.TrimSpace(binding.ProviderMicroVMID)
+	return binding
+}
+
+func normalizeProviderSession(session ProviderSession) ProviderSession {
+	session.TenantID = strings.TrimSpace(session.TenantID)
+	session.Namespace = strings.TrimSpace(session.Namespace)
+	session.SessionID = strings.TrimSpace(session.SessionID)
+	session.ProviderMicroVMID = strings.TrimSpace(session.ProviderMicroVMID)
+	session.State = LifecycleState(strings.TrimSpace(string(session.State)))
+	session.ProviderState = normalizeProviderState(session.ProviderState)
+	session.ImageRef = strings.TrimSpace(session.ImageRef)
+	session.ImageVersion = strings.TrimSpace(session.ImageVersion)
+	return session
+}
+
+func normalizeProviderToken(token ProviderToken) ProviderToken {
+	token.TenantID = strings.TrimSpace(token.TenantID)
+	token.Namespace = strings.TrimSpace(token.Namespace)
+	token.SessionID = strings.TrimSpace(token.SessionID)
+	token.ProviderMicroVMID = strings.TrimSpace(token.ProviderMicroVMID)
+	token.TokenID = strings.TrimSpace(token.TokenID)
+	token.TokenType = strings.TrimSpace(token.TokenType)
+	token.Scope = normalizeStringSlice(token.Scope)
+	return token
+}
+
+func normalizeStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func sessionFromProviderState(binding ProviderSessionBinding, providerState string, imageRef string, imageVersion string, startedAt time.Time, terminatedAt time.Time) (ProviderSession, error) {
+	state, terminal, err := MapProviderState(providerState)
+	if err != nil {
+		return ProviderSession{}, err
+	}
+	session := ProviderSession{
+		TenantID:          binding.TenantID,
+		Namespace:         binding.Namespace,
+		SessionID:         binding.SessionID,
+		ProviderMicroVMID: binding.ProviderMicroVMID,
+		State:             state,
+		ProviderState:     normalizeProviderState(providerState),
+		ImageRef:          strings.TrimSpace(imageRef),
+		ImageVersion:      strings.TrimSpace(imageVersion),
+		StartedAt:         startedAt,
+		TerminatedAt:      terminatedAt,
+		RegistryVersion:   binding.RegistryVersion,
+		Terminal:          terminal,
+	}
+	if err := ValidateProviderSession(session); err != nil {
+		return ProviderSession{}, err
+	}
+	return session, nil
+}
+
+func providerTokenMetadata(operation Operation, input ProviderTokenInput, now time.Time) (ProviderToken, error) {
+	tokenType := "auth"
+	if operation == OperationShellToken {
+		tokenType = "shell"
+	}
+	if now.IsZero() {
+		now = time.Unix(0, 0).UTC()
+	}
+	now = now.UTC()
+	scope := providerTokenScope(operation, input.AllowedPortScope)
+	expiresAt := now.Add(time.Duration(input.TTLSeconds) * time.Second).UTC()
+	token := ProviderToken{
+		TenantID:          input.Binding.TenantID,
+		Namespace:         input.Binding.Namespace,
+		SessionID:         input.Binding.SessionID,
+		ProviderMicroVMID: input.Binding.ProviderMicroVMID,
+		TokenID:           safeProviderTokenID(input.Binding, tokenType, expiresAt, scope),
+		TokenType:         tokenType,
+		ExpiresAt:         expiresAt,
+		Scope:             scope,
+	}
+	if err := ValidateProviderToken(token); err != nil {
+		return ProviderToken{}, err
+	}
+	return token, nil
+}
+
+func providerTokenScope(operation Operation, scopes []ProviderPortScope) []string {
+	if operation == OperationShellToken {
+		return []string{"shell"}
+	}
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		switch {
+		case scope.AllPorts:
+			out = append(out, "ports:*")
+		case scope.Port > 0:
+			out = append(out, fmt.Sprintf("ports:%d", scope.Port))
+		default:
+			out = append(out, fmt.Sprintf("ports:%d-%d", scope.StartPort, scope.EndPort))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func safeProviderTokenID(binding ProviderSessionBinding, tokenType string, expiresAt time.Time, scope []string) string {
+	parts := make([]string, 0, 6+len(scope))
+	parts = append(parts,
+		binding.TenantID,
+		binding.Namespace,
+		binding.SessionID,
+		binding.ProviderMicroVMID,
+		tokenType,
+		expiresAt.UTC().Format(time.RFC3339Nano),
+	)
+	parts = append(parts, scope...)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return tokenType + "-" + hex.EncodeToString(sum[:8])
+}
+
+func sanitizeProviderError(err error, requestID string) error {
+	if err == nil {
+		return nil
+	}
+	var safe SafeError
+	if errors.As(err, &safe) {
+		if safe.RequestID == "" {
+			safe.RequestID = strings.TrimSpace(requestID)
+		}
+		return safe
+	}
+	return safeError(ErrorCodeProviderOperationFailed, "apptheory: microvm provider operation failed", requestID)
+}

--- a/testkit/microvm/provider.go
+++ b/testkit/microvm/provider.go
@@ -1,0 +1,324 @@
+package microvm
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+)
+
+// ProviderCall records one fake provider operation.
+type ProviderCall struct {
+	Operation runtimemicrovm.Operation
+	RequestID string
+	TenantID  string
+	Namespace string
+	SessionID string
+}
+
+// FakeProvider is an in-memory deterministic M16 real MicroVM provider for tests.
+type FakeProvider struct {
+	mu       sync.Mutex
+	now      time.Time
+	next     int64
+	tokens   int64
+	sessions map[runtimemicrovm.SessionKey]runtimemicrovm.ProviderSession
+	errors   map[runtimemicrovm.Operation]error
+	calls    []ProviderCall
+}
+
+var _ runtimemicrovm.Provider = (*FakeProvider)(nil)
+
+// NewFakeProvider creates a fake provider with a deterministic starting clock.
+func NewFakeProvider() *FakeProvider {
+	return NewFakeProviderWithTime(time.Unix(0, 0).UTC())
+}
+
+// NewFakeProviderWithTime creates a fake provider with the provided current time.
+func NewFakeProviderWithTime(now time.Time) *FakeProvider {
+	if now.IsZero() {
+		now = time.Unix(0, 0).UTC()
+	}
+	return &FakeProvider{
+		now:      now.UTC(),
+		sessions: map[runtimemicrovm.SessionKey]runtimemicrovm.ProviderSession{},
+		errors:   map[runtimemicrovm.Operation]error{},
+	}
+}
+
+// SetNow sets the fake provider clock.
+func (p *FakeProvider) SetNow(now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !now.IsZero() {
+		p.now = now.UTC()
+	}
+}
+
+// SetOperationError configures a sanitized failure for the next calls to an operation.
+func (p *FakeProvider) SetOperationError(operation runtimemicrovm.Operation, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.errors == nil {
+		p.errors = map[runtimemicrovm.Operation]error{}
+	}
+	if err == nil {
+		delete(p.errors, operation)
+		return
+	}
+	p.errors[operation] = err
+}
+
+// Calls returns a copy of recorded provider calls.
+func (p *FakeProvider) Calls() []ProviderCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]ProviderCall(nil), p.calls...)
+}
+
+// Run creates a deterministic fake provider MicroVM session.
+func (p *FakeProvider) Run(_ context.Context, input runtimemicrovm.ProviderRunInput) (runtimemicrovm.ProviderSession, error) {
+	if err := runtimemicrovm.ValidateProviderRunInput(input); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.record(runtimemicrovm.OperationRun, input.RequestID, input.TenantID, input.Namespace, input.SessionID)
+	if err := p.configuredError(runtimemicrovm.OperationRun, input.RequestID); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	key := providerKey(input.TenantID, input.Namespace, input.SessionID)
+	if _, exists := p.sessions[key]; exists {
+		return runtimemicrovm.ProviderSession{}, fakeProviderError(input.RequestID)
+	}
+	p.next++
+	session := runtimemicrovm.ProviderSession{
+		TenantID:          strings.TrimSpace(input.TenantID),
+		Namespace:         strings.TrimSpace(input.Namespace),
+		SessionID:         strings.TrimSpace(input.SessionID),
+		ProviderMicroVMID: fmt.Sprintf("microvm-%06d", p.next),
+		State:             runtimemicrovm.StateRunning,
+		ProviderState:     "running",
+		ImageRef:          strings.TrimSpace(input.ImageRef),
+		ImageVersion:      strings.TrimSpace(input.ImageVersion),
+		StartedAt:         p.now,
+		RegistryVersion:   p.next,
+	}
+	if err := runtimemicrovm.ValidateProviderSession(session); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	p.sessions[key] = session
+	return session, nil
+}
+
+// Get returns a tenant-bound fake provider session.
+func (p *FakeProvider) Get(_ context.Context, input runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error) {
+	return p.lookup(runtimemicrovm.OperationGet, input)
+}
+
+// List returns deterministic fake provider sessions for one tenant and namespace.
+func (p *FakeProvider) List(_ context.Context, input runtimemicrovm.ProviderListInput) (runtimemicrovm.ProviderListOutput, error) {
+	if err := runtimemicrovm.ValidateProviderListInput(input); err != nil {
+		return runtimemicrovm.ProviderListOutput{}, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.record(runtimemicrovm.OperationList, input.RequestID, input.TenantID, input.Namespace, "")
+	if err := p.configuredError(runtimemicrovm.OperationList, input.RequestID); err != nil {
+		return runtimemicrovm.ProviderListOutput{}, err
+	}
+	sessions := make([]runtimemicrovm.ProviderSession, 0)
+	for _, session := range p.sessions {
+		if session.TenantID != strings.TrimSpace(input.TenantID) || session.Namespace != strings.TrimSpace(input.Namespace) {
+			continue
+		}
+		if input.ImageRef != "" && session.ImageRef != strings.TrimSpace(input.ImageRef) {
+			continue
+		}
+		if input.ImageVersion != "" && session.ImageVersion != strings.TrimSpace(input.ImageVersion) {
+			continue
+		}
+		sessions = append(sessions, session)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].SessionID < sessions[j].SessionID
+	})
+	return runtimemicrovm.ProviderListOutput{Sessions: sessions}, nil
+}
+
+// Suspend marks a fake provider session suspended.
+func (p *FakeProvider) Suspend(_ context.Context, input runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error) {
+	return p.transition(runtimemicrovm.OperationSuspend, input, "suspended", p.now, time.Time{})
+}
+
+// Resume marks a fake provider session ready.
+func (p *FakeProvider) Resume(_ context.Context, input runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error) {
+	return p.transition(runtimemicrovm.OperationResume, input, "ready", p.now, time.Time{})
+}
+
+// Terminate marks a fake provider session terminated.
+func (p *FakeProvider) Terminate(_ context.Context, input runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error) {
+	return p.transition(runtimemicrovm.OperationTerminate, input, "terminated", p.now, p.now)
+}
+
+// CreateAuthToken returns sanitized deterministic auth-token metadata.
+func (p *FakeProvider) CreateAuthToken(_ context.Context, input runtimemicrovm.ProviderTokenInput) (runtimemicrovm.ProviderToken, error) {
+	return p.token(runtimemicrovm.OperationAuthToken, input)
+}
+
+// CreateShellToken returns sanitized deterministic shell-token metadata.
+func (p *FakeProvider) CreateShellToken(_ context.Context, input runtimemicrovm.ProviderTokenInput) (runtimemicrovm.ProviderToken, error) {
+	return p.token(runtimemicrovm.OperationShellToken, input)
+}
+
+func (p *FakeProvider) lookup(operation runtimemicrovm.Operation, input runtimemicrovm.ProviderSessionInput) (runtimemicrovm.ProviderSession, error) {
+	if err := runtimemicrovm.ValidateProviderSessionInput(operation, input); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.record(operation, input.RequestID, input.TenantID, input.Namespace, input.Binding.SessionID)
+	if err := p.configuredError(operation, input.RequestID); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	session, err := p.boundSession(input.RequestID, input.Binding)
+	if err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	return session, nil
+}
+
+func (p *FakeProvider) transition(operation runtimemicrovm.Operation, input runtimemicrovm.ProviderSessionInput, providerState string, updatedAt time.Time, terminatedAt time.Time) (runtimemicrovm.ProviderSession, error) {
+	if err := runtimemicrovm.ValidateProviderSessionInput(operation, input); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.record(operation, input.RequestID, input.TenantID, input.Namespace, input.Binding.SessionID)
+	if err := p.configuredError(operation, input.RequestID); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	session, err := p.boundSession(input.RequestID, input.Binding)
+	if err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	state, terminal, err := runtimemicrovm.MapProviderState(providerState)
+	if err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	session.ProviderState = providerState
+	session.State = state
+	session.Terminal = terminal
+	if !updatedAt.IsZero() && session.StartedAt.IsZero() {
+		session.StartedAt = updatedAt.UTC()
+	}
+	session.TerminatedAt = terminatedAt.UTC()
+	session.RegistryVersion++
+	if err := runtimemicrovm.ValidateProviderSession(session); err != nil {
+		return runtimemicrovm.ProviderSession{}, err
+	}
+	p.sessions[session.Key()] = session
+	return session, nil
+}
+
+func (p *FakeProvider) token(operation runtimemicrovm.Operation, input runtimemicrovm.ProviderTokenInput) (runtimemicrovm.ProviderToken, error) {
+	if err := runtimemicrovm.ValidateProviderTokenInput(operation, input); err != nil {
+		return runtimemicrovm.ProviderToken{}, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.record(operation, input.RequestID, input.TenantID, input.Namespace, input.Binding.SessionID)
+	if err := p.configuredError(operation, input.RequestID); err != nil {
+		return runtimemicrovm.ProviderToken{}, err
+	}
+	if _, err := p.boundSession(input.RequestID, input.Binding); err != nil {
+		return runtimemicrovm.ProviderToken{}, err
+	}
+	tokenType := "auth"
+	scope := fakeProviderTokenScope(input.AllowedPortScope)
+	if operation == runtimemicrovm.OperationShellToken {
+		tokenType = "shell"
+		scope = []string{"shell"}
+	}
+	ttl := input.TTLSeconds
+	if ttl == 0 {
+		ttl = 900
+	}
+	p.tokens++
+	token := runtimemicrovm.ProviderToken{
+		TenantID:          input.Binding.TenantID,
+		Namespace:         input.Binding.Namespace,
+		SessionID:         input.Binding.SessionID,
+		ProviderMicroVMID: input.Binding.ProviderMicroVMID,
+		TokenID:           fmt.Sprintf("%s-%06d", tokenType, p.tokens),
+		TokenType:         tokenType,
+		ExpiresAt:         p.now.Add(time.Duration(ttl) * time.Second).UTC(),
+		Scope:             scope,
+	}
+	if err := runtimemicrovm.ValidateProviderToken(token); err != nil {
+		return runtimemicrovm.ProviderToken{}, err
+	}
+	return token, nil
+}
+
+func (p *FakeProvider) boundSession(requestID string, binding runtimemicrovm.ProviderSessionBinding) (runtimemicrovm.ProviderSession, error) {
+	session, ok := p.sessions[binding.Key()]
+	if !ok || session.ProviderMicroVMID != strings.TrimSpace(binding.ProviderMicroVMID) {
+		return runtimemicrovm.ProviderSession{}, runtimemicrovm.SafeError{
+			Code:      runtimemicrovm.ErrorCodeTenantBindingViolation,
+			Message:   "apptheory: microvm provider binding is not available",
+			RequestID: requestID,
+		}
+	}
+	return session, nil
+}
+
+func (p *FakeProvider) configuredError(operation runtimemicrovm.Operation, requestID string) error {
+	if err := p.errors[operation]; err != nil {
+		_ = err
+		return fakeProviderError(requestID)
+	}
+	return nil
+}
+
+func (p *FakeProvider) record(operation runtimemicrovm.Operation, requestID, tenantID, namespace, sessionID string) {
+	p.calls = append(p.calls, ProviderCall{
+		Operation: operation,
+		RequestID: strings.TrimSpace(requestID),
+		TenantID:  strings.TrimSpace(tenantID),
+		Namespace: strings.TrimSpace(namespace),
+		SessionID: strings.TrimSpace(sessionID),
+	})
+}
+
+func fakeProviderError(requestID string) error {
+	return runtimemicrovm.SafeError{
+		Code:      runtimemicrovm.ErrorCodeProviderOperationFailed,
+		Message:   "apptheory: microvm provider operation failed",
+		RequestID: strings.TrimSpace(requestID),
+	}
+}
+
+func fakeProviderTokenScope(scopes []runtimemicrovm.ProviderPortScope) []string {
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		switch {
+		case scope.AllPorts:
+			out = append(out, "ports:*")
+		case scope.Port > 0:
+			out = append(out, fmt.Sprintf("ports:%d", scope.Port))
+		default:
+			out = append(out, fmt.Sprintf("ports:%d-%d", scope.StartPort, scope.EndPort))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func providerKey(tenantID, namespace, sessionID string) runtimemicrovm.SessionKey {
+	return runtimemicrovm.SessionKey{TenantID: strings.TrimSpace(tenantID), Namespace: strings.TrimSpace(namespace), SessionID: strings.TrimSpace(sessionID)}
+}

--- a/testkit/microvm/provider_test.go
+++ b/testkit/microvm/provider_test.go
@@ -1,0 +1,190 @@
+package microvm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+)
+
+func TestFakeProviderCoversAllM16Operations(t *testing.T) {
+	now := time.Unix(1000, 0).UTC()
+	provider := NewFakeProviderWithTime(now)
+
+	run, err := provider.Run(context.Background(), fakeRunInput("req-run", "session-1", "image-ref"))
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateRunning, run.State)
+	require.Equal(t, "running", run.ProviderState)
+
+	binding := run.Binding()
+	got, err := provider.Get(context.Background(), fakeSessionInput("req-get", binding))
+	require.NoError(t, err)
+	require.Equal(t, binding, got.Binding())
+
+	list, err := provider.List(context.Background(), runtimemicrovm.ProviderListInput{
+		RequestID:   "req-list",
+		TenantID:    "tenant-1",
+		Namespace:   "namespace-1",
+		AuthContext: fakeAuth(),
+	})
+	require.NoError(t, err)
+	require.Len(t, list.Sessions, 1)
+
+	suspended, err := provider.Suspend(context.Background(), fakeSessionInput("req-suspend", binding))
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateSuspended, suspended.State)
+
+	resumed, err := provider.Resume(context.Background(), fakeSessionInput("req-resume", suspended.Binding()))
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateReady, resumed.State)
+	require.Equal(t, "ready", resumed.ProviderState)
+
+	authToken, err := provider.CreateAuthToken(context.Background(), fakeTokenInput("req-auth", resumed.Binding()))
+	require.NoError(t, err)
+	require.Equal(t, "auth", authToken.TokenType)
+	require.Equal(t, []string{"ports:443"}, authToken.Scope)
+
+	shellToken, err := provider.CreateShellToken(context.Background(), fakeTokenInput("req-shell", resumed.Binding()))
+	require.NoError(t, err)
+	require.Equal(t, "shell", shellToken.TokenType)
+	require.Equal(t, []string{"shell"}, shellToken.Scope)
+
+	terminated, err := provider.Terminate(context.Background(), fakeSessionInput("req-terminate", resumed.Binding()))
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.StateTerminated, terminated.State)
+	require.True(t, terminated.Terminal)
+
+	calls := provider.Calls()
+	require.Len(t, calls, 8)
+	require.Equal(t, runtimemicrovm.OperationRun, calls[0].Operation)
+	require.Equal(t, runtimemicrovm.OperationTerminate, calls[7].Operation)
+}
+
+func TestFakeProviderTenantBindingTokenSafetyAndSanitizedErrors(t *testing.T) {
+	provider := NewFakeProviderWithTime(time.Unix(1100, 0).UTC())
+	run, err := provider.Run(context.Background(), fakeRunInput("req-run", "session-1", "image-ref"))
+	require.NoError(t, err)
+
+	crossTenant := fakeSessionInput("req-cross", run.Binding())
+	crossTenant.TenantID = "tenant-2"
+	_, err = provider.Get(context.Background(), crossTenant)
+	requireRuntimeSafeError(t, err, runtimemicrovm.ErrorCodeTenantBindingViolation)
+
+	_, err = provider.List(context.Background(), runtimemicrovm.ProviderListInput{
+		RequestID:   "req-list-cross",
+		TenantID:    "tenant-2",
+		Namespace:   "namespace-1",
+		AuthContext: runtimemicrovm.AuthContext{Subject: "subject-2", TenantID: "tenant-2", Namespace: "namespace-1"},
+		KnownSessions: []runtimemicrovm.ProviderSessionBinding{
+			run.Binding(),
+		},
+	})
+	requireRuntimeSafeError(t, err, runtimemicrovm.ErrorCodeTenantBindingViolation)
+
+	token, err := provider.CreateAuthToken(context.Background(), fakeTokenInput("req-auth", run.Binding()))
+	require.NoError(t, err)
+	encoded, err := json.Marshal(token)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "plaintext_token")
+	require.NotContains(t, string(encoded), "bearer_token")
+	require.NotContains(t, string(encoded), "X-aws-proxy-auth")
+
+	provider.SetOperationError(runtimemicrovm.OperationGet, errors.New("provider leaked bearer_token raw_sdk_client"))
+	_, err = provider.Get(context.Background(), fakeSessionInput("req-raw", run.Binding()))
+	requireRuntimeSafeError(t, err, runtimemicrovm.ErrorCodeProviderOperationFailed)
+	require.NotContains(t, err.Error(), "bearer_token")
+	require.NotContains(t, err.Error(), "raw_sdk_client")
+}
+
+func TestFakeProviderRejectsInvalidTokenAndForbiddenRunMetadata(t *testing.T) {
+	provider := NewFakeProvider()
+	provider.SetNow(time.Unix(1200, 0).UTC())
+	input := fakeRunInput("req-run", "session-1", "image-ref")
+	input.SessionSpec.Metadata = map[string]string{"raw_aws_credentials": "value"}
+	_, err := provider.Run(context.Background(), input)
+	requireRuntimeSafeError(t, err, runtimemicrovm.ErrorCodeForbiddenField)
+
+	run, err := provider.Run(context.Background(), fakeRunInput("req-run-2", "session-2", "image-ref"))
+	require.NoError(t, err)
+	token := fakeTokenInput("req-token", run.Binding())
+	token.AllowedPortScope = nil
+	_, err = provider.CreateAuthToken(context.Background(), token)
+	requireRuntimeSafeError(t, err, runtimemicrovm.ErrorCodeTokenSafetyViolation)
+
+	_, err = provider.Run(context.Background(), fakeRunInput("req-run-2", "session-2", "image-ref"))
+	requireRuntimeSafeError(t, err, runtimemicrovm.ErrorCodeProviderOperationFailed)
+	provider.SetOperationError(runtimemicrovm.OperationRun, nil)
+
+	filtered, err := provider.List(context.Background(), runtimemicrovm.ProviderListInput{
+		RequestID:   "req-list-filter",
+		TenantID:    "tenant-1",
+		Namespace:   "namespace-1",
+		AuthContext: fakeAuth(),
+		ImageRef:    "does-not-match",
+	})
+	require.NoError(t, err)
+	require.Empty(t, filtered.Sessions)
+
+	allPortsToken := fakeTokenInput("req-all-ports", run.Binding())
+	allPortsToken.AllowedPortScope = []runtimemicrovm.ProviderPortScope{{AllPorts: true}, {StartPort: 8000, EndPort: 8001}}
+	tokenOut, err := provider.CreateAuthToken(context.Background(), allPortsToken)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ports:*", "ports:8000-8001"}, tokenOut.Scope)
+
+	zero := NewFakeProviderWithTime(time.Time{})
+	require.False(t, zero.now.IsZero())
+}
+
+func fakeRunInput(requestID, sessionID, imageRef string) runtimemicrovm.ProviderRunInput {
+	return runtimemicrovm.ProviderRunInput{
+		RequestID:           requestID,
+		TenantID:            "tenant-1",
+		Namespace:           "namespace-1",
+		SessionID:           sessionID,
+		AuthContext:         fakeAuth(),
+		ImageRef:            imageRef,
+		NetworkConnectorRef: "network-ref",
+		SessionSpec:         runtimemicrovm.SessionSpec{Metadata: map[string]string{"purpose": "test"}},
+	}
+}
+
+func fakeSessionInput(requestID string, binding runtimemicrovm.ProviderSessionBinding) runtimemicrovm.ProviderSessionInput {
+	return runtimemicrovm.ProviderSessionInput{
+		RequestID:   requestID,
+		TenantID:    binding.TenantID,
+		Namespace:   binding.Namespace,
+		AuthContext: fakeAuth(),
+		Binding:     binding,
+	}
+}
+
+func fakeTokenInput(requestID string, binding runtimemicrovm.ProviderSessionBinding) runtimemicrovm.ProviderTokenInput {
+	return runtimemicrovm.ProviderTokenInput{
+		RequestID:   requestID,
+		TenantID:    binding.TenantID,
+		Namespace:   binding.Namespace,
+		AuthContext: fakeAuth(),
+		Binding:     binding,
+		TTLSeconds:  120,
+		AllowedPortScope: []runtimemicrovm.ProviderPortScope{
+			{Port: 443},
+		},
+	}
+}
+
+func fakeAuth() runtimemicrovm.AuthContext {
+	return runtimemicrovm.AuthContext{Subject: "subject-1", TenantID: "tenant-1", Namespace: "namespace-1"}
+}
+
+func requireRuntimeSafeError(t *testing.T, err error, code string) {
+	t.Helper()
+	require.Error(t, err)
+	var safe runtimemicrovm.SafeError
+	require.ErrorAs(t, err, &safe)
+	require.Equal(t, code, safe.Code)
+}


### PR DESCRIPTION
## Milestone
M16 Go Provider Adapter — add the Go constrained AWS Lambda MicroVM provider adapter and deterministic fake provider.

## Linear
https://linear.app/theorycloud/project/corrective-first-class-aws-lambda-microvm-support-83b6988ac556/overview / M16 Go Provider Adapter

## Summary
- Adds the safe Go `microvm.Provider` surface for run/get/list/suspend/resume/terminate/auth-token/shell-token.
- Adds the official AWS SDK-backed `AWSLambdaMicroVMProvider` using `github.com/aws/aws-sdk-go-v2/service/lambdamicrovms` behind an internal constrained seam.
- Adds deterministic `testkit/microvm.FakeProvider` coverage for all eight operations, tenant/session binding, provider state mapping, and sanitized token metadata.
- Updates the Go API snapshot for the new public Go surface only.

## Contract impact
Go provider adapter milestone for the existing M16 real MicroVM contract from PR #734. This does not redefine the M16 fixture truth and does not implement TS/Py provider parity, registry recovery, controller route replacement, CDK changes, or live AWS/cloud mutations.

## Validation
Commands run on the final commit:
- `go test ./runtime/microvm ./testkit/microvm ./contract-tests/runners/go`
- `./scripts/update-api-snapshots.sh`
- `./scripts/verify-api-snapshots.sh`
- `./scripts/verify-contract-tests.sh`
- `make test`
- `make lint`
- `make rubric`

## Security notes
The public AppTheory surface does not expose raw AWS SDK clients, AWS config credentials, provider bearer/session token plaintext, or raw provider payloads. Token operations return sanitized issuance metadata only.
