### PR TITLE
feat(microvm): add EqualToAI conformance harness

### DIFF
--- a/examples/microvm-conformance/README.md
+++ b/examples/microvm-conformance/README.md
@@ -1,0 +1,90 @@
+# AppTheory MicroVM Consumer Conformance Harness
+
+This harness is the AppTheory-owned validation surface for an external consumer, such as EqualToAI/Host, to run against a **consumer-provided lab deployment** of the canonical AppTheory MicroVM controller.
+
+It proves the AppTheory framework contract that can be observed from outside the deployment:
+
+- canonical controller vocabulary and routes: `run`, `get`, `list`, `suspend`, `resume`, `terminate`, `auth-token`, and `shell-auth-token`;
+- fail-closed missing/invalid auth and safe tenant/namespace negative checks;
+- tenant/namespace-bound list and get behavior, without treating AppTheory as product business truth;
+- sanitized token metadata only for `auth-token` and `shell-auth-token` responses;
+- cleanup by exercising `terminate` and requiring post-terminate terminal-or-denied behavior;
+- token/secret no-leak scanning across responses plus supplied registry-record and log artifacts.
+
+`shell-auth-token` is canonical. `shell-token` is not used as a canonical route or command by this harness.
+
+## Proof boundary
+
+A local dry-run proves only that the harness, assertions, fixture transport, and leak scanner are ready. It does **not** prove live AWS Lambda MicroVM operation, mutate AWS, validate EqualToAI/Host infrastructure, or certify customer workload/platform readiness.
+
+Live proof exists only when EqualToAI/Host runs this harness against its deployed lab controller with real lab configuration and supplies any registry/log artifacts it wants included in the no-leak boundary.
+
+The registry checks are intentionally bounded: AppTheory verifies observable tenant/namespace binding in controller responses and supplied registry-record-like JSON artifacts. Product-owned reconstruction truth remains outside AppTheory.
+
+## Configuration
+
+Copy `equaltoai-host.config.example.json` outside the repo and replace placeholders with lab values. Keep the auth token in an environment variable; do not put live tokens in the JSON file.
+
+Required fields:
+
+- `endpoint`: base URL for the lab AppTheory MicroVM controller.
+- `auth_token_env`: environment variable that contains the lab bearer token.
+- `tenant_id` and `namespace`: the tenant/namespace the lab token should be bound to.
+- `run.image_ref` and `run.network_connector_ref`: lab MicroVM image and connector references.
+
+Optional scanner fields:
+
+- `scanner.registry_artifact_paths`: JSON registry-record-like files to scan and tenant-check.
+- `scanner.log_artifact_paths`: text or JSON logs to scan.
+- `scanner.sensitive_value_env`: additional environment variables whose values must never appear in scanned artifacts.
+
+All example values are obvious placeholders. Do not replace them with fake-but-real-looking AWS keys or credentials.
+
+## Local dry-run
+
+From the AppTheory repo root:
+
+```bash
+./scripts/verify-microvm-conformance-harness.sh
+```
+
+Equivalent direct commands:
+
+```bash
+python3 scripts/test_microvm_conformance.py
+python3 scripts/microvm_conformance.py run \
+  --config examples/microvm-conformance/equaltoai-host.config.example.json \
+  --dry-run \
+  --fixture examples/microvm-conformance/fixtures/no-leak-artifacts.json
+python3 scripts/microvm_conformance.py scan \
+  --artifact no-leak=examples/microvm-conformance/fixtures/scanner-no-leak-artifacts.json \
+  --sensitive-value auth-token-DO-NOT-LOG-123456 \
+  --sensitive-value provider-token-DO-NOT-LOG-123456
+```
+
+## Live lab run
+
+After exporting the lab token, run:
+
+```bash
+export APPTHEORY_MICROVM_CONFORMANCE_AUTH_TOKEN='<lab-token-from-EqualToAI-Host-secret-store>'
+python3 scripts/microvm_conformance.py run --config /path/to/equaltoai-host.lab.json
+```
+
+The harness does not print the token or response bodies. On a leak, it reports the artifact and finding type with the value suppressed.
+
+A passing live run means the supplied lab deployment satisfied the externally observable AppTheory conformance boundary at the time of the run. It is not a general AWS account audit and not a customer readiness claim.
+
+## Token leak scanner only
+
+To scan collected response, registry, and log artifacts without running controller operations:
+
+```bash
+python3 scripts/microvm_conformance.py scan \
+  --artifact responses=/path/to/responses.json \
+  --artifact registry=/path/to/registry-records.json \
+  --artifact logs=/path/to/controller.log \
+  --sensitive-env APPTHEORY_MICROVM_CONFORMANCE_AUTH_TOKEN
+```
+
+The scanner fails closed on plaintext supplied sensitive values, bearer credentials, private keys, AWS-looking credentials, forbidden credential fields such as `token_value` or `provider_token`, and secret-looking field names that are not AppTheory's sanitized token metadata.

--- a/examples/microvm-conformance/README.md
+++ b/examples/microvm-conformance/README.md
@@ -87,4 +87,4 @@ python3 scripts/microvm_conformance.py scan \
   --sensitive-env APPTHEORY_MICROVM_CONFORMANCE_AUTH_TOKEN
 ```
 
-The scanner fails closed on plaintext supplied sensitive values, bearer credentials, private keys, AWS-looking credentials, forbidden credential fields such as `token_value` or `provider_token`, and secret-looking field names that are not AppTheory's sanitized token metadata.
+The scanner fails closed on plaintext supplied sensitive values, bearer credentials, private keys, AWS-looking credentials, forbidden credential fields such as `token_value`, `provider_token`, or `session_token_plaintext`, and secret-looking field names that are not AppTheory's sanitized token metadata.

--- a/examples/microvm-conformance/equaltoai-host.config.example.json
+++ b/examples/microvm-conformance/equaltoai-host.config.example.json
@@ -1,0 +1,37 @@
+{
+  "endpoint": "https://microvm-controller.example.invalid",
+  "auth_token_env": "APPTHEORY_MICROVM_CONFORMANCE_AUTH_TOKEN",
+  "tenant_id": "tenant-example",
+  "namespace": "namespace-example",
+  "timeout_seconds": 30,
+  "headers": {},
+  "run": {
+    "image_ref": "microvm-image-ref-placeholder",
+    "network_connector_ref": "microvm-egress-connector-ref-placeholder",
+    "ingress_network_connector_refs": [
+      "microvm-ingress-connector-ref-placeholder"
+    ],
+    "egress_network_connector_refs": [
+      "microvm-egress-connector-ref-placeholder"
+    ],
+    "session_spec": {
+      "metadata": {
+        "purpose": "apptheory-conformance"
+      }
+    },
+    "maximum_duration_seconds": 900,
+    "ttl_seconds": 1800
+  },
+  "negative": {
+    "tenant_id": "tenant-negative-example",
+    "namespace": "namespace-negative-example"
+  },
+  "scanner": {
+    "registry_artifact_paths": [],
+    "log_artifact_paths": [],
+    "sensitive_value_env": [
+      "APPTHEORY_MICROVM_CONFORMANCE_AUTH_TOKEN"
+    ],
+    "sensitive_values": []
+  }
+}

--- a/examples/microvm-conformance/fixtures/leak-artifacts.json
+++ b/examples/microvm-conformance/fixtures/leak-artifacts.json
@@ -1,0 +1,25 @@
+{
+  "responses": {
+    "auth-token": {
+      "status": 200,
+      "body": {
+        "command": "auth-token",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "token_value": "provider-token-DO-NOT-LOG-123456"
+      }
+    }
+  },
+  "registry_records": [
+    {
+      "tenant_id": "tenant-example",
+      "namespace": "namespace-example",
+      "session_id": "session-fixture-001",
+      "provider_token": "provider-token-DO-NOT-LOG-123456"
+    }
+  ],
+  "logs": [
+    "unexpected Authorization: Bearer provider-token-DO-NOT-LOG-123456"
+  ]
+}

--- a/examples/microvm-conformance/fixtures/no-leak-artifacts.json
+++ b/examples/microvm-conformance/fixtures/no-leak-artifacts.json
@@ -1,0 +1,200 @@
+{
+  "responses": {
+    "missing-auth": {
+      "status": 401,
+      "body": {
+        "error": {
+          "code": "m16.microvm.unauthenticated_controller",
+          "message": "controller requires authenticated access"
+        }
+      }
+    },
+    "invalid-auth": {
+      "status": 401,
+      "body": {
+        "error": {
+          "code": "m16.microvm.unauthenticated_controller",
+          "message": "controller rejected invalid access"
+        }
+      }
+    },
+    "run": {
+      "status": 200,
+      "body": {
+        "command": "run",
+        "request_id": "fixture-run",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "state": "running",
+        "provider_microvm_id": "provider-microvm-fixture-001",
+        "provider_state": "running",
+        "registry_version": 1
+      }
+    },
+    "get": {
+      "status": 200,
+      "body": {
+        "command": "get",
+        "request_id": "fixture-get",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "state": "running",
+        "provider_microvm_id": "provider-microvm-fixture-001",
+        "provider_state": "running",
+        "registry_version": 1
+      }
+    },
+    "list": {
+      "status": 200,
+      "body": {
+        "command": "list",
+        "request_id": "fixture-list",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "sessions": [
+          {
+            "tenant_id": "tenant-example",
+            "namespace": "namespace-example",
+            "session_id": "session-fixture-001",
+            "state": "running",
+            "provider_microvm_id": "provider-microvm-fixture-001",
+            "provider_state": "running",
+            "image_ref": "microvm-image-ref-placeholder"
+          }
+        ]
+      }
+    },
+    "tenant-mismatch-get": {
+      "status": 403,
+      "body": {
+        "error": {
+          "code": "m16.microvm.tenant_binding_violation",
+          "message": "tenant binding mismatch"
+        }
+      }
+    },
+    "namespace-mismatch-get": {
+      "status": 404,
+      "body": {
+        "error": {
+          "code": "m16.microvm.session_registry_incomplete",
+          "message": "session is not available for namespace"
+        }
+      }
+    },
+    "suspend": {
+      "status": 200,
+      "body": {
+        "command": "suspend",
+        "request_id": "fixture-suspend",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "state": "suspended",
+        "provider_microvm_id": "provider-microvm-fixture-001",
+        "provider_state": "suspended",
+        "registry_version": 2
+      }
+    },
+    "resume": {
+      "status": 200,
+      "body": {
+        "command": "resume",
+        "request_id": "fixture-resume",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "state": "running",
+        "provider_microvm_id": "provider-microvm-fixture-001",
+        "provider_state": "running",
+        "registry_version": 3
+      }
+    },
+    "auth-token": {
+      "status": 200,
+      "body": {
+        "command": "auth-token",
+        "request_id": "fixture-auth-token",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "token_id": "auth-token-metadata-001",
+        "token_type": "auth",
+        "expires_at": "2026-06-25T12:15:00Z",
+        "scope": [
+          "ports:443"
+        ]
+      }
+    },
+    "shell-auth-token": {
+      "status": 200,
+      "body": {
+        "command": "shell-auth-token",
+        "request_id": "fixture-shell-auth-token",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "token_id": "shell-token-metadata-001",
+        "token_type": "shell",
+        "expires_at": "2026-06-25T12:15:00Z",
+        "scope": [
+          "shell"
+        ]
+      }
+    },
+    "terminate": {
+      "status": 200,
+      "body": {
+        "command": "terminate",
+        "request_id": "fixture-terminate",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "state": "terminated",
+        "provider_microvm_id": "provider-microvm-fixture-001",
+        "provider_state": "terminated",
+        "registry_version": 4
+      }
+    },
+    "post-terminate-get": {
+      "status": 200,
+      "body": {
+        "command": "get",
+        "request_id": "fixture-post-terminate-get",
+        "tenant_id": "tenant-example",
+        "namespace": "namespace-example",
+        "session_id": "session-fixture-001",
+        "state": "terminated",
+        "provider_microvm_id": "provider-microvm-fixture-001",
+        "provider_state": "terminated",
+        "registry_version": 4
+      }
+    }
+  },
+  "registry_records": [
+    {
+      "tenant_id": "tenant-example",
+      "namespace": "namespace-example",
+      "session_id": "session-fixture-001",
+      "state": "terminated",
+      "provider_microvm_id": "provider-microvm-fixture-001",
+      "provider_state": "terminated",
+      "token_metadata": [
+        {
+          "token_id": "auth-token-metadata-001",
+          "token_type": "auth",
+          "expires_at": "2026-06-25T12:15:00Z",
+          "scope": [
+            "ports:443"
+          ]
+        }
+      ]
+    }
+  ],
+  "logs": [
+    "microvm controller issued sanitized auth-token metadata token_id=auth-token-metadata-001",
+    "microvm controller issued sanitized shell-auth-token metadata token_id=shell-token-metadata-001"
+  ]
+}

--- a/examples/microvm-conformance/fixtures/scanner-no-leak-artifacts.json
+++ b/examples/microvm-conformance/fixtures/scanner-no-leak-artifacts.json
@@ -1,0 +1,50 @@
+{
+  "responses": [
+    {
+      "command": "auth-token",
+      "tenant_id": "tenant-example",
+      "namespace": "namespace-example",
+      "session_id": "session-fixture-001",
+      "token_id": "auth-token-metadata-001",
+      "token_type": "auth",
+      "expires_at": "2026-06-25T12:15:00Z",
+      "scope": [
+        "ports:443"
+      ]
+    },
+    {
+      "command": "shell-auth-token",
+      "tenant_id": "tenant-example",
+      "namespace": "namespace-example",
+      "session_id": "session-fixture-001",
+      "token_id": "shell-token-metadata-001",
+      "token_type": "shell",
+      "expires_at": "2026-06-25T12:15:00Z",
+      "scope": [
+        "shell"
+      ]
+    }
+  ],
+  "registry_records": [
+    {
+      "tenant_id": "tenant-example",
+      "namespace": "namespace-example",
+      "session_id": "session-fixture-001",
+      "state": "running",
+      "provider_microvm_id": "provider-microvm-fixture-001",
+      "token_metadata": [
+        {
+          "token_id": "auth-token-metadata-001",
+          "token_type": "auth",
+          "expires_at": "2026-06-25T12:15:00Z",
+          "scope": [
+            "ports:443"
+          ]
+        }
+      ]
+    }
+  ],
+  "logs": [
+    "microvm controller emitted sanitized token_id=auth-token-metadata-001 only"
+  ]
+}

--- a/scripts/microvm_conformance.py
+++ b/scripts/microvm_conformance.py
@@ -50,6 +50,7 @@ SAFE_TOKEN_FIELD_NAMES = {
 }
 
 FORBIDDEN_FIELD_NAMES = {
+    "account_wide_list_token",
     "authorization",
     "authorization_header",
     "auth_header",
@@ -61,12 +62,20 @@ FORBIDDEN_FIELD_NAMES = {
     "credentials",
     "password",
     "plaintext_token",
+    "provider_error",
+    "provider_exception",
     "private_key",
     "provider_auth_token",
+    "provider_secret",
     "provider_shell_token",
     "provider_token",
     "provider_token_value",
+    "raw_aws_credentials",
+    "raw_lifecycle_hook_payload",
+    "raw_provider_error",
+    "raw_provider_exception",
     "raw_secret",
+    "raw_sdk_client",
     "raw_token",
     "refresh_token",
     "secret",
@@ -74,9 +83,11 @@ FORBIDDEN_FIELD_NAMES = {
     "secret_key",
     "secret_value",
     "session_token",
+    "session_token_plaintext",
     "shell_token",
     "token",
     "token_value",
+    "x_amz_security_token",
     "x_aws_proxy_auth",
     "aws_access_key_id",
     "aws_secret_access_key",
@@ -88,6 +99,11 @@ SECRET_KEY_FRAGMENTS = (
     "password",
     "credential",
     "private_key",
+)
+
+SESSION_TOKEN_PLAINTEXT_TEXT_PATTERN = re.compile(
+    r"(?i)(?:^|[^A-Za-z0-9_])session[_-]?token[_-]?plaintext(?![A-Za-z0-9_])"
+    r"\s*[:=]\s*[\"']?[A-Za-z0-9._~+/=-]{1,}"
 )
 
 TEXT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -179,6 +195,15 @@ class LeakScanner:
                         message="secret-looking text appears in artifact",
                     )
                 )
+        if SESSION_TOKEN_PLAINTEXT_TEXT_PATTERN.search(text):
+            findings.append(
+                LeakFinding(
+                    artifact=artifact,
+                    path="$",
+                    kind="forbidden-field",
+                    message="field 'session_token_plaintext' must not carry plaintext credentials or provider tokens",
+                )
+            )
         payload = _parse_json_maybe(text)
         if payload is not _NOT_JSON:
             findings.extend(self.scan_json(artifact, payload))
@@ -529,7 +554,14 @@ class MicroVMConformanceHarness:
         self._expect_success(payload, command, session_id=session_id)
         if not payload.get("token_id") or not payload.get("token_type") or not payload.get("expires_at"):
             raise ConformanceFailure(f"{command} did not return sanitized token metadata")
-        forbidden = {"token_value", "bearer_token", "provider_token", "shell_token", "auth_token"}
+        forbidden = {
+            "token_value",
+            "bearer_token",
+            "provider_token",
+            "shell_token",
+            "auth_token",
+            "session_token_plaintext",
+        }
         present = sorted(field for field in forbidden if field in payload and payload[field])
         if present:
             raise ConformanceFailure(f"{command} returned forbidden plaintext token fields: {', '.join(present)}")

--- a/scripts/microvm_conformance.py
+++ b/scripts/microvm_conformance.py
@@ -1,0 +1,852 @@
+#!/usr/bin/env python3
+"""AppTheory MicroVM conformance harness and token leak scanner.
+
+This script is intentionally dependency-free so external consumers can copy or
+run it from a pinned AppTheory GitHub release asset without provisioning live AWS
+credentials on the AppTheory side. Live mode talks only to a supplied AppTheory
+MicroVM controller endpoint. Dry-run mode uses deterministic fixture transport
+and makes no network calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+CANONICAL_COMMANDS: tuple[str, ...] = (
+    "run",
+    "get",
+    "list",
+    "suspend",
+    "resume",
+    "terminate",
+    "auth-token",
+    "shell-auth-token",
+)
+
+TERMINAL_STATES = {"terminated", "terminating", "stopped", "deleted", "deleting"}
+DENIAL_STATUSES = {400, 401, 403, 404, 410, 422, 502}
+AUTH_DENIAL_STATUSES = {401, 403}
+
+SAFE_TOKEN_FIELD_NAMES = {
+    "token_id",
+    "token_type",
+    "token_metadata",
+    "tokens_metadata",
+    "expires_at",
+    "scope",
+    "allowed_port_scope",
+}
+
+FORBIDDEN_FIELD_NAMES = {
+    "authorization",
+    "authorization_header",
+    "auth_header",
+    "auth_token",
+    "auth_token_value",
+    "bearer",
+    "bearer_token",
+    "credential",
+    "credentials",
+    "password",
+    "plaintext_token",
+    "private_key",
+    "provider_auth_token",
+    "provider_shell_token",
+    "provider_token",
+    "provider_token_value",
+    "raw_secret",
+    "raw_token",
+    "refresh_token",
+    "secret",
+    "secret_access_key",
+    "secret_key",
+    "secret_value",
+    "session_token",
+    "shell_token",
+    "token",
+    "token_value",
+    "x_aws_proxy_auth",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+}
+
+SECRET_KEY_FRAGMENTS = (
+    "secret",
+    "password",
+    "credential",
+    "private_key",
+)
+
+TEXT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("bearer credential", re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}")),
+    ("aws access key", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")),
+    ("private key block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    (
+        "secret-looking key/value",
+        re.compile(
+            r"(?i)\b(?!token_id\b|token_type\b|token_metadata\b)"
+            r"(?:token|auth[_-]?token|secret|password|credential|api[_-]?key|private[_-]?key)"
+            r"\s*[:=]\s*[\"']?[A-Za-z0-9._~+/=-]{8,}"
+        ),
+    ),
+)
+
+
+class ConformanceFailure(RuntimeError):
+    """Raised when the harness cannot prove the requested contract boundary."""
+
+
+@dataclasses.dataclass(slots=True)
+class LeakFinding:
+    artifact: str
+    path: str
+    kind: str
+    message: str
+
+    def format(self) -> str:
+        location = f"{self.artifact}:{self.path}" if self.path else self.artifact
+        return f"{location}: {self.kind}: {self.message}"
+
+
+@dataclasses.dataclass(slots=True)
+class HTTPResult:
+    status: int
+    body: str
+    headers: Mapping[str, str] = dataclasses.field(default_factory=dict)
+
+    def json(self) -> Any:
+        if not self.body.strip():
+            return None
+        return json.loads(self.body)
+
+
+@dataclasses.dataclass(slots=True)
+class OperationProof:
+    name: str
+    status: int
+    command: str = ""
+    session_id: str = ""
+    denied: bool = False
+
+
+class LeakScanner:
+    """Scans response, registry, and log artifacts for secret leakage.
+
+    The scanner intentionally favors fail-closed findings over optimistic
+    "sanitized" claims. It allows AppTheory's sanitized token metadata fields
+    (`token_id`, `token_type`, `expires_at`, and `scope`) but treats plaintext
+    token fields, bearer values, provider token values, and supplied sensitive
+    values as leaks.
+    """
+
+    def __init__(self, sensitive_values: Iterable[str] = ()) -> None:
+        self.sensitive_values = tuple(
+            value.strip() for value in sensitive_values if isinstance(value, str) and value.strip()
+        )
+
+    def scan_text(self, artifact: str, text: str) -> list[LeakFinding]:
+        findings: list[LeakFinding] = []
+        for sensitive in self.sensitive_values:
+            if sensitive and sensitive in text:
+                findings.append(
+                    LeakFinding(
+                        artifact=artifact,
+                        path="$",
+                        kind="sensitive-value",
+                        message="a supplied sensitive value appears in plaintext",
+                    )
+                )
+        for kind, pattern in TEXT_PATTERNS:
+            if pattern.search(text):
+                findings.append(
+                    LeakFinding(
+                        artifact=artifact,
+                        path="$",
+                        kind=kind,
+                        message="secret-looking text appears in artifact",
+                    )
+                )
+        payload = _parse_json_maybe(text)
+        if payload is not _NOT_JSON:
+            findings.extend(self.scan_json(artifact, payload))
+        return _dedupe_findings(findings)
+
+    def scan_json(self, artifact: str, payload: Any) -> list[LeakFinding]:
+        findings: list[LeakFinding] = []
+
+        def visit(value: Any, path: str) -> None:
+            if isinstance(value, Mapping):
+                for raw_key, raw_child in value.items():
+                    key = str(raw_key)
+                    child_path = f"{path}.{key}" if path else key
+                    normalized = _normalize_key(key)
+                    if _is_safe_structural_key(key, raw_child):
+                        visit(raw_child, child_path)
+                        continue
+                    if _is_forbidden_field(normalized) and _has_non_empty_value(raw_child):
+                        findings.append(
+                            LeakFinding(
+                                artifact=artifact,
+                                path=child_path,
+                                kind="forbidden-field",
+                                message=f"field {key!r} must not carry plaintext credentials or provider tokens",
+                            )
+                        )
+                    elif _is_secret_looking_field(normalized) and _has_non_empty_value(raw_child):
+                        findings.append(
+                            LeakFinding(
+                                artifact=artifact,
+                                path=child_path,
+                                kind="secret-looking-field",
+                                message=f"field {key!r} looks credential-bearing and is not sanitized metadata",
+                            )
+                        )
+                    visit(raw_child, child_path)
+            elif isinstance(value, list):
+                for index, child in enumerate(value):
+                    visit(child, f"{path}[{index}]")
+            elif isinstance(value, str):
+                for sensitive in self.sensitive_values:
+                    if sensitive and sensitive in value:
+                        findings.append(
+                            LeakFinding(
+                                artifact=artifact,
+                                path=path or "$",
+                                kind="sensitive-value",
+                                message="a supplied sensitive value appears in plaintext",
+                            )
+                        )
+                for kind, pattern in TEXT_PATTERNS:
+                    if pattern.search(value):
+                        findings.append(
+                            LeakFinding(
+                                artifact=artifact,
+                                path=path or "$",
+                                kind=kind,
+                                message="secret-looking text appears in JSON value",
+                            )
+                        )
+
+        visit(payload, "$")
+        return _dedupe_findings(findings)
+
+    def assert_clean(self, artifacts: Mapping[str, str]) -> None:
+        findings: list[LeakFinding] = []
+        for name, text in artifacts.items():
+            findings.extend(self.scan_text(name, text))
+        if findings:
+            formatted = "\n".join(finding.format() for finding in findings)
+            raise ConformanceFailure(f"token leak scanner failed closed:\n{formatted}")
+
+
+class MicroVMConformanceHarness:
+    def __init__(self, config: Mapping[str, Any], transport: "Transport", scanner: LeakScanner) -> None:
+        self.config = config
+        self.transport = transport
+        self.scanner = scanner
+        self.tenant_id = _required_string(config, "tenant_id")
+        self.namespace = _required_string(config, "namespace")
+        negative = config.get("negative", {})
+        if not isinstance(negative, Mapping):
+            negative = {}
+        self.negative_tenant_id = str(negative.get("tenant_id") or f"{self.tenant_id}-negative")
+        self.negative_namespace = str(negative.get("namespace") or f"{self.namespace}-negative")
+        self.response_artifacts: dict[str, str] = {}
+        self.proofs: list[OperationProof] = []
+
+    def run(self) -> list[OperationProof]:
+        self._prove_auth_fail_closed()
+        run_payload = self._request_json("POST", "/microvms", self._run_body(), "run")
+        session_id = _required_payload_string(run_payload, "session_id", "run response")
+        self._expect_success(run_payload, "run", session_id=session_id)
+
+        self._expect_success(
+            self._request_json("GET", f"/microvms/{_quote_path(session_id)}", None, "get"),
+            "get",
+            session_id=session_id,
+        )
+        self._prove_registry_list_is_tenant_bound(session_id)
+        self._prove_tenant_and_namespace_fail_closed(session_id)
+
+        self._expect_success(
+            self._request_json("POST", f"/microvms/{_quote_path(session_id)}/suspend", {}, "suspend"),
+            "suspend",
+            session_id=session_id,
+        )
+        self._expect_success(
+            self._request_json("POST", f"/microvms/{_quote_path(session_id)}/resume", {}, "resume"),
+            "resume",
+            session_id=session_id,
+        )
+        self._expect_token_metadata(
+            self._request_json(
+                "POST",
+                f"/microvms/{_quote_path(session_id)}/auth-token",
+                {"allowed_port_scope": [{"port": 443}]},
+                "auth-token",
+            ),
+            "auth-token",
+            session_id,
+        )
+        self._expect_token_metadata(
+            self._request_json(
+                "POST",
+                f"/microvms/{_quote_path(session_id)}/shell-auth-token",
+                {},
+                "shell-auth-token",
+            ),
+            "shell-auth-token",
+            session_id,
+        )
+        self._expect_success(
+            self._request_json("DELETE", f"/microvms/{_quote_path(session_id)}", {}, "terminate"),
+            "terminate",
+            session_id=session_id,
+        )
+        self._prove_terminal_or_denied(session_id)
+        self._scan_supplied_artifacts(session_id)
+        self.scanner.assert_clean(self.response_artifacts)
+        self._assert_full_vocabulary()
+        return self.proofs
+
+    def _prove_auth_fail_closed(self) -> None:
+        missing = self._request("GET", "/microvms?max_results=1", None, "missing-auth", auth_mode="missing")
+        self._expect_denied("missing-auth", missing, AUTH_DENIAL_STATUSES)
+        invalid = self._request("GET", "/microvms?max_results=1", None, "invalid-auth", auth_mode="invalid")
+        self._expect_denied("invalid-auth", invalid, AUTH_DENIAL_STATUSES)
+
+    def _prove_registry_list_is_tenant_bound(self, session_id: str) -> None:
+        payload = self._request_json("GET", "/microvms?max_results=50", None, "list")
+        self._expect_success(payload, "list", session_id=session_id, allow_empty_session=True)
+        sessions = payload.get("sessions") if isinstance(payload, Mapping) else None
+        if not isinstance(sessions, list):
+            raise ConformanceFailure("list response must include a tenant-bound sessions array")
+        if not any(isinstance(item, Mapping) and item.get("session_id") == session_id for item in sessions):
+            raise ConformanceFailure("list response did not include the session created by this harness")
+        self._assert_records_tenant_bound(sessions, session_id, "list response")
+        self.proofs.append(OperationProof(name="list", status=200, command="list", session_id=session_id))
+
+    def _prove_tenant_and_namespace_fail_closed(self, session_id: str) -> None:
+        tenant_result = self._request(
+            "GET",
+            f"/microvms/{_quote_path(session_id)}?tenant_id={urllib.parse.quote(self.negative_tenant_id)}",
+            None,
+            "tenant-mismatch-get",
+        )
+        self._expect_denied("tenant-mismatch-get", tenant_result, DENIAL_STATUSES)
+
+        namespace_result = self._request(
+            "GET",
+            f"/microvms/{_quote_path(session_id)}",
+            None,
+            "namespace-mismatch-get",
+            namespace=self.negative_namespace,
+        )
+        if 200 <= namespace_result.status < 300:
+            payload = self._json_or_fail(namespace_result, "namespace-mismatch-get")
+            if isinstance(payload, Mapping) and payload.get("session_id") == session_id:
+                raise ConformanceFailure("namespace-mismatch-get returned the tenant session instead of failing closed")
+        else:
+            self._expect_denied("namespace-mismatch-get", namespace_result, DENIAL_STATUSES)
+
+    def _prove_terminal_or_denied(self, session_id: str) -> None:
+        result = self._request("GET", f"/microvms/{_quote_path(session_id)}", None, "post-terminate-get")
+        if 200 <= result.status < 300:
+            payload = self._json_or_fail(result, "post-terminate-get")
+            if not isinstance(payload, Mapping):
+                raise ConformanceFailure("post-terminate-get returned non-object JSON")
+            state_text = " ".join(
+                str(payload.get(field) or "") for field in ("state", "lifecycle_state", "provider_state")
+            ).lower()
+            if not any(state in state_text for state in TERMINAL_STATES):
+                raise ConformanceFailure("post-terminate-get did not report a terminal state")
+            self.proofs.append(
+                OperationProof(
+                    name="post-terminate-get",
+                    status=result.status,
+                    command=str(payload.get("command") or "get"),
+                    session_id=session_id,
+                )
+            )
+            return
+        self._expect_denied("post-terminate-get", result, DENIAL_STATUSES)
+
+    def _scan_supplied_artifacts(self, session_id: str) -> None:
+        artifacts: dict[str, str] = {}
+        scanner_config = self.config.get("scanner", {})
+        if not isinstance(scanner_config, Mapping):
+            scanner_config = {}
+        for group_name, key in (("registry", "registry_artifact_paths"), ("logs", "log_artifact_paths")):
+            for artifact_path in _string_list(scanner_config.get(key)):
+                path = Path(artifact_path)
+                if not path.is_file():
+                    raise ConformanceFailure(f"{group_name} artifact not found: {path}")
+                text = path.read_text(encoding="utf-8")
+                artifacts[f"{group_name}:{path}"] = text
+                if group_name == "registry":
+                    self._validate_registry_artifact(path, text, session_id)
+        self.scanner.assert_clean(artifacts)
+
+    def _validate_registry_artifact(self, path: Path, text: str, session_id: str) -> None:
+        payload = _parse_json_maybe(text)
+        if payload is _NOT_JSON:
+            raise ConformanceFailure(f"registry artifact must be JSON so tenant binding can be checked: {path}")
+        records = _find_record_like_objects(payload)
+        if not records:
+            raise ConformanceFailure(f"registry artifact contains no registry-record-like objects: {path}")
+        self._assert_records_tenant_bound(records, session_id, f"registry artifact {path}")
+
+    def _assert_records_tenant_bound(self, records: Sequence[Any], session_id: str, label: str) -> None:
+        for index, item in enumerate(records):
+            if not isinstance(item, Mapping):
+                continue
+            item_session = item.get("session_id") or item.get("SessionID")
+            if not item_session:
+                continue
+            tenant = item.get("tenant_id") or item.get("TenantID")
+            namespace = item.get("namespace") or item.get("Namespace")
+            if tenant != self.tenant_id or namespace != self.namespace:
+                raise ConformanceFailure(
+                    f"{label} is not tenant/namespace bound at record {index}: session={item_session!r}"
+                )
+            if item_session == session_id and not (tenant and namespace):
+                raise ConformanceFailure(f"{label} record for harness session is missing tenant or namespace")
+
+    def _run_body(self) -> dict[str, Any]:
+        run = self.config.get("run", {})
+        if not isinstance(run, Mapping):
+            raise ConformanceFailure("config.run must be an object")
+        body: dict[str, Any] = {
+            "tenant_id": self.tenant_id,
+            "namespace": self.namespace,
+            "image_ref": _required_string(run, "image_ref", "run"),
+            "network_connector_ref": _required_string(run, "network_connector_ref", "run"),
+            "session_spec": run.get("session_spec") if isinstance(run.get("session_spec"), Mapping) else {},
+        }
+        for key in (
+            "image_version",
+            "ingress_network_connector_refs",
+            "egress_network_connector_refs",
+            "idle_policy",
+            "maximum_duration_seconds",
+            "ttl_seconds",
+        ):
+            if key in run:
+                body[key] = run[key]
+        return body
+
+    def _request_json(self, method: str, path: str, body: Any, name: str) -> Mapping[str, Any]:
+        result = self._request(method, path, body, name)
+        if not (200 <= result.status < 300):
+            raise ConformanceFailure(f"{name} failed with HTTP {result.status}; response body suppressed")
+        payload = self._json_or_fail(result, name)
+        if not isinstance(payload, Mapping):
+            raise ConformanceFailure(f"{name} returned non-object JSON")
+        return payload
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: Any,
+        name: str,
+        *,
+        auth_mode: str = "valid",
+        namespace: str | None = None,
+    ) -> HTTPResult:
+        result = self.transport.request(
+            method,
+            path,
+            body,
+            self._headers(auth_mode=auth_mode, namespace=namespace),
+            name,
+        )
+        self.response_artifacts[f"response:{name}"] = result.body
+        self.scanner.assert_clean({f"response:{name}": result.body})
+        return result
+
+    def _headers(self, *, auth_mode: str, namespace: str | None = None) -> dict[str, str]:
+        headers = {
+            "content-type": "application/json",
+            "accept": "application/json",
+            "x-tenant-id": self.tenant_id,
+            "x-namespace-id": namespace or self.namespace,
+            "x-request-id": f"apptheory-conformance-{int(time.time())}",
+        }
+        extra_headers = self.config.get("headers", {})
+        if isinstance(extra_headers, Mapping):
+            for key, value in extra_headers.items():
+                if isinstance(key, str) and isinstance(value, str):
+                    headers[key] = value
+        if auth_mode == "valid":
+            token = _auth_token_from_config(self.config)
+            if token:
+                headers["authorization"] = f"Bearer {token}"
+        elif auth_mode == "invalid":
+            headers["authorization"] = "Bearer apptheory-conformance-invalid-token"
+        elif auth_mode != "missing":
+            raise ConformanceFailure(f"unknown auth mode {auth_mode!r}")
+        return headers
+
+    def _expect_success(
+        self,
+        payload: Mapping[str, Any],
+        command: str,
+        *,
+        session_id: str,
+        allow_empty_session: bool = False,
+    ) -> None:
+        actual = str(payload.get("command") or "")
+        if actual != command:
+            raise ConformanceFailure(f"expected command {command!r}, got {actual!r}")
+        if actual == "shell-token":
+            raise ConformanceFailure("shell-token is not canonical; expected shell-auth-token")
+        if str(payload.get("tenant_id") or "") not in {"", self.tenant_id}:
+            raise ConformanceFailure(f"{command} response crossed tenant boundary")
+        if str(payload.get("namespace") or "") not in {"", self.namespace}:
+            raise ConformanceFailure(f"{command} response crossed namespace boundary")
+        payload_session = str(payload.get("session_id") or "")
+        if not allow_empty_session and payload_session != session_id:
+            raise ConformanceFailure(f"{command} response returned wrong session binding")
+        if payload.get("error"):
+            raise ConformanceFailure(f"{command} response carried an error envelope")
+        self.proofs.append(OperationProof(name=command, status=200, command=actual, session_id=session_id))
+
+    def _expect_token_metadata(self, payload: Mapping[str, Any], command: str, session_id: str) -> None:
+        self._expect_success(payload, command, session_id=session_id)
+        if not payload.get("token_id") or not payload.get("token_type") or not payload.get("expires_at"):
+            raise ConformanceFailure(f"{command} did not return sanitized token metadata")
+        forbidden = {"token_value", "bearer_token", "provider_token", "shell_token", "auth_token"}
+        present = sorted(field for field in forbidden if field in payload and payload[field])
+        if present:
+            raise ConformanceFailure(f"{command} returned forbidden plaintext token fields: {', '.join(present)}")
+
+    def _expect_denied(self, name: str, result: HTTPResult, statuses: set[int]) -> None:
+        if result.status not in statuses:
+            raise ConformanceFailure(f"{name} expected fail-closed status {sorted(statuses)}, got {result.status}")
+        self.proofs.append(OperationProof(name=name, status=result.status, denied=True))
+
+    def _json_or_fail(self, result: HTTPResult, name: str) -> Any:
+        try:
+            return result.json()
+        except json.JSONDecodeError as exc:
+            raise ConformanceFailure(f"{name} did not return valid JSON") from exc
+
+    def _assert_full_vocabulary(self) -> None:
+        observed = {proof.command for proof in self.proofs if proof.command}
+        missing = [command for command in CANONICAL_COMMANDS if command not in observed]
+        if missing:
+            raise ConformanceFailure(f"harness did not prove canonical commands: {', '.join(missing)}")
+        if "shell-token" in observed:
+            raise ConformanceFailure("harness observed legacy shell-token as a canonical command")
+
+
+class Transport:
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: Any,
+        headers: Mapping[str, str],
+        name: str,
+    ) -> HTTPResult:
+        raise NotImplementedError
+
+
+class HTTPTransport(Transport):
+    def __init__(self, endpoint: str, timeout_seconds: float = 30.0) -> None:
+        self.endpoint = endpoint.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        parsed = urllib.parse.urlparse(self.endpoint)
+        if parsed.scheme not in {"https", "http"} or not parsed.netloc:
+            raise ConformanceFailure("config.endpoint must be an http(s) URL")
+        if parsed.scheme != "https" and parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+            raise ConformanceFailure("live conformance endpoints carrying bearer tokens must use https")
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: Any,
+        headers: Mapping[str, str],
+        name: str,
+    ) -> HTTPResult:
+        del name
+        data: bytes | None = None
+        if body is not None:
+            data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        request = urllib.request.Request(
+            self.endpoint + path,
+            data=data,
+            headers=dict(headers),
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:  # noqa: S310
+                return HTTPResult(
+                    status=response.status,
+                    body=response.read().decode("utf-8", errors="replace"),
+                    headers=dict(response.headers.items()),
+                )
+        except urllib.error.HTTPError as exc:
+            return HTTPResult(
+                status=exc.code,
+                body=exc.read().decode("utf-8", errors="replace"),
+                headers=dict(exc.headers.items()) if exc.headers else {},
+            )
+        except urllib.error.URLError as exc:
+            raise ConformanceFailure(f"live conformance request failed: {exc.reason}") from exc
+
+
+class FixtureTransport(Transport):
+    def __init__(self, fixture: Mapping[str, Any]) -> None:
+        responses = fixture.get("responses")
+        if not isinstance(responses, Mapping):
+            raise ConformanceFailure("dry-run fixture must contain a responses object")
+        self.responses = responses
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: Any,
+        headers: Mapping[str, str],
+        name: str,
+    ) -> HTTPResult:
+        del method, path, body, headers
+        raw = self.responses.get(name)
+        if not isinstance(raw, Mapping):
+            raise ConformanceFailure(f"dry-run fixture missing response for {name}")
+        status = int(raw.get("status", 200))
+        payload = raw.get("body", {})
+        text = payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True)
+        return HTTPResult(status=status, body=text, headers={})
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ConformanceFailure(f"invalid JSON config: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ConformanceFailure("config root must be a JSON object")
+    return payload
+
+
+def build_scanner(config: Mapping[str, Any], cli_sensitive_values: Sequence[str] = ()) -> LeakScanner:
+    values: list[str] = list(cli_sensitive_values)
+    token = _auth_token_from_config(config)
+    if token:
+        values.append(token)
+    scanner_config = config.get("scanner", {})
+    if isinstance(scanner_config, Mapping):
+        values.extend(_string_list(scanner_config.get("sensitive_values")))
+        for env_name in _string_list(scanner_config.get("sensitive_value_env")):
+            env_value = os.environ.get(env_name, "")
+            if env_value:
+                values.append(env_value)
+    return LeakScanner(values)
+
+
+def run_harness(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    scanner = build_scanner(config)
+    if args.dry_run:
+        fixture_path = Path(args.fixture) if args.fixture else Path("examples/microvm-conformance/fixtures/no-leak-artifacts.json")
+        fixture = load_config(fixture_path)
+        transport: Transport = FixtureTransport(fixture)
+    else:
+        if not _auth_token_from_config(config):
+            raise ConformanceFailure("live mode requires auth_token_env or auth_token to resolve a non-empty token")
+        endpoint = _required_string(config, "endpoint")
+        timeout = float(config.get("timeout_seconds", 30.0))
+        transport = HTTPTransport(endpoint, timeout)
+    proofs = MicroVMConformanceHarness(config, transport, scanner).run()
+    commands = ",".join(command for command in CANONICAL_COMMANDS if any(p.command == command for p in proofs))
+    denied = ",".join(proof.name for proof in proofs if proof.denied)
+    mode = "dry-run" if args.dry_run else "live"
+    print(f"microvm-conformance: PASS mode={mode} commands={commands} denied_checks={denied}")
+    if args.dry_run:
+        print("microvm-conformance: dry-run fixture proof only; no live AWS or EqualToAI/Host lab proof claimed")
+    return 0
+
+
+def run_scan(args: argparse.Namespace) -> int:
+    sensitive_values = list(args.sensitive_value or [])
+    for env_name in args.sensitive_env or []:
+        env_value = os.environ.get(env_name, "")
+        if env_value:
+            sensitive_values.append(env_value)
+    scanner = LeakScanner(sensitive_values)
+    artifacts: dict[str, str] = {}
+    for item in args.artifact or []:
+        if "=" not in item:
+            raise ConformanceFailure("--artifact must be NAME=PATH")
+        name, raw_path = item.split("=", 1)
+        path = Path(raw_path)
+        if not path.is_file():
+            raise ConformanceFailure(f"artifact not found: {path}")
+        artifacts[name] = path.read_text(encoding="utf-8")
+    scanner.assert_clean(artifacts)
+    print(f"microvm-token-scan: PASS artifacts={len(artifacts)}")
+    return 0
+
+
+def _auth_token_from_config(config: Mapping[str, Any]) -> str:
+    token_env = str(config.get("auth_token_env") or "").strip()
+    if token_env:
+        return os.environ.get(token_env, "")
+    return str(config.get("auth_token") or "").strip()
+
+
+def _required_string(config: Mapping[str, Any], key: str, scope: str = "config") -> str:
+    value = config.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConformanceFailure(f"{scope}.{key} is required")
+    return value.strip()
+
+
+def _required_payload_string(payload: Mapping[str, Any], key: str, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConformanceFailure(f"{label} missing {key}")
+    return value.strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str) and item.strip()]
+    return []
+
+
+def _quote_path(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def _normalize_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
+
+
+def _is_forbidden_field(normalized: str) -> bool:
+    return normalized in FORBIDDEN_FIELD_NAMES
+
+
+def _is_safe_structural_key(key: str, value: Any) -> bool:
+    # Canonical operation names are often used as fixture/artifact map keys.
+    # Treat only mapping containers as structural; a scalar auth-token field is
+    # still suspicious and will be evaluated through normalized field rules.
+    return key in {"auth-token", "shell-auth-token"} and isinstance(value, Mapping)
+
+
+def _is_secret_looking_field(normalized: str) -> bool:
+    if normalized in SAFE_TOKEN_FIELD_NAMES:
+        return False
+    if normalized in FORBIDDEN_FIELD_NAMES:
+        return True
+    return any(fragment in normalized for fragment in SECRET_KEY_FRAGMENTS)
+
+
+def _has_non_empty_value(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return bool(value)
+    if isinstance(value, Mapping):
+        return bool(value)
+    return True
+
+
+_NOT_JSON = object()
+
+
+def _parse_json_maybe(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return _NOT_JSON
+
+
+def _dedupe_findings(findings: Sequence[LeakFinding]) -> list[LeakFinding]:
+    seen: set[tuple[str, str, str, str]] = set()
+    out: list[LeakFinding] = []
+    for finding in findings:
+        key = (finding.artifact, finding.path, finding.kind, finding.message)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def _find_record_like_objects(payload: Any) -> list[Mapping[str, Any]]:
+    records: list[Mapping[str, Any]] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, Mapping):
+            keys = {_normalize_key(str(key)) for key in value}
+            if "session_id" in keys and ("tenant_id" in keys or "namespace" in keys):
+                records.append(value)
+            for child in value.values():
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(payload)
+    return records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="AppTheory MicroVM conformance harness and token leak scanner")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="run the MicroVM conformance harness")
+    run_parser.add_argument("--config", required=True, help="path to conformance config JSON")
+    run_parser.add_argument("--dry-run", action="store_true", help="use deterministic fixture transport; no network")
+    run_parser.add_argument("--fixture", help="dry-run fixture JSON path")
+    run_parser.set_defaults(func=run_harness)
+
+    scan_parser = subparsers.add_parser("scan", help="scan response/registry/log artifacts for token leaks")
+    scan_parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        help="artifact to scan as NAME=PATH; repeat for responses, registry records, and logs",
+    )
+    scan_parser.add_argument("--sensitive-value", action="append", default=[], help="sensitive plaintext value to detect")
+    scan_parser.add_argument("--sensitive-env", action="append", default=[], help="environment variable containing a value to detect")
+    scan_parser.set_defaults(func=run_scan)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except ConformanceFailure as exc:
+        print(f"microvm-conformance: FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_microvm_conformance.py
+++ b/scripts/test_microvm_conformance.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Fixture tests for the AppTheory MicroVM conformance harness."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "microvm_conformance.py"
+spec = importlib.util.spec_from_file_location("microvm_conformance", MODULE_PATH)
+if spec is None or spec.loader is None:  # pragma: no cover - import guard
+    raise RuntimeError("unable to import microvm_conformance.py")
+microvm_conformance = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = microvm_conformance
+spec.loader.exec_module(microvm_conformance)
+
+CONFIG_PATH = ROOT / "examples" / "microvm-conformance" / "equaltoai-host.config.example.json"
+NO_LEAK_FIXTURE_PATH = ROOT / "examples" / "microvm-conformance" / "fixtures" / "no-leak-artifacts.json"
+LEAK_FIXTURE_PATH = ROOT / "examples" / "microvm-conformance" / "fixtures" / "leak-artifacts.json"
+
+
+class MicroVMConformanceScannerTests(unittest.TestCase):
+    def test_scanner_passes_no_leak_fixture(self) -> None:
+        scanner = microvm_conformance.LeakScanner(
+            ["auth-token-DO-NOT-LOG-123456", "provider-token-DO-NOT-LOG-123456"]
+        )
+        scanner.assert_clean(
+            {
+                "no-leak": (
+                    ROOT / "examples" / "microvm-conformance" / "fixtures" / "scanner-no-leak-artifacts.json"
+                ).read_text(encoding="utf-8")
+            }
+        )
+
+    def test_scanner_fails_closed_on_plaintext_sensitive_value(self) -> None:
+        scanner = microvm_conformance.LeakScanner(["provider-token-DO-NOT-LOG-123456"])
+        with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+            scanner.assert_clean({"leak": LEAK_FIXTURE_PATH.read_text(encoding="utf-8")})
+        message = str(raised.exception)
+        self.assertIn("token leak scanner failed closed", message)
+        self.assertIn("forbidden-field", message)
+        self.assertNotIn("provider-token-DO-NOT-LOG-123456", message)
+
+    def test_scanner_fails_closed_on_bearer_log(self) -> None:
+        scanner = microvm_conformance.LeakScanner([])
+        with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+            scanner.assert_clean({"logs": "unexpected outbound Authorization: Bearer redactedbutstillcredential"})
+        self.assertIn("bearer credential", str(raised.exception))
+
+    def test_scanner_allows_sanitized_token_metadata(self) -> None:
+        scanner = microvm_conformance.LeakScanner([])
+        scanner.assert_clean(
+            {
+                "response": json.dumps(
+                    {
+                        "command": "shell-auth-token",
+                        "token_id": "shell-token-metadata-001",
+                        "token_type": "shell",
+                        "expires_at": "2026-06-25T12:15:00Z",
+                        "scope": ["shell"],
+                    }
+                )
+            }
+        )
+
+
+class MicroVMConformanceHarnessTests(unittest.TestCase):
+    def test_dry_run_validates_full_canonical_vocabulary(self) -> None:
+        proofs = self._run_with_fixture(self._fixture())
+        observed = {proof.command for proof in proofs if proof.command}
+        self.assertTrue(set(microvm_conformance.CANONICAL_COMMANDS).issubset(observed))
+        self.assertNotIn("shell-token", observed)
+        self.assertIn("missing-auth", {proof.name for proof in proofs if proof.denied})
+        self.assertIn("invalid-auth", {proof.name for proof in proofs if proof.denied})
+
+    def test_harness_fails_when_shell_token_is_treated_as_canonical(self) -> None:
+        fixture = self._fixture()
+        fixture["responses"]["shell-auth-token"]["body"]["command"] = "shell-token"
+        with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+            self._run_with_fixture(fixture)
+        self.assertIn("shell-auth-token", str(raised.exception))
+
+    def test_harness_fails_when_list_is_account_wide(self) -> None:
+        fixture = self._fixture()
+        fixture["responses"]["list"]["body"]["sessions"].append(
+            {
+                "tenant_id": "other-tenant",
+                "namespace": "namespace-example",
+                "session_id": "session-from-raw-account-list",
+                "state": "running",
+                "provider_microvm_id": "provider-microvm-other",
+            }
+        )
+        with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+            self._run_with_fixture(fixture)
+        self.assertIn("not tenant/namespace bound", str(raised.exception))
+
+    def test_harness_scans_registry_artifacts_and_fails_on_cross_tenant_record(self) -> None:
+        fixture = self._fixture()
+        config = self._config()
+        with tempfile.TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "records": [
+                            {
+                                "tenant_id": "other-tenant",
+                                "namespace": "namespace-example",
+                                "session_id": "session-fixture-001",
+                                "state": "running",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            config["scanner"]["registry_artifact_paths"] = [str(registry_path)]
+            with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+                self._run_with_fixture(fixture, config=config)
+        self.assertIn("registry artifact", str(raised.exception))
+
+    def test_harness_fails_closed_on_response_token_leak(self) -> None:
+        fixture = self._fixture()
+        fixture["responses"]["auth-token"]["body"]["token_value"] = "provider-token-DO-NOT-LOG-123456"
+        with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+            self._run_with_fixture(fixture)
+        self.assertIn("token leak scanner failed closed", str(raised.exception))
+
+    def _run_with_fixture(self, fixture: dict[str, Any], *, config: dict[str, Any] | None = None) -> list[Any]:
+        cfg = config or self._config()
+        scanner = microvm_conformance.build_scanner(cfg)
+        harness = microvm_conformance.MicroVMConformanceHarness(
+            cfg,
+            microvm_conformance.FixtureTransport(fixture),
+            scanner,
+        )
+        return harness.run()
+
+    def _config(self) -> dict[str, Any]:
+        return copy.deepcopy(microvm_conformance.load_config(CONFIG_PATH))
+
+    def _fixture(self) -> dict[str, Any]:
+        return copy.deepcopy(microvm_conformance.load_config(NO_LEAK_FIXTURE_PATH))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_microvm_conformance.py
+++ b/scripts/test_microvm_conformance.py
@@ -54,6 +54,61 @@ class MicroVMConformanceScannerTests(unittest.TestCase):
             scanner.assert_clean({"logs": "unexpected outbound Authorization: Bearer redactedbutstillcredential"})
         self.assertIn("bearer credential", str(raised.exception))
 
+    def test_scanner_fails_closed_on_canonical_session_token_plaintext(self) -> None:
+        scanner = microvm_conformance.LeakScanner([])
+        leaked_value = "session-token-DO-NOT-LOG-123456"
+        artifacts = {
+            "response": json.dumps(
+                {
+                    "command": "auth-token",
+                    "session_token_plaintext": leaked_value,
+                }
+            ),
+            "registry": json.dumps(
+                {
+                    "records": [
+                        {
+                            "tenant_id": "tenant-example",
+                            "namespace": "namespace-example",
+                            "session_id": "session-fixture-001",
+                            "session_token_plaintext": leaked_value,
+                        }
+                    ]
+                }
+            ),
+            "logs": f"issued session_token_plaintext={leaked_value}",
+        }
+        for artifact, text in artifacts.items():
+            with self.subTest(artifact=artifact):
+                with self.assertRaises(microvm_conformance.ConformanceFailure) as raised:
+                    scanner.assert_clean({artifact: text})
+                message = str(raised.exception)
+                self.assertIn("token leak scanner failed closed", message)
+                self.assertIn("forbidden-field", message)
+                self.assertIn("session_token_plaintext", message)
+                self.assertNotIn(leaked_value, message)
+
+    def test_scanner_does_not_treat_canonical_route_names_as_token_fields(self) -> None:
+        scanner = microvm_conformance.LeakScanner([])
+        scanner.assert_clean(
+            {
+                "routes": json.dumps(
+                    {
+                        "auth-token": {
+                            "command": "auth-token",
+                            "token_id": "auth-token-metadata-001",
+                            "token_type": "auth",
+                        },
+                        "shell-auth-token": {
+                            "command": "shell-auth-token",
+                            "token_id": "shell-token-metadata-001",
+                            "token_type": "shell",
+                        },
+                    }
+                )
+            }
+        )
+
     def test_scanner_allows_sanitized_token_metadata(self) -> None:
         scanner = microvm_conformance.LeakScanner([])
         scanner.assert_clean(

--- a/scripts/verify-microvm-conformance-harness.sh
+++ b/scripts/verify-microvm-conformance-harness.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
 python3 scripts/test_microvm_conformance.py
 python3 scripts/microvm_conformance.py run \
   --config examples/microvm-conformance/equaltoai-host.config.example.json \
@@ -12,5 +15,22 @@ python3 scripts/microvm_conformance.py scan \
   --artifact no-leak=examples/microvm-conformance/fixtures/scanner-no-leak-artifacts.json \
   --sensitive-value auth-token-DO-NOT-LOG-123456 \
   --sensitive-value provider-token-DO-NOT-LOG-123456
+
+session_token_leak="$tmpdir/session-token-plaintext-leak.json"
+session_token_scan_output="$tmpdir/session-token-plaintext-scan.out"
+cat >"$session_token_leak" <<'JSON'
+{"response":{"command":"auth-token","session_token_plaintext":"session-token-DO-NOT-LOG-123456"}}
+JSON
+if python3 scripts/microvm_conformance.py scan \
+  --artifact session-token-plaintext="$session_token_leak" \
+  >"$session_token_scan_output" 2>&1; then
+  echo "microvm-conformance-harness: FAIL (session_token_plaintext scan unexpectedly passed)" >&2
+  exit 1
+fi
+if grep -q "session-token-DO-NOT-LOG-123456" "$session_token_scan_output"; then
+  echo "microvm-conformance-harness: FAIL (session_token_plaintext leaked in failure output)" >&2
+  exit 1
+fi
+grep -q "session_token_plaintext" "$session_token_scan_output"
 
 echo "microvm-conformance-harness: PASS"

--- a/scripts/verify-microvm-conformance-harness.sh
+++ b/scripts/verify-microvm-conformance-harness.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+python3 scripts/test_microvm_conformance.py
+python3 scripts/microvm_conformance.py run \
+  --config examples/microvm-conformance/equaltoai-host.config.example.json \
+  --dry-run \
+  --fixture examples/microvm-conformance/fixtures/no-leak-artifacts.json
+python3 scripts/microvm_conformance.py scan \
+  --artifact no-leak=examples/microvm-conformance/fixtures/scanner-no-leak-artifacts.json \
+  --sensitive-value auth-token-DO-NOT-LOG-123456 \
+  --sensitive-value provider-token-DO-NOT-LOG-123456
+
+echo "microvm-conformance-harness: PASS"


### PR DESCRIPTION
## Milestone
M16 Consumer Conformance Harness — AppTheory-owned harness for EqualToAI/Host lab validation.

## Linear
- THE-2166
- THE-2185
- THE-2186

## Scope
- Adds `scripts/microvm_conformance.py`, a dependency-free runner for dry-run fixture mode and live consumer-provided lab endpoints.
- Adds fail-closed token/secret leak scanning for responses, registry-record-like JSON, and logs.
- Adds `examples/microvm-conformance/` docs, sample placeholder config, and pass/fail fixtures.
- Validates canonical MicroVM operations only: `run`, `get`, `list`, `suspend`, `resume`, `terminate`, `auth-token`, `shell-auth-token`.

## Proof boundary
Local validation proves harness/scanner readiness only. No live EqualToAI/Host lab execution, AWS deployment, account mutation, DNS/cert changes, or customer workload/platform readiness claim is made by this PR.

## Validation
- `scripts/verify-microvm-conformance-harness.sh` — PASS
- `python3 scripts/microvm_conformance.py scan --artifact leak=examples/microvm-conformance/fixtures/leak-artifacts.json --sensitive-value provider-token-DO-NOT-LOG-123456` — expected FAIL, verified fail-closed without echoing the sensitive value
- `make lint` — PASS
- `make rubric` — PASS (GovTheory Status PASS, Pass 29, Fail 0, Blocked 0)
- `git diff -- gov-infra/evidence/gov-rubric-report.json` — no diff

## Notes
- This is a milestone integration PR and intentionally uses `Refs`, not issue-closing text.
- No core runtime/provider/CDK/contract fixture semantics were changed.
