### PR TITLE
docs: complete SP01 credibility sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,26 @@ AppTheory is the runtime layer of the [Theory Cloud](THEORY_CLOUD.md) stack — 
 
 ## Install
 
-AppTheory is distributed exclusively through immutable **[GitHub Releases](https://github.com/theory-cloud/AppTheory/releases)** — no PyPI, no npm. The single distribution path keeps versions aligned across all three runtimes.
+AppTheory is distributed exclusively through immutable **[GitHub Releases](https://github.com/theory-cloud/AppTheory/releases)** — no PyPI, no npm. The single distribution path keeps versions aligned across all three runtimes. Pin the release you are consuming and verify downloaded assets before installing them:
 
-| Runtime | Install |
-|---|---|
-| **Go** | `go get github.com/theory-cloud/apptheory@vX.Y.Z` |
-| **TypeScript** | install the `.tgz` release asset — see [TypeScript getting started](https://apptheory.theorycloud.ai/runtimes/typescript/) |
-| **Python** | install the `.whl` release asset — see [Python getting started](https://apptheory.theorycloud.ai/runtimes/python/) |
+```bash
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+# Go resolves the immutable git tag.
+go get "github.com/theory-cloud/apptheory@${TAG}"
+
+# TypeScript and Python install from verified GitHub Release assets.
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "theory-cloud-apptheory-${VERSION}.tgz" \
+  --pattern "apptheory-${VERSION}-py3-none-any.whl" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep -E " (theory-cloud-apptheory-${VERSION}\.tgz|apptheory-${VERSION}-py3-none-any\.whl)$" SHA256SUMS.txt | sha256sum -c -
+npm install "./theory-cloud-apptheory-${VERSION}.tgz"
+python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
+```
 
 ## At a glance
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ AppTheory is distributed exclusively through immutable **[GitHub Releases](https
 
 | | |
 |---|---|
-| **Contract test fixtures** | 145 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger |
+| **Contract test fixtures** | 145 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+observability, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
@@ -76,7 +76,7 @@ AppTheory is distributed exclusively through immutable **[GitHub Releases](https
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [145 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/).
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [145 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -115,7 +115,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 145-fixture covenant every runtime is tested against
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 145-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -144,7 +144,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (145) + runners for Go, TS, Python |
+| `contract-tests/` | Cross-language contract fixtures (145) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ AppTheory is distributed exclusively through immutable **[GitHub Releases](https
 
 | | |
 |---|---|
-| **Contract test fixtures** | 128 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger |
+| **Contract test fixtures** | 145 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger |
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+observability, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
 | **Distribution** | Immutable GitHub Releases — version-aligned across all runtimes |
 | **License** | Apache-2.0 — open source, production use |
-| **Status** | Pre-1.0, runtime contract stable across Go · TS · Python |
+| **Status** | v1 stable release line, runtime contract stable across Go · TS · Python |
 
 ## Why AppTheory?
 
@@ -115,7 +115,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 128-fixture covenant every runtime is tested against
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 145-fixture covenant every runtime is tested against
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -144,7 +144,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (128) + runners for Go, TS, Python |
+| `contract-tests/` | Cross-language contract fixtures (145) + runners for Go, TS, Python |
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,7 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by 89 shared contract test fixtures.
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by 145 shared contract test fixtures. <!-- apptheory-fixture-count -->
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.

--- a/cdk/docs/getting-started.md
+++ b/cdk/docs/getting-started.md
@@ -4,16 +4,21 @@ This guide deploys a minimal HTTP API backed by a Lambda function that runs an A
 
 ## Install
 
-AppTheory CDK is distributed via **GitHub Releases** (no npm/PyPI registry publishing).
-
-Examples:
+AppTheory CDK is distributed via **GitHub Releases** (no npm/PyPI registry publishing). Pin and verify the jsii package assets before installing them:
 
 ```bash
-# Node (install from a downloaded release tarball)
-npm i ./theory-cloud-apptheory-cdk-X.Y.Z.tgz
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
 
-# Python (install from a downloaded release wheel)
-python -m pip install ./apptheory_cdk-X.Y.Z-py3-none-any.whl
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "theory-cloud-apptheory-cdk-${VERSION}.tgz" \
+  --pattern "apptheory_cdk-${VERSION}-py3-none-any.whl" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep -E " (theory-cloud-apptheory-cdk-${VERSION}\.tgz|apptheory_cdk-${VERSION}-py3-none-any\.whl)$" SHA256SUMS.txt | sha256sum -c -
+npm install "./theory-cloud-apptheory-cdk-${VERSION}.tgz"
+python -m pip install "./apptheory_cdk-${VERSION}-py3-none-any.whl"
 ```
 
 ## Minimal example (TypeScript)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -163,7 +163,7 @@ tabletheory:
       cta: See event workloads
   stats:
     - label: Contract fixtures
-      value: "145"
+      value: "145" # apptheory-fixture-count
       sub: shared across Go · TS · Python
     - label: Runtimes
       value: "3"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -128,19 +128,19 @@ tabletheory:
   repo_branch: main
   docs_root: docs
   version_pill: "v1.x"
-  version_status: prerelease    # stable | prerelease | dev
+  version_status: stable        # stable | prerelease | dev
   runtimes:
     - id: go
       label: Go
-      install: "go get github.com/theory-cloud/apptheory@vX.Y.Z"
+      install: "go get github.com/theory-cloud/apptheory@v1.14.0"
       docs_path: runtimes/go
     - id: ts
       label: TypeScript
-      install: "npm i ./theory-cloud-apptheory-X.Y.Z.tgz   # from a GitHub Release asset"
+      install: "gh release download v1.14.0 --repo theory-cloud/AppTheory --pattern theory-cloud-apptheory-1.14.0.tgz --pattern SHA256SUMS.txt --clobber && grep ' theory-cloud-apptheory-1.14.0.tgz$' SHA256SUMS.txt | sha256sum -c - && npm install ./theory-cloud-apptheory-1.14.0.tgz"
       docs_path: runtimes/typescript
     - id: python
       label: Python
-      install: "python -m pip install ./apptheory-X.Y.Z-py3-none-any.whl   # from a GitHub Release asset"
+      install: "gh release download v1.14.0 --repo theory-cloud/AppTheory --pattern apptheory-1.14.0-py3-none-any.whl --pattern SHA256SUMS.txt --clobber && grep ' apptheory-1.14.0-py3-none-any.whl$' SHA256SUMS.txt | sha256sum -c - && python -m pip install ./apptheory-1.14.0-py3-none-any.whl"
       docs_path: runtimes/python
   surfaces:
     - id: core

--- a/docs/_data/runtimes.yml
+++ b/docs/_data/runtimes.yml
@@ -7,7 +7,7 @@
 - id: go
   label: Go
   icon: go-mark
-  install: "go get github.com/theory-cloud/apptheory@vX.Y.Z"
+  install: "go get github.com/theory-cloud/apptheory@v1.14.0"
   lang: go
   snippet: |
     package main
@@ -37,7 +37,7 @@
 - id: ts
   label: TypeScript
   icon: ts-mark
-  install: "npm i ./theory-cloud-apptheory-X.Y.Z.tgz   # from a GitHub Release asset"
+  install: "gh release download v1.14.0 --repo theory-cloud/AppTheory --pattern theory-cloud-apptheory-1.14.0.tgz --pattern SHA256SUMS.txt --clobber && grep ' theory-cloud-apptheory-1.14.0.tgz$' SHA256SUMS.txt | sha256sum -c - && npm install ./theory-cloud-apptheory-1.14.0.tgz"
   lang: typescript
   snippet: |
     import { createApp, text } from "@theory-cloud/apptheory";
@@ -54,7 +54,7 @@
 - id: python
   label: Python
   icon: py-mark
-  install: "python -m pip install ./apptheory-X.Y.Z-py3-none-any.whl   # from a GitHub Release asset"
+  install: "gh release download v1.14.0 --repo theory-cloud/AppTheory --pattern apptheory-1.14.0-py3-none-any.whl --pattern SHA256SUMS.txt --clobber && grep ' apptheory-1.14.0-py3-none-any.whl$' SHA256SUMS.txt | sha256sum -c - && python -m pip install ./apptheory-1.14.0-py3-none-any.whl"
   lang: python
   snippet: |
     from apptheory import create_app, text

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 128-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks }
+  - { title: "Contract fixtures",         desc: "The 145-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks }

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 145-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks }
+  - { title: "Contract fixtures",         desc: "The 145-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count

--- a/docs/cdk/getting-started.md
+++ b/docs/cdk/getting-started.md
@@ -8,13 +8,21 @@ Use this guide when you want to deploy an AppTheory application with the jsii CD
 
 ## Install
 
-AppTheory CDK is distributed via GitHub Releases.
-
-Examples:
+AppTheory CDK is distributed via GitHub Releases. Pin the jsii package assets and verify their checksums before installing them:
 
 ```bash
-npm i ./theory-cloud-apptheory-cdk-X.Y.Z.tgz
-python -m pip install ./apptheory_cdk-X.Y.Z-py3-none-any.whl
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "theory-cloud-apptheory-cdk-${VERSION}.tgz" \
+  --pattern "apptheory_cdk-${VERSION}-py3-none-any.whl" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep -E " (theory-cloud-apptheory-cdk-${VERSION}\.tgz|apptheory_cdk-${VERSION}-py3-none-any\.whl)$" SHA256SUMS.txt | sha256sum -c -
+npm install "./theory-cloud-apptheory-cdk-${VERSION}.tgz"
+python -m pip install "./apptheory_cdk-${VERSION}-py3-none-any.whl"
 ```
 
 ## Minimal TypeScript stack

--- a/docs/development/migration/lift-deprecation.md
+++ b/docs/development/migration/lift-deprecation.md
@@ -29,7 +29,7 @@ functionality** (portable subset + documented Go-only extensions) so services do
 
 ## Timeline (fill in when ready)
 
-- **T0:** AppTheory `v0.x` begins (contract + fixtures; migration helpers available).
+- **T0:** AppTheory v1 stable line is available (contract + fixtures; migration helpers available).
 - **T1:** AppTheory reaches “Lift-equivalent for Pay Theory” (documented parity across required features).
 - **T2:** Lift marked “maintenance mode” internally (no new features; fixes only).
 - **T3:** Lift end-of-support date (after all services migrate).

--- a/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
+++ b/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
@@ -69,15 +69,14 @@ These are enforced by release hygiene and the staging rubric via:
 - Stable releases: `vX.Y.Z`
 - Pre-releases: `vX.Y.Z-rc.N` (recommended)
 
-Initial public stable release:
+Public stable release line:
 
-- The first `main` stable cut for the v1 line is planned as `v1.0.0`.
-- The corresponding prerelease line starts on `premain` as `v1.0.0-rc.1`.
+- AppTheory is on the v1 stable release line; `main` cuts immutable stable releases such as `v1.14.0`.
+- The corresponding prerelease line starts on `premain` as `vX.Y.Z-rc.1` for the next release candidate train.
 
 Breaking changes:
 
 - Prefer semver major bumps for contract-breaking changes.
-- While AppTheory is `0.x`, breaking changes may ship in `0.(Y+1).0` as needed; keep `0.Y.Z` patch releases non-breaking.
 - If contract changes, the contract fixtures must change in the same release.
 
 ## Release assets (required)

--- a/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
+++ b/docs/development/planning/apptheory/supporting/apptheory-versioning-and-release-policy.md
@@ -111,7 +111,7 @@ Python:
 
 Go:
 
-- Install by tag: `go get github.com/theory-cloud/apptheory@vX.Y.Z`
+- Install by tag: `go get github.com/theory-cloud/apptheory@v1.14.0` (or the exact stable/RC tag being evaluated).
 - CDK Go bindings live under `github.com/theory-cloud/apptheory/cdk-go/apptheorycdk`.
 
 ## CI/CD rules (no dangerous tokens)

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -5,7 +5,7 @@ description: Tiered middleware, routing, normalization, and the AppTheory error 
 
 # HTTP Runtime (P0–P2)
 
-The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [145 contract fixtures](../reference/contract-fixtures.md).
+The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [145 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
 
 The runtime is **tiered.** You opt into a tier when you create the app:
 
@@ -158,4 +158,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — P2 observability output shapes
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 145-fixture covenant
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 145-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -158,4 +158,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — P2 observability output shapes
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 128-fixture covenant
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 145-fixture covenant

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,11 +26,23 @@ go mod download
 (cd cdk && npm ci)
 ```
 
-AppTheory release artifacts are also published via GitHub Releases:
+AppTheory release artifacts are also published via GitHub Releases. Pin and verify the release you consume:
 
-- Go module: `go get github.com/theory-cloud/apptheory@vX.Y.Z`
-- TypeScript tarball: `npm i ./theory-cloud-apptheory-X.Y.Z.tgz`
-- Python wheel: `python -m pip install ./apptheory-X.Y.Z-py3-none-any.whl`
+```bash
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+go get "github.com/theory-cloud/apptheory@${TAG}"
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "theory-cloud-apptheory-${VERSION}.tgz" \
+  --pattern "apptheory-${VERSION}-py3-none-any.whl" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep -E " (theory-cloud-apptheory-${VERSION}\.tgz|apptheory-${VERSION}-py3-none-any\.whl)$" SHA256SUMS.txt | sha256sum -c -
+npm install "./theory-cloud-apptheory-${VERSION}.tgz"
+python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
+```
 
 ## First deterministic local invocation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by 145 shared contract fixtures. The Go runtime also carries the MCP
+    every commit by 145 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
     Streamable HTTP surface used by Remote MCP deployments.
   </p>
   <div class="hero__actions">

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 145 shared fixtures that arbitrate behavior across Go, TypeScript, and Python.
+description: The 145 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
 ---
 
 # Contract Fixtures
 
-AppTheory ships **145 contract test fixtures** in `contract-tests/fixtures/` that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **145 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -27,7 +27,7 @@ When the contract needs to grow, the fixture grows first. When the fixture grows
 
 ## Categories
 
-The 145 fixtures span (counts approximate; see `contract-tests/fixtures/` for the canonical inventory):
+The 145 fixtures span (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
 
 | Category | Covers |
 | --- | --- |

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -12,7 +12,7 @@ The Go runtime is the most complete implementation of the AppTheory contract and
 The Go toolchain resolves modules from the immutable git tag — no registry is involved beyond Go's standard proxy.
 
 ```bash
-go get github.com/theory-cloud/apptheory@vX.Y.Z
+go get github.com/theory-cloud/apptheory@v1.14.0
 ```
 
 Pin a specific release tag from the [releases page](https://github.com/theory-cloud/AppTheory/releases). AppTheory does not publish to the npm or PyPI registries; the Go module is the only language artifact that ships through Go's normal toolchain path.

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -5,7 +5,7 @@ description: The Go implementation of the AppTheory contract — routing, middle
 
 # Go Runtime
 
-The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [145 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree.
+The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [145 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -161,11 +161,11 @@ See the [MCP Method Surface](../integrations/mcp.md) for the full Streamable HTT
 
 ## What's verified
 
-The Go runtime passes all 145 contract fixtures on every commit. Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
+The Go runtime passes all 145 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
 
 ## Next reads
 
 - [API Reference](../api-reference.md) — full surface table
 - [HTTP Runtime tiers](../features/http-runtime.md) — P0 / P1 / P2
 - [Event Shape Dispatch](../reference/event-shapes.md) — when `HandleLambda` calls what
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 145-fixture covenant
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 145-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -168,4 +168,4 @@ The Go runtime passes all 145 contract fixtures on every commit. Any behavioral 
 - [API Reference](../api-reference.md) — full surface table
 - [HTTP Runtime tiers](../features/http-runtime.md) — P0 / P1 / P2
 - [Event Shape Dispatch](../reference/event-shapes.md) — when `HandleLambda` calls what
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 128-fixture covenant
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 145-fixture covenant

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: The Python implementation of the AppTheory contract — typed, asyn
 
 # Python Runtime
 
-The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [145 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree.
+The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [145 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -95,7 +95,7 @@ Applies to HTTP error serialization only.
 
 ## What's verified
 
-The Python runtime passes all 145 contract fixtures on every commit, against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
+The Python runtime passes all 145 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -9,11 +9,19 @@ The Python runtime is an independent implementation of the AppTheory contract â€
 
 ## Install
 
-Distribution is **GitHub Releases only.** PyPI is not used; AppTheory does not publish to it. Consumers pin a release-asset wheel downloaded from the [releases page](https://github.com/theory-cloud/AppTheory/releases):
+Distribution is **GitHub Releases only.** PyPI is not used; AppTheory does not publish to it. Pin the release wheel and verify its checksum before installing it:
 
 ```bash
-# After downloading the .whl asset from the GitHub Release
-python -m pip install ./apptheory-X.Y.Z-py3-none-any.whl
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "apptheory-${VERSION}-py3-none-any.whl" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep " apptheory-${VERSION}-py3-none-any.whl$" SHA256SUMS.txt | sha256sum -c -
+python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 ```
 
 Python 3.14+ is required.

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [145 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree.
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [145 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -121,7 +121,7 @@ See [CDK Getting Started](../cdk/getting-started.md).
 
 ## What's verified
 
-The TypeScript runtime passes all 145 contract fixtures on every commit, against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
+The TypeScript runtime passes all 145 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -9,11 +9,19 @@ The TypeScript runtime is an independent implementation of the AppTheory contrac
 
 ## Install
 
-Distribution is **GitHub Releases only.** The npm registry is not used; AppTheory does not publish to it. Consumers pin a release-asset tarball downloaded from the [releases page](https://github.com/theory-cloud/AppTheory/releases):
+Distribution is **GitHub Releases only.** The npm registry is not used; AppTheory does not publish to it. Pin the release asset and verify its checksum before installing it:
 
 ```bash
-# After downloading the .tgz asset from the GitHub Release
-npm i ./theory-cloud-apptheory-X.Y.Z.tgz
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "theory-cloud-apptheory-${VERSION}.tgz" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep " theory-cloud-apptheory-${VERSION}.tgz$" SHA256SUMS.txt | sha256sum -c -
+npm install "./theory-cloud-apptheory-${VERSION}.tgz"
 ```
 
 The package is ESM and ships TypeScript declarations. Node.js 24+ is required.

--- a/examples/cdk/lambda-role/package-lock.json
+++ b/examples/cdk/lambda-role/package-lock.json
@@ -1,0 +1,493 @@
+{
+  "name": "lambda-role-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lambda-role-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@theory-cloud/apptheory-cdk": "file:../../../cdk",
+        "aws-cdk-lib": "2.257.0",
+        "constructs": "10.6.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "../../../cdk": {
+      "name": "@theory-cloud/apptheory-cdk",
+      "version": "1.14.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "25.5.0",
+        "aws-cdk-lib": "2.257.0",
+        "constructs": "10.6.0",
+        "jsii": "5.9.34",
+        "jsii-pacmak": "1.127.0",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "2.257.0",
+        "constructs": "10.6.0"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@theory-cloud/apptheory-cdk": {
+      "resolved": "../../../cdk",
+      "link": true
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.3",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.3",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.4",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.18.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/examples/cdk/lambda-role/package.json
+++ b/examples/cdk/lambda-role/package.json
@@ -9,7 +9,7 @@
     "destroy": "cdk destroy"
   },
   "dependencies": {
-    "@theory-cloud/apptheory-cdk": "file:../../..",
+    "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },

--- a/examples/cdk/sqs-queue/package-lock.json
+++ b/examples/cdk/sqs-queue/package-lock.json
@@ -1,0 +1,493 @@
+{
+  "name": "sqs-queue-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sqs-queue-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@theory-cloud/apptheory-cdk": "file:../../../cdk",
+        "aws-cdk-lib": "2.257.0",
+        "constructs": "10.6.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "../../../cdk": {
+      "name": "@theory-cloud/apptheory-cdk",
+      "version": "1.14.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "25.5.0",
+        "aws-cdk-lib": "2.257.0",
+        "constructs": "10.6.0",
+        "jsii": "5.9.34",
+        "jsii-pacmak": "1.127.0",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "2.257.0",
+        "constructs": "10.6.0"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@theory-cloud/apptheory-cdk": {
+      "resolved": "../../../cdk",
+      "link": true
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.3",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.3",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.4",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.18.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/examples/cdk/sqs-queue/package.json
+++ b/examples/cdk/sqs-queue/package.json
@@ -9,7 +9,7 @@
     "destroy": "cdk destroy"
   },
   "dependencies": {
-    "@theory-cloud/apptheory-cdk": "file:../../..",
+    "@theory-cloud/apptheory-cdk": "file:../../../cdk",
     "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -807,6 +807,19 @@ function sameStringSet(actual, expected) {
   return actualSorted.every((value, index) => value === expectedSorted[index]);
 }
 
+function allowedDependencyGroupsForLockfile() {
+  // The older linked CDK examples carry aws-cdk-lib as a dev dependency.
+  // The queue/role examples are private deploy examples with aws-cdk-lib in
+  // dependencies; osv-scanner omits dependency_groups for those lockfiles.
+  if (
+    allowed.lockfile === "examples/cdk/sqs-queue/package-lock.json" ||
+    allowed.lockfile === "examples/cdk/lambda-role/package-lock.json"
+  ) {
+    return [];
+  }
+  return ["dev"];
+}
+
 function hasFixedVersion(vuln) {
   for (const affected of vuln.affected ?? []) {
     if (affected?.package?.ecosystem !== "npm" || affected.package.name !== allowed.packageName) {
@@ -857,7 +870,7 @@ function isAllowedAwsCdkBundledBraceExpansion(result, pkg, vuln) {
     packageInfo.ecosystem === "npm" &&
     packageInfo.name === allowed.packageName &&
     packageInfo.version === allowed.packageVersion &&
-    sameStringSet(dependencyGroups, ["dev"]) &&
+    sameStringSet(dependencyGroups, allowedDependencyGroupsForLockfile()) &&
     vuln.id === allowed.advisoryId &&
     aliases.includes(allowed.alias) &&
     hasFixedVersion(vuln) &&
@@ -950,6 +963,8 @@ gov_cmd_vuln() {
     "cdk/package-lock.json"
     "examples/cdk/multilang/package-lock.json"
     "examples/cdk/ssr-site/package-lock.json"
+    "examples/cdk/sqs-queue/package-lock.json"
+    "examples/cdk/lambda-role/package-lock.json"
   )
 
   local lf
@@ -2445,6 +2460,8 @@ check_supply_chain_apptheory() {
     "cdk"
     "examples/cdk/multilang"
     "examples/cdk/ssr-site"
+    "examples/cdk/sqs-queue"
+    "examples/cdk/lambda-role"
   )
 
   require_cmd_or_blocked git || return $?

--- a/py/docs/getting-started.md
+++ b/py/docs/getting-started.md
@@ -4,12 +4,19 @@ This guide walks you through installing and running a minimal AppTheory app in P
 
 ## Install
 
-AppTheory is distributed via **GitHub Releases** (no PyPI publishing).
-
-Example (install from a downloaded release wheel):
+AppTheory is distributed via **GitHub Releases** (no PyPI publishing). Pin and verify the release wheel before installing it:
 
 ```bash
-python -m pip install ./apptheory-X.Y.Z-py3-none-any.whl
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "apptheory-${VERSION}-py3-none-any.whl" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep " apptheory-${VERSION}-py3-none-any.whl$" SHA256SUMS.txt | sha256sum -c -
+python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 ```
 
 ## Minimal local invocation (P2 default)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,6 +37,16 @@
           "type": "json",
           "path": "examples/cdk/lesser-parity/package-lock.json",
           "jsonpath": "$.packages['../../../cdk'].version"
+        },
+        {
+          "type": "json",
+          "path": "examples/cdk/sqs-queue/package-lock.json",
+          "jsonpath": "$.packages['../../../cdk'].version"
+        },
+        {
+          "type": "json",
+          "path": "examples/cdk/lambda-role/package-lock.json",
+          "jsonpath": "$.packages['../../../cdk'].version"
         }
       ]
     }

--- a/release-please-config.premain.json
+++ b/release-please-config.premain.json
@@ -40,6 +40,16 @@
           "type": "json",
           "path": "examples/cdk/lesser-parity/package-lock.json",
           "jsonpath": "$.packages['../../../cdk'].version"
+        },
+        {
+          "type": "json",
+          "path": "examples/cdk/sqs-queue/package-lock.json",
+          "jsonpath": "$.packages['../../../cdk'].version"
+        },
+        {
+          "type": "json",
+          "path": "examples/cdk/lambda-role/package-lock.json",
+          "jsonpath": "$.packages['../../../cdk'].version"
         }
       ]
     }

--- a/scripts/verify-fixture-count.sh
+++ b/scripts/verify-fixture-count.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+actual="$(find contract-tests/fixtures -name '*.json' | wc -l | tr -d '[:space:]')"
+export APPTHEORY_FIXTURE_COUNT_ACTUAL="${actual}"
+
+python3 <<'PY'
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+actual = int(os.environ["APPTHEORY_FIXTURE_COUNT_ACTUAL"])
+
+tracked = subprocess.check_output(["git", "ls-files", "README.md", "docs"], text=True).splitlines()
+public_suffixes = {".md", ".markdown", ".html", ".yml", ".yaml"}
+ignored_prefixes = (
+    "docs/assets/",
+    "docs/development/planning/",
+)
+
+marker_re = re.compile(r"apptheory-fixture-count(?::\s*(?P<count>\d+))?", re.IGNORECASE)
+claim_patterns = [
+    re.compile(r"(?<![A-Za-z0-9.])(?P<count>\d+)\s+(?:shared\s+)?(?:contract(?:\s+test)?\s+)?fixtures?\b", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9.])(?P<count>\d+)-fixture\b", re.IGNORECASE),
+    re.compile(r"\bfixtures\s*\((?P<count>\d+)\)", re.IGNORECASE),
+]
+
+mismatches: list[str] = []
+marker_count = 0
+claim_count = 0
+seen_claims: set[tuple[str, int, int, str]] = set()
+
+for name in tracked:
+    if name.startswith(ignored_prefixes):
+        continue
+    path = Path(name)
+    if path.suffix.lower() not in public_suffixes:
+        continue
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for marker_match in marker_re.finditer(line):
+            marker_count += 1
+            explicit = marker_match.group("count")
+            if explicit is not None:
+                values = [int(explicit)]
+            else:
+                visible_line = line[: marker_match.start()]
+                values = [int(value) for value in re.findall(r"(?<![\d.])\d+(?![\d.])", visible_line)]
+            if not values:
+                mismatches.append(f"{name}:{lineno}: fixture-count marker has no count on the same line")
+                continue
+            for value in values:
+                if value != actual:
+                    mismatches.append(f"{name}:{lineno}: marker count {value} != actual corpus count {actual}")
+        for pattern in claim_patterns:
+            for match in pattern.finditer(line):
+                value = int(match.group("count"))
+                key = (name, lineno, match.start(), match.group(0))
+                if key in seen_claims:
+                    continue
+                seen_claims.add(key)
+                claim_count += 1
+                if value != actual:
+                    mismatches.append(f"{name}:{lineno}: documented fixture count {value} != actual corpus count {actual}: {match.group(0)!r}")
+
+if marker_count == 0:
+    mismatches.append("no apptheory-fixture-count markers found in README/docs")
+
+if mismatches:
+    print("fixture-count: FAIL", file=sys.stderr)
+    for mismatch in mismatches:
+        print(f"- {mismatch}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"fixture-count: PASS (actual={actual}, claims={claim_count}, markers={marker_count})")
+PY

--- a/scripts/verify-fixture-count.sh
+++ b/scripts/verify-fixture-count.sh
@@ -15,11 +15,23 @@ from pathlib import Path
 
 actual = int(os.environ["APPTHEORY_FIXTURE_COUNT_ACTUAL"])
 
-tracked = subprocess.check_output(["git", "ls-files", "README.md", "docs"], text=True).splitlines()
+# Keep the root set intentionally explicit: these are user-facing root
+# documents. Agent bootstrap files and planning artifacts contain historical
+# review text and are not public fixture-count claims.
+scan_roots = [
+    "README.md",
+    "THEORY_CLOUD.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "docs",
+]
+tracked = subprocess.check_output(["git", "ls-files", "--", *scan_roots], text=True).splitlines()
 public_suffixes = {".md", ".markdown", ".html", ".yml", ".yaml"}
 ignored_prefixes = (
     "docs/assets/",
     "docs/development/planning/",
+    "docs/_site/",
+    "docs/.jekyll-cache/",
 )
 
 marker_re = re.compile(r"apptheory-fixture-count(?::\s*(?P<count>\d+))?", re.IGNORECASE)
@@ -68,7 +80,7 @@ for name in tracked:
                     mismatches.append(f"{name}:{lineno}: documented fixture count {value} != actual corpus count {actual}: {match.group(0)!r}")
 
 if marker_count == 0:
-    mismatches.append("no apptheory-fixture-count markers found in README/docs")
+    mismatches.append("no apptheory-fixture-count markers found in root user-facing docs or docs/")
 
 if mismatches:
     print("fixture-count: FAIL", file=sys.stderr)

--- a/scripts/verify-rubric.sh
+++ b/scripts/verify-rubric.sh
@@ -7,6 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # gov-infra evidence report and includes the release gate through SEC-4's
 # deterministic build check. Keep this wrapper thin so `make rubric`, CI,
 # and local validation cannot drift into separate meanings of "rubric".
+bash ./scripts/verify-fixture-count.sh
 bash ./gov-infra/verifiers/gov-verify-rubric.sh
 
 echo "rubric: PASS"

--- a/ts/docs/getting-started.md
+++ b/ts/docs/getting-started.md
@@ -4,12 +4,19 @@ This guide walks you through installing and running a minimal AppTheory app in T
 
 ## Install
 
-AppTheory is distributed via **GitHub Releases** (no npm registry publishing).
-
-Example (install from a downloaded release tarball):
+AppTheory is distributed via **GitHub Releases** (no npm registry publishing). Pin and verify the release tarball before installing it:
 
 ```bash
-npm i ./theory-cloud-apptheory-X.Y.Z.tgz
+VERSION=1.14.0
+TAG="v${VERSION}"
+REPO="theory-cloud/AppTheory"
+
+gh release download "${TAG}" --repo "${REPO}" \
+  --pattern "theory-cloud-apptheory-${VERSION}.tgz" \
+  --pattern "SHA256SUMS.txt" \
+  --clobber
+grep " theory-cloud-apptheory-${VERSION}.tgz$" SHA256SUMS.txt | sha256sum -c -
+npm install "./theory-cloud-apptheory-${VERSION}.tgz"
 ```
 
 ## Minimal local invocation (P2 default)

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz#sha512-8S5HvnI3AHdMi5aEkoXZNHacO5GN7zfWpYlgfwo6ZMEjQTo/qx1iXWMI6W9vT1E0Ij7Q8RS53lb7VOy7BFHeqg=="
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
@@ -1490,7 +1490,7 @@
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
       "version": "1.10.1",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz#sha512-8S5HvnI3AHdMi5aEkoXZNHacO5GN7zfWpYlgfwo6ZMEjQTo/qx1iXWMI6W9vT1E0Ij7Q8RS53lb7VOy7BFHeqg==",
       "integrity": "sha512-8S5HvnI3AHdMi5aEkoXZNHacO5GN7zfWpYlgfwo6ZMEjQTo/qx1iXWMI6W9vT1E0Ij7Q8RS53lb7VOy7BFHeqg==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "test": "npm run check",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint --max-warnings=0 --report-unused-disable-directives \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
@@ -22,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
     "@aws-sdk/client-lambda-microvms": "^3.1075.0",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz"
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz#sha512-8S5HvnI3AHdMi5aEkoXZNHacO5GN7zfWpYlgfwo6ZMEjQTo/qx1iXWMI6W9vT1E0Ij7Q8RS53lb7VOy7BFHeqg=="
   },
   "overrides": {
     "@typescript-eslint/typescript-estree": {


### PR DESCRIPTION
## Milestone
SP01 Credibility Sweep — make fixture counts, release status, install commands, example dependencies, and TableTheory dependency integrity true.

## Linear
Refs THE-2233, THE-2234, THE-2235, THE-2236, THE-2237

## Tasks
- [x] THE-2233 — Correct stale fixture-count and release-status claims
- [x] THE-2234 — Gate fixture-count claims on the actual corpus
- [x] THE-2235 — Fix broken example CDK dependencies
- [x] THE-2236 — Pin the TS TableTheory dependency with an integrity hash
- [x] THE-2237 — Replace placeholder installs with resolvable commands

## Contract impact
Docs/example/dependency-integrity only. No runtime behavior changes.

## Validation
- Baseline before branch: `make rubric` — PASS
- `grep -rn '128-fixture\|Pre-1.0' README.md docs/` — no matches
- Install-placeholder grep over README/docs/package docs — no `X.Y.Z` install placeholders
- `./scripts/verify-fixture-count.sh` — PASS (`actual=145`, `claims=18`, `markers=19`)
- `cd examples/cdk/sqs-queue && npm ci` — PASS
- `cd examples/cdk/lambda-role && npm ci` — PASS
- `cd ts && npm ci && npm test` — PASS
- TableTheory tarball integrity recomputed from public release asset — PASS
- TypeScript release-install docs followed in a clean scratch directory — PASS
- `make test` — PASS (`version-alignment: PASS (1.14.0)`)
- `make rubric` — PASS (`Status: PASS`, `Pass: 29`, `Fail: 0`, `Blocked: 0`)

## Security / operations
No cloud mutation, AWS account/DNS/IAM changes, secrets, live receipts, release manifest changes, branch deletion, or history rewrite.

## Cross-repo notes
TableTheory was not changed. The TS TableTheory release tarball integrity now matches the public GitHub Release asset.