### PR TITLE
feat(contract): pin MCP contract truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ---
 
-AppTheory is a **contract-first serverless runtime for AWS Lambda** designed to keep request handling, middleware, and event normalization consistent across languages and reliable in generative coding workflows (humans + AI assistants). It ships peer implementations in Go, TypeScript, and Python — not a Go library with bindings, but three independent runtimes that pass the same contract fixtures on every commit.
+AppTheory is a **contract-first serverless runtime for AWS Lambda** designed to keep request handling, middleware, and event normalization consistent across languages and reliable in generative coding workflows (humans + AI assistants). It ships peer implementations in Go, TypeScript, and Python — not a Go library with bindings, but three independent runtimes verified against the shared non-MCP fixture corpus on every commit. Go additionally executes the SP09 MCP fixtures; TypeScript and Python load them and explicitly skip those 11 future-runtime fixtures pending SP10/SP11.
 
 ```
             FaceTheory (client delivery)
@@ -76,7 +76,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 
 | | |
 |---|---|
-| **Contract test fixtures** | 194 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
+| **Contract test fixtures** | 194 total — Go executes all; TypeScript/Python pass 183 shared non-MCP fixtures and explicitly skip 11 MCP future-runtime fixtures | <!-- apptheory-fixture-count -->
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+duration-aware observability hooks, inbound trace recording, EMF metric sink path, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
@@ -89,7 +89,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [194 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — with drift prevention on the shared non-MCP corpus. Go executes all [194 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/); TypeScript and Python pass the 183 shared non-MCP fixtures and explicitly skip the 11 MCP future-runtime fixtures pending SP10/SP11. <!-- apptheory-fixture-count -->
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -97,7 +97,7 @@ Use AppTheory when you want AWS-Lambda-backed services that are:
 
 ## MCP server runtime
 
-AppTheory includes a complete [Model Context Protocol](https://modelcontextprotocol.io) production stack: Streamable HTTP transport, session management, OAuth protected resources, resumable SSE streaming, and CDK deployment constructs. The MCP runtime is a **first-class part of the contract**, not an experimental add-on — `theory-mcp-server` itself runs on it.
+AppTheory's Go runtime includes a complete [Model Context Protocol](https://modelcontextprotocol.io) production stack: Streamable HTTP transport, session management, OAuth protected resources, resumable SSE streaming, and CDK deployment constructs. The Go MCP runtime is a **first-class part of the contract**, not an experimental add-on — `theory-mcp-server` itself runs on it. TypeScript and Python MCP runtime parity is intentionally staged for SP10/SP11 and represented today by explicit skips of the 11 MCP fixtures.
 
 - [MCP integration guide](https://apptheory.theorycloud.ai/integrations/mcp/) — transport, JSON-RPC surface, registries, sessions, streaming
 - [Remote MCP deployment](https://apptheory.theorycloud.ai/integrations/remote-mcp/) — OAuth, protected resource metadata, Autheory integration
@@ -128,7 +128,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 194-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 194-fixture covenant: Go executes all; TypeScript/Python skip 11 MCP future-runtime fixtures pending SP10/SP11 <!-- apptheory-fixture-count -->
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -157,7 +157,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (194) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
+| `contract-tests/` | Contract fixtures (194 total) + runners for Go, TS, Python; Go executes the MCP tier while TS/Py explicitly skip it pending SP10/SP11 | <!-- apptheory-fixture-count -->
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 
 | | |
 |---|---|
-| **Contract test fixtures** | 189 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
+| **Contract test fixtures** | 192 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+duration-aware observability hooks, inbound trace recording, EMF metric sink path, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
@@ -89,7 +89,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [189 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [192 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -128,7 +128,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 189-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 192-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -157,7 +157,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (189) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
+| `contract-tests/` | Cross-language contract fixtures (192) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 
 | | |
 |---|---|
-| **Contract test fixtures** | 183 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
+| **Contract test fixtures** | 187 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+duration-aware observability hooks, inbound trace recording, EMF metric sink path, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
@@ -89,7 +89,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [183 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [187 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -128,7 +128,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 183-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 187-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -157,7 +157,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (183) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
+| `contract-tests/` | Cross-language contract fixtures (187) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 
 | | |
 |---|---|
-| **Contract test fixtures** | 192 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
+| **Contract test fixtures** | 194 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+duration-aware observability hooks, inbound trace recording, EMF metric sink path, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
@@ -89,7 +89,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [192 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [194 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -128,7 +128,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 192-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 194-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -157,7 +157,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (192) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
+| `contract-tests/` | Cross-language contract fixtures (194) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 
 | | |
 |---|---|
-| **Contract test fixtures** | 187 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
+| **Contract test fixtures** | 189 — routing, normalization, error envelope, event dispatch, MCP, jobs ledger | <!-- apptheory-fixture-count -->
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Tiers** | P0 (core) · P1 (+request-id, auth, CORS, guardrails) · P2 (+duration-aware observability hooks, inbound trace recording, EMF metric sink path, rate limiting) — default P2 |
 | **Event sources** | Lambda Function URL · API Gateway v2 · ALB · AppSync · SQS · EventBridge · DynamoDB Streams · Kinesis · WebSockets |
@@ -89,7 +89,7 @@ python -m pip install "./apptheory-${VERSION}-py3-none-any.whl"
 Use AppTheory when you want AWS-Lambda-backed services that are:
 
 - **Serverless-first** — one unified `HandleLambda` entrypoint dispatches Lambda Function URL, API Gateway v2, ALB, AppSync, SQS, EventBridge, DynamoDB Streams, Kinesis, and WebSockets. The same handler shape covers every event source.
-- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [187 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
+- **Cross-language consistent** — one routing model, one middleware order, one error envelope — across three runtimes — without behavioral drift. Verified on every commit by the [189 contract fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/). <!-- apptheory-fixture-count -->
 - **Generative-coding friendly** — explicit tiers, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat routing, middleware, and event normalization as a contract
@@ -128,7 +128,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 
 **Contract reference and feature pages:**
 
-- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 187-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
+- [Contract Fixtures](https://apptheory.theorycloud.ai/reference/contract-fixtures/) — the 189-fixture covenant every runtime is tested against <!-- apptheory-fixture-count -->
 - [Event Shape Dispatch](https://apptheory.theorycloud.ai/reference/event-shapes/) — which Lambda event shapes route to which handler
 - [HTTP Runtime](https://apptheory.theorycloud.ai/features/http-runtime/) — P0/P1/P2 tier surface
 - [Jobs Ledger](https://apptheory.theorycloud.ai/features/jobs-ledger/)
@@ -157,7 +157,7 @@ The full documentation site lives at **[apptheory.theorycloud.ai](https://appthe
 | `py/` | Python runtime (3.14+) |
 | `cdk/` | CDK constructs (jsii) — `AppTheoryHttpApi`, `AppTheoryMcpServer`, `AppTheoryQueue`, ... |
 | `cdk-go/` | Generated Go bindings for the jsii CDK package |
-| `contract-tests/` | Cross-language contract fixtures (187) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
+| `contract-tests/` | Cross-language contract fixtures (189) + runners for Go, TS, Python | <!-- apptheory-fixture-count -->
 | `api-snapshots/` | Public API surface lockfiles for each runtime — the release gate |
 | `examples/` | CDK + handler examples: `multilang`, `import-pipeline`, `ssr-site`, MCP, ... |
 | `.github/workflows/` | CI: rubric, release-please (stable + prerelease), Pages publish, subtree publish |

--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,9 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by 194 shared contract test fixtures. <!-- apptheory-fixture-count -->
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by the shared non-MCP contract fixture
+  corpus. Go also executes the 11 SP09 MCP fixtures; TypeScript and Python load them and explicitly skip those
+  future-runtime fixtures pending SP10/SP11. <!-- apptheory-fixture-count -->
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.
@@ -68,9 +70,12 @@ and MCP server implementation.
 Theory Cloud supports Go, TypeScript, and Python not through separate implementations that happen to share a name,
 but through contract-enforced behavioral parity.
 
-Each framework maintains a set of shared test fixtures — language-neutral descriptions of expected behavior. The Go,
-TypeScript, and Python runtimes are independently tested against these same fixtures. If a timestamp format, error
-envelope structure, or middleware ordering differs between languages, the contract tests fail.
+Each framework maintains a set of shared test fixtures — language-neutral descriptions of expected behavior. For
+shared runtime surfaces, the Go, TypeScript, and Python runtimes are independently tested against the same fixtures.
+Implementation-leg fixtures must be labeled honestly: AppTheory's SP09 `mcp/` fixtures run in Go today, while
+TypeScript and Python load them and report the 11 MCP future-runtime skips until SP10/SP11 add those runtime legs. If
+a timestamp format, error envelope structure, or middleware ordering differs between languages in the shared corpus,
+the contract tests fail.
 
 TableTheory additionally defines a [DMS (Data Model Specification)](https://github.com/theory-cloud/TableTheory)
 that serves as the language-neutral source of truth for data models. All three SDKs validate against the same DMS

--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,7 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by 183 shared contract test fixtures. <!-- apptheory-fixture-count -->
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by 187 shared contract test fixtures. <!-- apptheory-fixture-count -->
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.

--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,7 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by 192 shared contract test fixtures. <!-- apptheory-fixture-count -->
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by 194 shared contract test fixtures. <!-- apptheory-fixture-count -->
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.

--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,7 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by 189 shared contract test fixtures. <!-- apptheory-fixture-count -->
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by 192 shared contract test fixtures. <!-- apptheory-fixture-count -->
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.

--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,7 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by 187 shared contract test fixtures. <!-- apptheory-fixture-count -->
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by 189 shared contract test fixtures. <!-- apptheory-fixture-count -->
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.

--- a/api-snapshots/go.txt
+++ b/api-snapshots/go.txt
@@ -2643,9 +2643,11 @@ type ResourceDef struct {
 type ResourceHandler func(context.Context) ([]ResourceContent, error)
 
 type ResourceRegistry struct {
-	mu        sync.RWMutex
-	resources []registeredResource
-	index     map[string]int
+	mu            sync.RWMutex
+	resources     []registeredResource
+	index         map[string]int
+	templates     []ResourceTemplateDef
+	templateIndex map[string]int
 }
 
 type ResourceSubscription struct {
@@ -2654,6 +2656,14 @@ type ResourceSubscription struct {
 }
 
 type ResourceSubscriptionHook func(context.Context, ResourceSubscription) error
+
+type ResourceTemplateDef struct {
+	URITemplate string `json:"uriTemplate"`
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
 
 type Response struct {
 	JSONRPC string    `json:"jsonrpc"`
@@ -2998,9 +3008,13 @@ func (*ResourceRegistry) Len() int
 
 func (*ResourceRegistry) List() []ResourceDef
 
+func (*ResourceRegistry) ListTemplates() []ResourceTemplateDef
+
 func (*ResourceRegistry) Read(context.Context, string) ([]ResourceContent, error)
 
 func (*ResourceRegistry) RegisterResource(ResourceDef, ResourceHandler) error
+
+func (*ResourceRegistry) RegisterResourceTemplate(ResourceTemplateDef) error
 
 func (*Server) Handler() apptheory.Handler
 

--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -17,6 +17,7 @@ File layout is organized by behavior domain. The historical tier/milestone label
 - `contract-tests/fixtures/microvm-foundation/` — M15 Lambda MicroVM validation-only lifecycle/controller/session vocabulary
 - `contract-tests/fixtures/microvm-operations/` — M16 real Lambda MicroVM operation, route, provider-state, tenant, and token-safety contracts
 - `contract-tests/fixtures/openapi/` — P0 descriptive OpenAPI generation with byte-pinned canonical JSON output
+- `contract-tests/fixtures/mcp/` — SP09 Go MCP protocol, registry, session, Streamable HTTP, resumable SSE, and task-store contracts
 
 Each fixture is a single JSON object.
 
@@ -30,8 +31,8 @@ while provider/runtime payload objects remain open so behavior-specific contract
 
 ## Common shape
 
-- `id` (string): stable identifier (use `p0.*`, `p1.*`, `p2.*`, `m1.*`, `m2.*`, `m3.*`, `m12.*`, `m14.*`, `m15.*`, or `m16.*` prefixes).
-- `tier` (string): `p0` / `p1` / `p2` / `m1` / `m2` / `m3` / `m12` / `m14` / `m15` / `m16`.
+- `id` (string): stable identifier (use `p0.*`, `p1.*`, `p2.*`, `m1.*`, `m2.*`, `m3.*`, `m12.*`, `m14.*`, `m15.*`, `m16.*`, or `mcp.*` prefixes).
+- `tier` (string): `p0` / `p1` / `p2` / `m1` / `m2` / `m3` / `m12` / `m14` / `m15` / `m16` / `mcp`.
 - `name` (string): short human-friendly name.
 - `setup.routes` (array): route table for the fixture runner.
   - `method` (string): HTTP method (e.g. `GET`).
@@ -69,6 +70,31 @@ while provider/runtime payload objects remain open so behavior-specific contract
 - `expect.logging_profile_catalog` (object, optional): expected built-in logging profile catalog.
 - `expect.metrics` (array, optional): expected metric emissions (portable subset).
 - `expect.spans` (array, optional): expected trace span emissions (portable subset).
+
+## SP09 MCP fixtures
+
+MCP fixtures pin the Go MCP runtime contract for protocol `2025-11-25`. They are a Go implementation leg for SP09:
+the TypeScript and Python contract runners must load and explicitly skip `tier: "mcp"` fixtures until SP10/SP11 add
+their MCP runtimes. That skip is intentional and reported by those runners; it is not parity proof for TS/Py.
+
+`setup.mcp` builds a deterministic Go `runtime/mcp.Server`:
+
+- `server.name` / `server.version`: expected `serverInfo` values in `initialize`.
+- `id_sequence`: deterministic server IDs for sessions and task IDs.
+- `stream_id_sequence`: deterministic stream IDs for resumable SSE stores.
+- `tools`: registered tools. `handler` is a runner-owned deterministic handler such as `echo_text`, `fail_error`,
+  `stream_progress`, or `task_echo`; `task_support` may be `forbidden`, `optional`, or `required`.
+- `resources`: static resources with exact `resources/list` metadata and `resources/read` contents.
+- `resource_templates`: `resources/templates/list` metadata.
+- `prompts`: registered prompt templates; `handler` renders deterministic `prompts/get` messages.
+- `session_store.seed`: deterministic pre-seeded sessions for expiration/rejection checks.
+- `task_runtime`: opt-in deterministic task store settings for task lifecycle fixtures.
+
+`input.mcp.steps` is an ordered exchange against one mounted `/mcp` AppTheory route. Each step carries the canonical
+HTTP request shape (`method`, `path`, `headers`, `body`, `is_base64`) and optional `read_body` for SSE readers. Expected
+steps live in `expect.mcp.steps` and compare status, canonical headers, cookies, body JSON, or parsed `sse_frames`.
+The fixtures intentionally exercise HTTP framing (POST/GET/DELETE), JSON-RPC envelopes, session headers, and replay
+semantics through the runtime handler instead of calling private Go helpers directly.
 
 
 ## HTTP source provenance fixtures

--- a/contract-tests/fixtures/fixture.schema.json
+++ b/contract-tests/fixtures/fixture.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "id": {
       "type": "string",
-      "pattern": "^(p0|p1|p2|m1|m2|m3|m12|m14|m15|m16)(\\.|_)[A-Za-z0-9_.-]+$"
+      "pattern": "^(p0|p1|p2|m1|m2|m3|m12|m14|m15|m16|mcp)(\\.|_)[A-Za-z0-9_.-]+$"
     },
     "tier": { "$ref": "#/$defs/tier" },
     "name": { "type": "string", "minLength": 1 },
@@ -20,7 +20,7 @@
   "$defs": {
     "tier": {
       "type": "string",
-      "enum": ["p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14", "m15", "m16"]
+      "enum": ["p0", "p1", "p2", "m1", "m2", "m3", "m12", "m14", "m15", "m16", "mcp"]
     },
     "stringArray": {
       "type": "array",
@@ -87,7 +87,135 @@
         "environment": { "$ref": "#/$defs/stringMap" },
         "openapi": { "$ref": "#/$defs/openapiSpec" },
         "microvm_contract": { "type": "object", "additionalProperties": true },
-        "microvm_controller_route": { "type": "object", "additionalProperties": true }
+        "microvm_controller_route": { "type": "object", "additionalProperties": true },
+        "mcp": { "$ref": "#/$defs/mcpSetup" }
+      }
+    },
+    "mcpSetup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "server": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "version": { "type": "string", "minLength": 1 }
+          }
+        },
+        "id_sequence": { "$ref": "#/$defs/stringArray" },
+        "stream_id_sequence": { "$ref": "#/$defs/stringArray" },
+        "tools": { "type": "array", "items": { "$ref": "#/$defs/mcpTool" } },
+        "resources": { "type": "array", "items": { "$ref": "#/$defs/mcpResource" } },
+        "resource_templates": { "type": "array", "items": { "$ref": "#/$defs/mcpResourceTemplate" } },
+        "prompts": { "type": "array", "items": { "$ref": "#/$defs/mcpPrompt" } },
+        "session_store": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "seed": { "type": "array", "items": { "$ref": "#/$defs/mcpSession" } }
+          }
+        },
+        "task_runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "default_ttl_ms": { "type": "integer" },
+            "max_ttl_ms": { "type": "integer" },
+            "poll_interval_ms": { "type": "integer" },
+            "list_limit": { "type": "integer" },
+            "model_immediate_response": { "type": "string" },
+            "clock_unix_ms": { "type": "integer" },
+            "update_clock_unix_ms": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "mcpTool": {
+      "type": "object",
+      "required": ["name", "input_schema", "handler"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "input_schema": {},
+        "output_schema": {},
+        "handler": { "type": "string", "minLength": 1 },
+        "streaming": { "type": "boolean" },
+        "task_support": { "type": "string", "enum": ["forbidden", "optional", "required"] }
+      }
+    },
+    "mcpResource": {
+      "type": "object",
+      "required": ["uri", "name", "contents"],
+      "additionalProperties": false,
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "mime_type": { "type": "string" },
+        "size": { "type": "integer" },
+        "contents": { "type": "array", "items": { "$ref": "#/$defs/mcpResourceContent" } }
+      }
+    },
+    "mcpResourceTemplate": {
+      "type": "object",
+      "required": ["uri_template", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "uri_template": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "mime_type": { "type": "string" }
+      }
+    },
+    "mcpResourceContent": {
+      "type": "object",
+      "required": ["uri"],
+      "additionalProperties": false,
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "mime_type": { "type": "string" },
+        "text": { "type": "string" },
+        "blob": { "type": "string" }
+      }
+    },
+    "mcpPrompt": {
+      "type": "object",
+      "required": ["name", "handler"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "arguments": { "type": "array", "items": { "$ref": "#/$defs/mcpPromptArgument" } },
+        "handler": { "type": "string", "minLength": 1 }
+      }
+    },
+    "mcpPromptArgument": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "required": { "type": "boolean" }
+      }
+    },
+    "mcpSession": {
+      "type": "object",
+      "required": ["id", "expires_unix_ms"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "created_unix_ms": { "type": "integer" },
+        "expires_unix_ms": { "type": "integer" },
+        "data": { "$ref": "#/$defs/stringMap" }
       }
     },
     "openapiSpec": {
@@ -206,7 +334,26 @@
         "aws_event": { "$ref": "#/$defs/awsEvent" },
         "context": { "$ref": "#/$defs/context" },
         "logging_event": { "type": "object", "additionalProperties": true },
-        "logging_profile_catalog": { "type": "boolean" }
+        "logging_profile_catalog": { "type": "boolean" },
+        "mcp": { "$ref": "#/$defs/mcpInput" }
+      }
+    },
+    "mcpInput": {
+      "type": "object",
+      "required": ["steps"],
+      "additionalProperties": false,
+      "properties": {
+        "steps": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/mcpStep" } }
+      }
+    },
+    "mcpStep": {
+      "type": "object",
+      "required": ["name", "request"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "request": { "$ref": "#/$defs/request" },
+        "read_body": { "type": "boolean" }
       }
     },
     "response": {
@@ -251,7 +398,40 @@
         "logging_profile_catalog": { "type": "object", "additionalProperties": true },
         "microvm_contract_validation": { "type": "object", "additionalProperties": true },
         "microvm_lifecycle_adapter": { "type": "object", "additionalProperties": true },
-        "microvm_controller_route": { "type": "object", "additionalProperties": true }
+        "microvm_controller_route": { "type": "object", "additionalProperties": true },
+        "mcp": { "$ref": "#/$defs/mcpExpect" }
+      }
+    },
+    "mcpExpect": {
+      "type": "object",
+      "required": ["steps"],
+      "additionalProperties": false,
+      "properties": {
+        "steps": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/mcpExpectedStep" } }
+      }
+    },
+    "mcpExpectedStep": {
+      "type": "object",
+      "required": ["status", "headers", "cookies", "is_base64"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "type": "integer" },
+        "headers": { "type": "object", "additionalProperties": true },
+        "cookies": { "$ref": "#/$defs/stringArray" },
+        "body": {},
+        "body_json": {},
+        "sse_frames": { "type": "array", "items": { "$ref": "#/$defs/mcpSSEFrame" } },
+        "is_base64": { "type": "boolean" }
+      }
+    },
+    "mcpSSEFrame": {
+      "type": "object",
+      "required": ["id", "data"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "event": { "type": "string" },
+        "data": { "type": "string" }
       }
     }
   }

--- a/contract-tests/fixtures/mcp/core-initialize-2025-11-25.json
+++ b/contract-tests/fixtures/mcp/core-initialize-2025-11-25.json
@@ -1,0 +1,132 @@
+{
+  "id": "mcp.core.initialize_2025_11_25",
+  "tier": "mcp",
+  "name": "MCP initialize negotiates protocol 2025-11-25 and accepts initialized notification",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-core"
+      ],
+      "tools": [
+        {
+          "name": "echo",
+          "description": "Echo text",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          },
+          "handler": "echo_text"
+        }
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"fixture-client\",\"version\":\"sp09\"}}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "initialized_notification",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-core"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-core"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "tools": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          },
+          "is_base64": false
+        },
+        {
+          "status": 202,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/core-jsonrpc-error-envelope.json
+++ b/contract-tests/fixtures/mcp/core-jsonrpc-error-envelope.json
@@ -1,0 +1,143 @@
+{
+  "id": "mcp.core.jsonrpc_error_envelope",
+  "tier": "mcp",
+  "name": "MCP JSON-RPC errors stay inside canonical JSON-RPC response envelopes",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-core"
+      ],
+      "tools": [
+        {
+          "name": "echo",
+          "description": "Echo text",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          },
+          "handler": "echo_text"
+        }
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "missing_tool",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-core"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"missing\",\"arguments\":{}}}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-core"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "tools": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          },
+          "is_base64": false
+        },
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {
+              "code": -32602,
+              "message": "tool not found: missing"
+            }
+          },
+          "is_base64": false
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/core-malformed-request.json
+++ b/contract-tests/fixtures/mcp/core-malformed-request.json
@@ -1,0 +1,66 @@
+{
+  "id": "mcp.core.malformed_request",
+  "tier": "mcp",
+  "name": "MCP malformed JSON-RPC requests return parse error envelopes without opening a session",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      }
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "null_id",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"ping\"}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": null,
+            "error": {
+              "code": -32700,
+              "message": "Parse error: id must not be null"
+            }
+          },
+          "is_base64": false
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/core-tools-list-call.json
+++ b/contract-tests/fixtures/mcp/core-tools-list-call.json
@@ -1,0 +1,209 @@
+{
+  "id": "mcp.core.tools_list_call",
+  "tier": "mcp",
+  "name": "MCP tools/list and tools/call use registered Go runtime tools",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-core"
+      ],
+      "tools": [
+        {
+          "name": "echo",
+          "description": "Echo text",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          },
+          "handler": "echo_text"
+        }
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "tools_list",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-core"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"list\",\"method\":\"tools/list\"}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "tools_call",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-core"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"call\",\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{\"message\":\"hello contract\"}}}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-core"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "tools": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          },
+          "is_base64": false
+        },
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "list",
+            "result": {
+              "tools": [
+                {
+                  "name": "echo",
+                  "description": "Echo text",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "is_base64": false
+        },
+        {
+          "status": 200,
+          "headers": {
+            "content-type": [
+              "application/json"
+            ],
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "call",
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "hello contract"
+                }
+              ]
+            }
+          },
+          "is_base64": false
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/registry-prompts-render.json
+++ b/contract-tests/fixtures/mcp/registry-prompts-render.json
@@ -1,0 +1,254 @@
+{
+  "id": "mcp.registry.prompts_render",
+  "tier": "mcp",
+  "name": "MCP prompts/list and prompts/get render prompt templates through the registry",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-prompts"
+      ],
+      "prompts": [
+        {
+          "name": "greet",
+          "title": "Greeting",
+          "description": "Render a greeting",
+          "arguments": [
+            {
+              "name": "name",
+              "description": "Name to greet",
+              "required": true
+            }
+          ],
+          "handler": "render_greeting"
+        }
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "prompts_list",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-prompts"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"list\",\"method\":\"prompts/list\"}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "prompts_get",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-prompts"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"get\",\"method\":\"prompts/get\",\"params\":{\"name\":\"greet\",\"arguments\":{\"name\":\"Ada\"}}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "prompts_get_missing",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-prompts"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"missing\",\"method\":\"prompts/get\",\"params\":{\"name\":\"missing\"}}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-prompts"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "prompts": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "list",
+            "result": {
+              "prompts": [
+                {
+                  "name": "greet",
+                  "title": "Greeting",
+                  "description": "Render a greeting",
+                  "arguments": [
+                    {
+                      "name": "name",
+                      "description": "Name to greet",
+                      "required": true
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "get",
+            "result": {
+              "description": "Rendered greeting",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": {
+                    "type": "text",
+                    "text": "Hello, Ada."
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "missing",
+            "error": {
+              "code": -32602,
+              "message": "prompt not found: missing"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/registry-resources-templates.json
+++ b/contract-tests/fixtures/mcp/registry-resources-templates.json
@@ -1,0 +1,312 @@
+{
+  "id": "mcp.registry.resources_templates",
+  "tier": "mcp",
+  "name": "MCP resources/list, resources/read, and resources/templates/list pin registry behavior",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-resources"
+      ],
+      "resources": [
+        {
+          "uri": "file:///guide.txt",
+          "name": "guide",
+          "title": "Guide",
+          "description": "Fixture guide",
+          "mime_type": "text/plain",
+          "size": 14,
+          "contents": [
+            {
+              "uri": "file:///guide.txt",
+              "mime_type": "text/plain",
+              "text": "hello resource"
+            }
+          ]
+        }
+      ],
+      "resource_templates": [
+        {
+          "uri_template": "file:///{path}",
+          "name": "project-file",
+          "title": "Project file",
+          "description": "Read a project file by path",
+          "mime_type": "text/plain"
+        }
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "resources_list",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-resources"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"list\",\"method\":\"resources/list\"}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "resources_read",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-resources"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"read\",\"method\":\"resources/read\",\"params\":{\"uri\":\"file:///guide.txt\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "resources_templates_list",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-resources"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"templates\",\"method\":\"resources/templates/list\"}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "resources_read_missing",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "mcp-session-id": [
+                "sess-resources"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"missing\",\"method\":\"resources/read\",\"params\":{\"uri\":\"file:///missing.txt\"}}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-resources"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "resources": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "list",
+            "result": {
+              "resources": [
+                {
+                  "uri": "file:///guide.txt",
+                  "name": "guide",
+                  "title": "Guide",
+                  "description": "Fixture guide",
+                  "mimeType": "text/plain",
+                  "size": 14
+                }
+              ]
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "read",
+            "result": {
+              "contents": [
+                {
+                  "uri": "file:///guide.txt",
+                  "mimeType": "text/plain",
+                  "text": "hello resource"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "templates",
+            "result": {
+              "resourceTemplates": [
+                {
+                  "uriTemplate": "file:///{path}",
+                  "name": "project-file",
+                  "title": "Project file",
+                  "description": "Read a project file by path",
+                  "mimeType": "text/plain"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "missing",
+            "error": {
+              "code": -32602,
+              "message": "resource not found: file:///missing.txt"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/sessions-expired-rejected.json
+++ b/contract-tests/fixtures/mcp/sessions-expired-rejected.json
@@ -1,0 +1,79 @@
+{
+  "id": "mcp.transport.session_expired_rejected",
+  "tier": "mcp",
+  "name": "MCP expired sessions fail closed as not found",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "session_store": {
+        "seed": [
+          {
+            "id": "sess-expired",
+            "created_unix_ms": 1,
+            "expires_unix_ms": 1000,
+            "data": {
+              "protocolVersion": "2025-11-25"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "ping_expired",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-expired"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"expired\",\"method\":\"ping\"}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 404,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "error": "session not found"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/sessions-lifecycle-create-delete-reject.json
+++ b/contract-tests/fixtures/mcp/sessions-lifecycle-create-delete-reject.json
@@ -1,0 +1,192 @@
+{
+  "id": "mcp.transport.session_lifecycle_create_delete_reject",
+  "tier": "mcp",
+  "name": "MCP sessions are created by initialize, accepted for requests, deleted, then rejected",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-lifecycle"
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "ping",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-lifecycle"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"ping\",\"method\":\"ping\"}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "delete_session",
+          "request": {
+            "method": "DELETE",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-lifecycle"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": ""
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "ping_after_delete",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-lifecycle"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"after\",\"method\":\"ping\"}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-lifecycle"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {},
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "ping",
+            "result": {}
+          }
+        },
+        {
+          "status": 202,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false
+        },
+        {
+          "status": 404,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "error": "session not found"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/sse-resumable-replay.json
+++ b/contract-tests/fixtures/mcp/sse-resumable-replay.json
@@ -1,0 +1,234 @@
+{
+  "id": "mcp.sse.resumable_replay_from_last_event_id",
+  "tier": "mcp",
+  "name": "MCP resumable SSE assigns event IDs and replays after Last-Event-ID",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-sse"
+      ],
+      "stream_id_sequence": [
+        "stream-1"
+      ],
+      "tools": [
+        {
+          "name": "streamer",
+          "description": "Stream progress",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          },
+          "handler": "stream_progress",
+          "streaming": true
+        }
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "stream_call",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-sse"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"stream\",\"method\":\"tools/call\",\"params\":{\"name\":\"streamer\",\"arguments\":{\"message\":\"stream complete\"},\"_meta\":{\"progressToken\":\"pt-1\"}}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "replay_after_priming",
+          "request": {
+            "method": "GET",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-sse"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "text/event-stream"
+              ],
+              "last-event-id": [
+                "1"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": ""
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-sse"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "tools": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "text/event-stream"
+            ],
+            "cache-control": [
+              "no-cache"
+            ],
+            "connection": [
+              "keep-alive"
+            ],
+            "mcp-session-id": [
+              "sess-sse"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "sse_frames": [
+            {
+              "id": "1",
+              "data": ""
+            },
+            {
+              "id": "2",
+              "event": "message",
+              "data": "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"message\":\"half\",\"progress\":1,\"progressToken\":\"pt-1\",\"total\":2}}"
+            },
+            {
+              "id": "3",
+              "event": "message",
+              "data": "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"message\":\"done\",\"progress\":2,\"progressToken\":\"pt-1\",\"total\":2}}"
+            },
+            {
+              "id": "4",
+              "event": "message",
+              "data": "{\"jsonrpc\":\"2.0\",\"id\":\"stream\",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"stream complete\"}]}}"
+            }
+          ]
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "text/event-stream"
+            ],
+            "cache-control": [
+              "no-cache"
+            ],
+            "connection": [
+              "keep-alive"
+            ],
+            "mcp-session-id": [
+              "sess-sse"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "sse_frames": [
+            {
+              "id": "2",
+              "event": "message",
+              "data": "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"message\":\"half\",\"progress\":1,\"progressToken\":\"pt-1\",\"total\":2}}"
+            },
+            {
+              "id": "3",
+              "event": "message",
+              "data": "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"message\":\"done\",\"progress\":2,\"progressToken\":\"pt-1\",\"total\":2}}"
+            },
+            {
+              "id": "4",
+              "event": "message",
+              "data": "{\"jsonrpc\":\"2.0\",\"id\":\"stream\",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"stream complete\"}]}}"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/tasks-lifecycle-memory-store.json
+++ b/contract-tests/fixtures/mcp/tasks-lifecycle-memory-store.json
@@ -1,0 +1,388 @@
+{
+  "id": "mcp.tasks.lifecycle_memory_store",
+  "tier": "mcp",
+  "name": "MCP task lifecycle is pinned against deterministic store fakes",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-task",
+        "task-1"
+      ],
+      "tools": [
+        {
+          "name": "task_echo",
+          "description": "Echo through a task",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          },
+          "handler": "task_echo",
+          "task_support": "optional"
+        }
+      ],
+      "task_runtime": {
+        "enabled": true,
+        "default_ttl_ms": 86400000,
+        "max_ttl_ms": 86400000,
+        "poll_interval_ms": 100,
+        "list_limit": 10,
+        "model_immediate_response": "poll tasks/result",
+        "clock_unix_ms": 1783036800000,
+        "update_clock_unix_ms": 1783036801000
+      }
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "task_create",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-task"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"create\",\"method\":\"tools/call\",\"params\":{\"name\":\"task_echo\",\"arguments\":{\"message\":\"task result\"},\"task\":{}}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "task_result",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-task"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"result\",\"method\":\"tasks/result\",\"params\":{\"taskId\":\"task-1\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "task_get",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-task"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"get\",\"method\":\"tasks/get\",\"params\":{\"taskId\":\"task-1\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "tasks_list",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-task"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"list\",\"method\":\"tasks/list\",\"params\":{}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "task_cancel_terminal",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-task"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"cancel\",\"method\":\"tasks/cancel\",\"params\":{\"taskId\":\"task-1\"}}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-task"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "tasks": {
+                  "cancel": {},
+                  "list": {},
+                  "requests": {
+                    "tools": {
+                      "call": {}
+                    }
+                  }
+                },
+                "tools": {}
+              },
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "create",
+            "result": {
+              "_meta": {
+                "io.modelcontextprotocol/model-immediate-response": "poll tasks/result",
+                "io.modelcontextprotocol/related-task": {
+                  "taskId": "task-1"
+                }
+              },
+              "task": {
+                "taskId": "task-1",
+                "status": "working",
+                "createdAt": "2026-07-03T00:00:00Z",
+                "lastUpdatedAt": "2026-07-03T00:00:00Z",
+                "ttl": 86400000,
+                "pollInterval": 100
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "result",
+            "result": {
+              "_meta": {
+                "io.modelcontextprotocol/related-task": {
+                  "taskId": "task-1"
+                }
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "task result"
+                }
+              ],
+              "structuredContent": {
+                "message": "task result"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "get",
+            "result": {
+              "taskId": "task-1",
+              "status": "completed",
+              "createdAt": "2026-07-03T00:00:00Z",
+              "lastUpdatedAt": "2026-07-03T00:00:01Z",
+              "ttl": 86400000,
+              "pollInterval": 100
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "list",
+            "result": {
+              "tasks": [
+                {
+                  "taskId": "task-1",
+                  "status": "completed",
+                  "createdAt": "2026-07-03T00:00:00Z",
+                  "lastUpdatedAt": "2026-07-03T00:00:01Z",
+                  "ttl": 86400000,
+                  "pollInterval": 100
+                }
+              ]
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "cancel",
+            "error": {
+              "code": -32602,
+              "message": "task already terminal"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/fixtures/mcp/transport-framing-reserved-paths.json
+++ b/contract-tests/fixtures/mcp/transport-framing-reserved-paths.json
@@ -1,0 +1,237 @@
+{
+  "id": "mcp.transport.streamable_http_framing_reserved_paths",
+  "tier": "mcp",
+  "name": "MCP Streamable HTTP framing pins GET SSE, response acceptance, header rejection, and reserved path behavior",
+  "setup": {
+    "mcp": {
+      "server": {
+        "name": "ContractMCP",
+        "version": "sp09"
+      },
+      "id_sequence": [
+        "sess-transport"
+      ]
+    }
+  },
+  "input": {
+    "mcp": {
+      "steps": [
+        {
+          "name": "initialize",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"init\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "get_listener",
+          "request": {
+            "method": "GET",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-transport"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": ""
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "post_missing_sse_accept",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"bad\",\"method\":\"ping\"}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "jsonrpc_response_accepted",
+          "request": {
+            "method": "POST",
+            "path": "/mcp",
+            "headers": {
+              "mcp-session-id": [
+                "sess-transport"
+              ],
+              "mcp-protocol-version": [
+                "2025-11-25"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ],
+              "content-type": [
+                "application/json"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"client-rsp\",\"result\":{\"ok\":true}}"
+            },
+            "is_base64": false
+          }
+        },
+        {
+          "name": "reserved_suffix_path",
+          "request": {
+            "method": "POST",
+            "path": "/mcp/reserved",
+            "headers": {
+              "content-type": [
+                "application/json"
+              ],
+              "accept": [
+                "application/json, text/event-stream"
+              ]
+            },
+            "body": {
+              "encoding": "utf8",
+              "value": "{\"jsonrpc\":\"2.0\",\"id\":\"reserved\",\"method\":\"ping\"}"
+            },
+            "is_base64": false
+          }
+        }
+      ]
+    }
+  },
+  "expect": {
+    "mcp": {
+      "steps": [
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ],
+            "mcp-session-id": [
+              "sess-transport"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {},
+              "serverInfo": {
+                "name": "ContractMCP",
+                "version": "sp09"
+              }
+            }
+          }
+        },
+        {
+          "status": 200,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "text/event-stream"
+            ],
+            "cache-control": [
+              "no-cache"
+            ],
+            "connection": [
+              "keep-alive"
+            ],
+            "mcp-session-id": [
+              "sess-transport"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body": {
+            "encoding": "utf8",
+            "value": ": keepalive\n\n"
+          }
+        },
+        {
+          "status": 400,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "error": "POST /mcp requires Accept: application/json and text/event-stream"
+          }
+        },
+        {
+          "status": 202,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false
+        },
+        {
+          "status": 404,
+          "headers": {
+            "x-request-id": [
+              "req_mcp_123"
+            ],
+            "content-type": [
+              "application/json; charset=utf-8"
+            ]
+          },
+          "cookies": [],
+          "is_base64": false,
+          "body_json": {
+            "error": {
+              "code": "app.not_found",
+              "message": "not found",
+              "request_id": "req_mcp_123"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contract-tests/runners/go/apptheory_mcp.go
+++ b/contract-tests/runners/go/apptheory_mcp.go
@@ -1,0 +1,662 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+const mcpProtocolVersion = "2025-11-25"
+
+func runFixtureMCP(f Fixture) error {
+	if f.Input.MCP == nil {
+		return errors.New("fixture missing input.mcp")
+	}
+	if f.Expect.MCP == nil {
+		return errors.New("fixture missing expect.mcp")
+	}
+	if len(f.Input.MCP.Steps) != len(f.Expect.MCP.Steps) {
+		return fmt.Errorf("mcp steps length: expected %d, got %d", len(f.Expect.MCP.Steps), len(f.Input.MCP.Steps))
+	}
+
+	server, err := newFixtureMCPServer(f.Setup.MCP)
+	if err != nil {
+		return fmt.Errorf("setup mcp server: %w", err)
+	}
+	app := apptheory.New(apptheory.WithIDGenerator(fixedIDGenerator{id: "req_mcp_123"}))
+	handler := server.Handler()
+	app.Post("/mcp", handler)
+	app.Get("/mcp", handler)
+	app.Delete("/mcp", handler)
+
+	for i, step := range f.Input.MCP.Steps {
+		actual, err := invokeMCPFixtureStep(app, step)
+		if err != nil {
+			return fmt.Errorf("step %s: %w", step.Name, err)
+		}
+		if err := compareMCPExpectedStep(f.Expect.MCP.Steps[i], actual); err != nil {
+			return fmt.Errorf("step %s: %w", step.Name, err)
+		}
+	}
+	return nil
+}
+
+func newFixtureMCPServer(setup FixtureMCPSetup) (*mcp.Server, error) {
+	name := strings.TrimSpace(setup.Server.Name)
+	if name == "" {
+		name = "AppTheoryContractMCP"
+	}
+	version := strings.TrimSpace(setup.Server.Version)
+	if version == "" {
+		version = "sp09"
+	}
+
+	serverIDs := newSequenceIDGenerator(setup.IDSequence, "mcp-id")
+	streamIDs := newSequenceIDGenerator(setup.StreamIDSequence, "mcp-stream")
+	sessionStore := newFixtureMCPSessionStore(setup.SessionStore)
+	streamStore := mcp.NewMemoryStreamStore(mcp.WithStreamIDGenerator(streamIDs))
+
+	opts := []mcp.ServerOption{
+		mcp.WithServerIDGenerator(serverIDs),
+		mcp.WithSessionStore(sessionStore),
+		mcp.WithStreamStore(streamStore),
+	}
+	if setup.TaskRuntime != nil && setup.TaskRuntime.Enabled {
+		opts = append(opts, mcp.WithTaskRuntime(mcp.TaskRuntimeOptions{
+			Store:                  newFixtureMCPTaskStore(*setup.TaskRuntime),
+			DefaultTTL:             durationFromMilliseconds(setup.TaskRuntime.DefaultTTLMS),
+			MaxTTL:                 durationFromMilliseconds(setup.TaskRuntime.MaxTTLMS),
+			PollInterval:           durationFromMilliseconds(setup.TaskRuntime.PollIntervalMS),
+			ListLimit:              setup.TaskRuntime.ListLimit,
+			ModelImmediateResponse: setup.TaskRuntime.ModelImmediateResponse,
+		}))
+	}
+
+	server := mcp.NewServer(name, version, opts...)
+	for _, tool := range setup.Tools {
+		if err := registerFixtureMCPTool(server, tool); err != nil {
+			return nil, err
+		}
+	}
+	for _, resource := range setup.Resources {
+		if err := registerFixtureMCPResource(server, resource); err != nil {
+			return nil, err
+		}
+	}
+	if len(setup.ResourceTemplates) > 0 {
+		return nil, errors.New("resource templates are not supported by this Go MCP runner yet")
+	}
+	for _, prompt := range setup.Prompts {
+		if err := registerFixtureMCPPrompt(server, prompt); err != nil {
+			return nil, err
+		}
+	}
+	return server, nil
+}
+
+func durationFromMilliseconds(ms int64) time.Duration {
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+type sequenceIDGenerator struct {
+	mu       sync.Mutex
+	ids      []string
+	fallback string
+	next     int
+}
+
+func newSequenceIDGenerator(ids []string, fallback string) *sequenceIDGenerator {
+	return &sequenceIDGenerator{ids: append([]string(nil), ids...), fallback: fallback}
+}
+
+func (g *sequenceIDGenerator) NewID() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.next < len(g.ids) {
+		out := strings.TrimSpace(g.ids[g.next])
+		g.next++
+		if out != "" {
+			return out
+		}
+	}
+	g.next++
+	return fmt.Sprintf("%s-%d", g.fallback, g.next)
+}
+
+func newFixtureMCPSessionStore(config FixtureMCPSessionStore) *mcp.MemorySessionStore {
+	store := mcp.NewMemorySessionStore(mcp.WithClock(fixedClock{now: time.Unix(1700000000, 0).UTC()}))
+	for _, seed := range config.Seed {
+		created := timeFromUnixMilliseconds(seed.CreatedUnixMS)
+		if created.IsZero() {
+			created = time.Unix(0, 0).UTC()
+		}
+		sess := &mcp.Session{
+			ID:        seed.ID,
+			CreatedAt: created,
+			ExpiresAt: timeFromUnixMilliseconds(seed.ExpiresUnixMS),
+			Data:      cloneStringMap(seed.Data),
+		}
+		_ = store.Put(context.Background(), sess)
+	}
+	return store
+}
+
+func timeFromUnixMilliseconds(ms int64) time.Time {
+	if ms <= 0 {
+		return time.Time{}
+	}
+	sec := ms / 1000
+	nsec := (ms % 1000) * int64(time.Millisecond)
+	return time.Unix(sec, nsec).UTC()
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func registerFixtureMCPTool(server *mcp.Server, tool FixtureMCPTool) error {
+	def := mcp.ToolDef{
+		Name:         tool.Name,
+		Title:        tool.Title,
+		Description:  tool.Description,
+		InputSchema:  cloneRawMessage(tool.InputSchema),
+		OutputSchema: cloneRawMessage(tool.OutputSchema),
+	}
+	if support := strings.TrimSpace(tool.TaskSupport); support != "" {
+		def.Execution = &mcp.ToolExecution{TaskSupport: mcp.TaskSupport(support)}
+	}
+
+	if tool.Streaming {
+		handler, err := fixtureMCPStreamingToolHandler(tool.Handler)
+		if err != nil {
+			return err
+		}
+		return server.Registry().RegisterStreamingTool(def, handler)
+	}
+	handler, err := fixtureMCPToolHandler(tool.Handler)
+	if err != nil {
+		return err
+	}
+	return server.Registry().RegisterTool(def, handler)
+}
+
+func cloneRawMessage(in json.RawMessage) json.RawMessage {
+	return append(json.RawMessage(nil), in...)
+}
+
+func fixtureMCPToolHandler(name string) (mcp.ToolHandler, error) {
+	switch strings.TrimSpace(name) {
+	case "echo_text":
+		return func(_ context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
+			message, err := mcpFixtureMessageArg(args)
+			if err != nil {
+				return nil, err
+			}
+			return &mcp.ToolResult{Content: []mcp.ContentBlock{{Type: "text", Text: message}}}, nil
+		}, nil
+	case "fail_error":
+		return func(context.Context, json.RawMessage) (*mcp.ToolResult, error) {
+			return nil, errors.New("fixture tool failed")
+		}, nil
+	case "task_echo":
+		return func(_ context.Context, args json.RawMessage) (*mcp.ToolResult, error) {
+			message, err := mcpFixtureMessageArg(args)
+			if err != nil {
+				return nil, err
+			}
+			return &mcp.ToolResult{
+				Content:           []mcp.ContentBlock{{Type: "text", Text: message}},
+				StructuredContent: map[string]any{"message": message},
+			}, nil
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown mcp tool handler %q", name)
+	}
+}
+
+func fixtureMCPStreamingToolHandler(name string) (mcp.StreamingToolHandler, error) {
+	switch strings.TrimSpace(name) {
+	case "stream_progress":
+		return func(_ context.Context, args json.RawMessage, emit func(mcp.SSEEvent)) (*mcp.ToolResult, error) {
+			message, err := mcpFixtureMessageArg(args)
+			if err != nil {
+				return nil, err
+			}
+			emit(mcp.SSEEvent{Data: map[string]any{"seq": 1, "total": 2, "message": "half"}})
+			emit(mcp.SSEEvent{Data: map[string]any{"seq": 2, "total": 2, "message": "done"}})
+			return &mcp.ToolResult{Content: []mcp.ContentBlock{{Type: "text", Text: message}}}, nil
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown mcp streaming tool handler %q", name)
+	}
+}
+
+func mcpFixtureMessageArg(args json.RawMessage) (string, error) {
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if len(bytes.TrimSpace(args)) > 0 {
+		if err := json.Unmarshal(args, &payload); err != nil {
+			return "", err
+		}
+	}
+	if strings.TrimSpace(payload.Message) == "" {
+		return "", errors.New("missing message")
+	}
+	return payload.Message, nil
+}
+
+func registerFixtureMCPResource(server *mcp.Server, resource FixtureMCPResource) error {
+	contents := make([]mcp.ResourceContent, 0, len(resource.Contents))
+	for _, content := range resource.Contents {
+		contents = append(contents, mcp.ResourceContent{
+			URI:      content.URI,
+			MimeType: content.MimeType,
+			Text:     content.Text,
+			Blob:     content.Blob,
+		})
+	}
+	return server.Resources().RegisterResource(mcp.ResourceDef{
+		URI:         resource.URI,
+		Name:        resource.Name,
+		Title:       resource.Title,
+		Description: resource.Description,
+		MimeType:    resource.MimeType,
+		Size:        resource.Size,
+	}, func(context.Context) ([]mcp.ResourceContent, error) {
+		out := append([]mcp.ResourceContent(nil), contents...)
+		return out, nil
+	})
+}
+
+func registerFixtureMCPPrompt(server *mcp.Server, prompt FixtureMCPPrompt) error {
+	args := make([]mcp.PromptArgument, 0, len(prompt.Arguments))
+	for _, arg := range prompt.Arguments {
+		args = append(args, mcp.PromptArgument{
+			Name:        arg.Name,
+			Title:       arg.Title,
+			Description: arg.Description,
+			Required:    arg.Required,
+		})
+	}
+	handler, err := fixtureMCPPromptHandler(prompt.Handler)
+	if err != nil {
+		return err
+	}
+	return server.Prompts().RegisterPrompt(mcp.PromptDef{
+		Name:        prompt.Name,
+		Title:       prompt.Title,
+		Description: prompt.Description,
+		Arguments:   args,
+	}, handler)
+}
+
+func fixtureMCPPromptHandler(name string) (mcp.PromptHandler, error) {
+	switch strings.TrimSpace(name) {
+	case "render_greeting":
+		return func(_ context.Context, args json.RawMessage) (*mcp.PromptResult, error) {
+			var payload struct {
+				Name string `json:"name"`
+			}
+			if len(bytes.TrimSpace(args)) > 0 {
+				if err := json.Unmarshal(args, &payload); err != nil {
+					return nil, err
+				}
+			}
+			name := strings.TrimSpace(payload.Name)
+			if name == "" {
+				name = "friend"
+			}
+			return &mcp.PromptResult{
+				Description: "Rendered greeting",
+				Messages: []mcp.PromptMessage{{
+					Role:    "user",
+					Content: mcp.ContentBlock{Type: "text", Text: "Hello, " + name + "."},
+				}},
+			}, nil
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown mcp prompt handler %q", name)
+	}
+}
+
+type fixtureMCPActualStep struct {
+	Status    int
+	Headers   map[string][]string
+	Cookies   []string
+	Body      []byte
+	SSEFrames []FixtureMCPSSEFrame
+	IsBase64  bool
+}
+
+func invokeMCPFixtureStep(app *apptheory.App, step FixtureMCPStep) (fixtureMCPActualStep, error) {
+	body, err := decodeFixtureBody(step.Request.Body)
+	if err != nil {
+		return fixtureMCPActualStep{}, fmt.Errorf("decode request body: %w", err)
+	}
+	if step.Request.IsBase64 {
+		decoded, err := decodeBase64String(string(body))
+		if err != nil {
+			return fixtureMCPActualStep{}, fmt.Errorf("decode base64 request body: %w", err)
+		}
+		body = decoded
+	}
+	ctx, cancel := fixtureContext(time.Unix(0, 0).UTC(), 0)
+	if cancel != nil {
+		defer cancel()
+	}
+	resp := app.Serve(ctx, apptheory.Request{
+		Method:  strings.ToUpper(strings.TrimSpace(step.Request.Method)),
+		Path:    strings.TrimSpace(step.Request.Path),
+		Query:   cloneHeaders(step.Request.Query),
+		Headers: canonicalizeHeaders(step.Request.Headers),
+		Body:    body,
+	})
+
+	actualBody := append([]byte(nil), resp.Body...)
+	if resp.BodyReader != nil {
+		read, err := io.ReadAll(resp.BodyReader)
+		if err != nil {
+			return fixtureMCPActualStep{}, fmt.Errorf("read response body: %w", err)
+		}
+		actualBody = append(actualBody, read...)
+	}
+	frames, err := parseMCPSSEFrames(actualBody)
+	if err != nil {
+		return fixtureMCPActualStep{}, err
+	}
+	return fixtureMCPActualStep{
+		Status:    resp.Status,
+		Headers:   canonicalizeHeaders(resp.Headers),
+		Cookies:   append([]string(nil), resp.Cookies...),
+		Body:      actualBody,
+		SSEFrames: frames,
+		IsBase64:  resp.IsBase64,
+	}, nil
+}
+
+func decodeBase64String(value string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(strings.TrimSpace(value))
+}
+
+func compareMCPExpectedStep(expected FixtureMCPExpectedStep, actual fixtureMCPActualStep) error {
+	if expected.Status != actual.Status {
+		return fmt.Errorf("status: expected %d, got %d", expected.Status, actual.Status)
+	}
+	if expected.IsBase64 != actual.IsBase64 {
+		return fmt.Errorf("is_base64: expected %v, got %v", expected.IsBase64, actual.IsBase64)
+	}
+	if !equalStringSlices(expected.Cookies, actual.Cookies) {
+		return fmt.Errorf("cookies mismatch")
+	}
+	if !equalHeaders(canonicalizeHeaders(expected.Headers), actual.Headers) {
+		return fmt.Errorf("headers mismatch: expected %s, got %s", string(marshalIndentOrPlaceholder(canonicalizeHeaders(expected.Headers))), string(marshalIndentOrPlaceholder(actual.Headers)))
+	}
+	if len(expected.SSEFrames) > 0 {
+		if !reflectMCPFramesEqual(expected.SSEFrames, actual.SSEFrames) {
+			return fmt.Errorf("sse_frames mismatch: expected %s, got %s", string(marshalIndentOrPlaceholder(expected.SSEFrames)), string(marshalIndentOrPlaceholder(actual.SSEFrames)))
+		}
+		return nil
+	}
+	if len(expected.BodyJSON) > 0 {
+		var expectedJSON any
+		if err := json.Unmarshal(expected.BodyJSON, &expectedJSON); err != nil {
+			return fmt.Errorf("parse expected body_json: %w", err)
+		}
+		var actualJSON any
+		if err := json.Unmarshal(actual.Body, &actualJSON); err != nil {
+			return fmt.Errorf("parse actual body_json: %w (body=%q)", err, string(actual.Body))
+		}
+		if !jsonEqual(expectedJSON, actualJSON) {
+			return fmt.Errorf("body_json mismatch: expected %s, got %s", string(marshalIndentOrPlaceholder(expectedJSON)), string(marshalIndentOrPlaceholder(actualJSON)))
+		}
+		return nil
+	}
+	var expectedBody []byte
+	if expected.Body != nil {
+		var err error
+		expectedBody, err = decodeFixtureBody(*expected.Body)
+		if err != nil {
+			return fmt.Errorf("decode expected body: %w", err)
+		}
+	}
+	if !equalBytes(expectedBody, actual.Body) {
+		return fmt.Errorf("body mismatch: expected %q, got %q", string(expectedBody), string(actual.Body))
+	}
+	return nil
+}
+
+func reflectMCPFramesEqual(a, b []FixtureMCPSSEFrame) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func parseMCPSSEFrames(body []byte) ([]FixtureMCPSSEFrame, error) {
+	if !bytes.Contains(body, []byte("data: ")) && !bytes.Contains(body, []byte("id: ")) {
+		return nil, nil
+	}
+	chunks := bytes.Split(body, []byte("\n\n"))
+	frames := make([]FixtureMCPSSEFrame, 0, len(chunks))
+	for _, chunk := range chunks {
+		chunk = bytes.Trim(chunk, "\n")
+		if len(bytes.TrimSpace(chunk)) == 0 {
+			continue
+		}
+		frame := FixtureMCPSSEFrame{}
+		var dataLines []string
+		for _, rawLine := range bytes.Split(chunk, []byte("\n")) {
+			line := string(rawLine)
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(line, "id: "):
+				frame.ID = strings.TrimSpace(strings.TrimPrefix(line, "id: "))
+			case strings.HasPrefix(line, "event: "):
+				frame.Event = strings.TrimSpace(strings.TrimPrefix(line, "event: "))
+			case strings.HasPrefix(line, "data: "):
+				dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+			case strings.TrimSpace(line) == "":
+				// ignore
+			default:
+				return nil, fmt.Errorf("invalid SSE line %q", line)
+			}
+		}
+		frame.Data = strings.Join(dataLines, "\n")
+		frames = append(frames, frame)
+	}
+	return frames, nil
+}
+
+type fixtureMCPTaskStore struct {
+	mu         sync.RWMutex
+	sessions   map[string]map[string]*mcp.TaskRecord
+	createTime time.Time
+	updateTime time.Time
+}
+
+func newFixtureMCPTaskStore(config FixtureMCPTaskRuntime) *fixtureMCPTaskStore {
+	createTime := timeFromUnixMilliseconds(config.ClockUnixMS)
+	if createTime.IsZero() {
+		createTime = time.Unix(1772539200, 0).UTC()
+	}
+	updateTime := timeFromUnixMilliseconds(config.UpdateClockUnixMS)
+	if updateTime.IsZero() {
+		updateTime = createTime.Add(time.Second)
+	}
+	return &fixtureMCPTaskStore{
+		sessions:   map[string]map[string]*mcp.TaskRecord{},
+		createTime: createTime,
+		updateTime: updateTime,
+	}
+}
+
+func (s *fixtureMCPTaskStore) Create(_ context.Context, task mcp.TaskRecord) (*mcp.TaskRecord, error) {
+	task.SessionID = strings.TrimSpace(task.SessionID)
+	task.Task.TaskID = strings.TrimSpace(task.Task.TaskID)
+	if task.SessionID == "" {
+		return nil, errors.New("missing session id")
+	}
+	if task.Task.TaskID == "" {
+		return nil, errors.New("missing task id")
+	}
+	task.Task.CreatedAt = s.createTime
+	task.Task.LastUpdatedAt = s.createTime
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess := s.sessions[task.SessionID]
+	if sess == nil {
+		sess = map[string]*mcp.TaskRecord{}
+		s.sessions[task.SessionID] = sess
+	}
+	if _, exists := sess[task.Task.TaskID]; exists {
+		return nil, errors.New("task already exists")
+	}
+	sess[task.Task.TaskID] = cloneMCPTaskRecord(&task)
+	return cloneMCPTaskRecord(sess[task.Task.TaskID]), nil
+}
+
+func (s *fixtureMCPTaskStore) Get(_ context.Context, lookup mcp.TaskLookup) (*mcp.TaskRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record := s.recordLocked(lookup)
+	if record == nil {
+		return nil, mcp.ErrTaskNotFound
+	}
+	return cloneMCPTaskRecord(record), nil
+}
+
+func (s *fixtureMCPTaskStore) Update(_ context.Context, task mcp.TaskRecord) (*mcp.TaskRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record := s.recordLocked(mcp.TaskLookup{SessionID: task.SessionID, TaskID: task.Task.TaskID})
+	if record == nil {
+		return nil, mcp.ErrTaskNotFound
+	}
+	if mcpTaskTerminal(record.Task.Status) {
+		return nil, mcp.ErrTaskTerminal
+	}
+	task.Task.CreatedAt = record.Task.CreatedAt
+	task.Task.LastUpdatedAt = s.updateTime
+	s.sessions[task.SessionID][task.Task.TaskID] = cloneMCPTaskRecord(&task)
+	return cloneMCPTaskRecord(s.sessions[task.SessionID][task.Task.TaskID]), nil
+}
+
+func (s *fixtureMCPTaskStore) List(_ context.Context, req mcp.TaskListRequest) (*mcp.TaskListResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess := s.sessions[strings.TrimSpace(req.SessionID)]
+	if sess == nil {
+		return &mcp.TaskListResult{Tasks: []mcp.Task{}}, nil
+	}
+	records := make([]*mcp.TaskRecord, 0, len(sess))
+	for _, record := range sess {
+		records = append(records, record)
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].Task.CreatedAt.Equal(records[j].Task.CreatedAt) {
+			return records[i].Task.TaskID < records[j].Task.TaskID
+		}
+		return records[i].Task.CreatedAt.Before(records[j].Task.CreatedAt)
+	})
+	limit := req.Limit
+	if limit <= 0 || limit > len(records) {
+		limit = len(records)
+	}
+	tasks := make([]mcp.Task, 0, limit)
+	for _, record := range records[:limit] {
+		tasks = append(tasks, record.Task)
+	}
+	return &mcp.TaskListResult{Tasks: tasks}, nil
+}
+
+func (s *fixtureMCPTaskStore) Cancel(_ context.Context, lookup mcp.TaskLookup) (*mcp.TaskRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record := s.recordLocked(lookup)
+	if record == nil {
+		return nil, mcp.ErrTaskNotFound
+	}
+	if mcpTaskTerminal(record.Task.Status) {
+		return nil, mcp.ErrTaskTerminal
+	}
+	record.Task.Status = mcp.TaskStatusCanceled
+	record.Task.StatusMessage = "task canceled"
+	record.Task.LastUpdatedAt = s.updateTime
+	record.Error = &mcp.RPCError{Code: mcp.CodeServerError, Message: "task canceled"}
+	return cloneMCPTaskRecord(record), nil
+}
+
+func (s *fixtureMCPTaskStore) DeleteSession(_ context.Context, sessionID string) error {
+	s.mu.Lock()
+	delete(s.sessions, strings.TrimSpace(sessionID))
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *fixtureMCPTaskStore) recordLocked(lookup mcp.TaskLookup) *mcp.TaskRecord {
+	sess := s.sessions[strings.TrimSpace(lookup.SessionID)]
+	if sess == nil {
+		return nil
+	}
+	return sess[strings.TrimSpace(lookup.TaskID)]
+}
+
+func mcpTaskTerminal(status mcp.TaskStatus) bool {
+	switch status {
+	case mcp.TaskStatusCompleted, mcp.TaskStatusFailed, mcp.TaskStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneMCPTaskRecord(in *mcp.TaskRecord) *mcp.TaskRecord {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.Result = append(json.RawMessage(nil), in.Result...)
+	if in.Error != nil {
+		errCopy := *in.Error
+		out.Error = &errCopy
+	}
+	if in.Task.TTL != nil {
+		v := *in.Task.TTL
+		out.Task.TTL = &v
+	}
+	if in.Task.PollInterval != nil {
+		v := *in.Task.PollInterval
+		out.Task.PollInterval = &v
+	}
+	return &out
+}

--- a/contract-tests/runners/go/apptheory_mcp.go
+++ b/contract-tests/runners/go/apptheory_mcp.go
@@ -94,8 +94,10 @@ func newFixtureMCPServer(setup FixtureMCPSetup) (*mcp.Server, error) {
 			return nil, err
 		}
 	}
-	if len(setup.ResourceTemplates) > 0 {
-		return nil, errors.New("resource templates are not supported by this Go MCP runner yet")
+	for _, template := range setup.ResourceTemplates {
+		if err := registerFixtureMCPResourceTemplate(server, template); err != nil {
+			return nil, err
+		}
 	}
 	for _, prompt := range setup.Prompts {
 		if err := registerFixtureMCPPrompt(server, prompt); err != nil {
@@ -287,6 +289,16 @@ func registerFixtureMCPResource(server *mcp.Server, resource FixtureMCPResource)
 	}, func(context.Context) ([]mcp.ResourceContent, error) {
 		out := append([]mcp.ResourceContent(nil), contents...)
 		return out, nil
+	})
+}
+
+func registerFixtureMCPResourceTemplate(server *mcp.Server, template FixtureMCPResourceTemplate) error {
+	return server.Resources().RegisterResourceTemplate(mcp.ResourceTemplateDef{
+		URITemplate: template.URITemplate,
+		Name:        template.Name,
+		Title:       template.Title,
+		Description: template.Description,
+		MimeType:    template.MimeType,
 	})
 }
 

--- a/contract-tests/runners/go/apptheory_mcp.go
+++ b/contract-tests/runners/go/apptheory_mcp.go
@@ -17,8 +17,6 @@ import (
 	"github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
-const mcpProtocolVersion = "2025-11-25"
-
 func runFixtureMCP(f Fixture) error {
 	if f.Input.MCP == nil {
 		return errors.New("fixture missing input.mcp")
@@ -64,7 +62,10 @@ func newFixtureMCPServer(setup FixtureMCPSetup) (*mcp.Server, error) {
 
 	serverIDs := newSequenceIDGenerator(setup.IDSequence, "mcp-id")
 	streamIDs := newSequenceIDGenerator(setup.StreamIDSequence, "mcp-stream")
-	sessionStore := newFixtureMCPSessionStore(setup.SessionStore)
+	sessionStore, err := newFixtureMCPSessionStore(setup.SessionStore)
+	if err != nil {
+		return nil, fmt.Errorf("seed session store: %w", err)
+	}
 	streamStore := mcp.NewMemoryStreamStore(mcp.WithStreamIDGenerator(streamIDs))
 
 	opts := []mcp.ServerOption{
@@ -139,7 +140,7 @@ func (g *sequenceIDGenerator) NewID() string {
 	return fmt.Sprintf("%s-%d", g.fallback, g.next)
 }
 
-func newFixtureMCPSessionStore(config FixtureMCPSessionStore) *mcp.MemorySessionStore {
+func newFixtureMCPSessionStore(config FixtureMCPSessionStore) (*mcp.MemorySessionStore, error) {
 	store := mcp.NewMemorySessionStore(mcp.WithClock(fixedClock{now: time.Unix(1700000000, 0).UTC()}))
 	for _, seed := range config.Seed {
 		created := timeFromUnixMilliseconds(seed.CreatedUnixMS)
@@ -152,9 +153,11 @@ func newFixtureMCPSessionStore(config FixtureMCPSessionStore) *mcp.MemorySession
 			ExpiresAt: timeFromUnixMilliseconds(seed.ExpiresUnixMS),
 			Data:      cloneStringMap(seed.Data),
 		}
-		_ = store.Put(context.Background(), sess)
+		if err := store.Put(context.Background(), sess); err != nil {
+			return nil, fmt.Errorf("seed session %q: %w", seed.ID, err)
+		}
 	}
-	return store
+	return store, nil
 }
 
 func timeFromUnixMilliseconds(ms int64) time.Time {
@@ -336,15 +339,15 @@ func fixtureMCPPromptHandler(name string) (mcp.PromptHandler, error) {
 					return nil, err
 				}
 			}
-			name := strings.TrimSpace(payload.Name)
-			if name == "" {
-				name = "friend"
+			renderedName := strings.TrimSpace(payload.Name)
+			if renderedName == "" {
+				renderedName = "friend"
 			}
 			return &mcp.PromptResult{
 				Description: "Rendered greeting",
 				Messages: []mcp.PromptMessage{{
 					Role:    "user",
-					Content: mcp.ContentBlock{Type: "text", Text: "Hello, " + name + "."},
+					Content: mcp.ContentBlock{Type: "text", Text: "Hello, " + renderedName + "."},
 				}},
 			}, nil
 		}, nil
@@ -368,9 +371,9 @@ func invokeMCPFixtureStep(app *apptheory.App, step FixtureMCPStep) (fixtureMCPAc
 		return fixtureMCPActualStep{}, fmt.Errorf("decode request body: %w", err)
 	}
 	if step.Request.IsBase64 {
-		decoded, err := decodeBase64String(string(body))
-		if err != nil {
-			return fixtureMCPActualStep{}, fmt.Errorf("decode base64 request body: %w", err)
+		decoded, decodeErr := decodeBase64String(string(body))
+		if decodeErr != nil {
+			return fixtureMCPActualStep{}, fmt.Errorf("decode base64 request body: %w", decodeErr)
 		}
 		body = decoded
 	}
@@ -388,9 +391,9 @@ func invokeMCPFixtureStep(app *apptheory.App, step FixtureMCPStep) (fixtureMCPAc
 
 	actualBody := append([]byte(nil), resp.Body...)
 	if resp.BodyReader != nil {
-		read, err := io.ReadAll(resp.BodyReader)
-		if err != nil {
-			return fixtureMCPActualStep{}, fmt.Errorf("read response body: %w", err)
+		read, readErr := io.ReadAll(resp.BodyReader)
+		if readErr != nil {
+			return fixtureMCPActualStep{}, fmt.Errorf("read response body: %w", readErr)
 		}
 		actualBody = append(actualBody, read...)
 	}

--- a/contract-tests/runners/go/fixture.go
+++ b/contract-tests/runners/go/fixture.go
@@ -28,6 +28,7 @@ type FixtureSetup struct {
 	Environment     map[string]string         `json:"environment,omitempty"`
 	LoggingProfile  json.RawMessage           `json:"logging_profile,omitempty"`
 	OpenAPI         json.RawMessage           `json:"openapi,omitempty"`
+	MCP             FixtureMCPSetup           `json:"mcp,omitempty"`
 	WebSockets      []FixtureWebSocketRoute   `json:"websockets,omitempty"`
 	SQS             []FixtureSQSRoute         `json:"sqs,omitempty"`
 	Kinesis         []FixtureKinesisRoute     `json:"kinesis,omitempty"`
@@ -89,6 +90,7 @@ type FixtureInput struct {
 	AWSEvent              *FixtureAWSEvent `json:"aws_event,omitempty"`
 	LoggingEvent          json.RawMessage  `json:"logging_event,omitempty"`
 	LoggingProfileCatalog bool             `json:"logging_profile_catalog,omitempty"`
+	MCP                   *FixtureMCPInput `json:"mcp,omitempty"`
 }
 
 type FixtureAWSEvent struct {
@@ -126,6 +128,127 @@ type FixtureExpect struct {
 	MicroVMContractValidation  *FixtureMicroVMContractValidation  `json:"microvm_contract_validation,omitempty"`
 	MicroVMLifecycleAdapter    *FixtureMicroVMLifecycleAdapter    `json:"microvm_lifecycle_adapter,omitempty"`
 	MicroVMControllerRoute     *FixtureMicroVMControllerRoute     `json:"microvm_controller_route,omitempty"`
+	MCP                        *FixtureMCPExpect                  `json:"mcp,omitempty"`
+}
+
+type FixtureMCPSetup struct {
+	Server            FixtureMCPServer             `json:"server,omitempty"`
+	IDSequence        []string                     `json:"id_sequence,omitempty"`
+	StreamIDSequence  []string                     `json:"stream_id_sequence,omitempty"`
+	Tools             []FixtureMCPTool             `json:"tools,omitempty"`
+	Resources         []FixtureMCPResource         `json:"resources,omitempty"`
+	ResourceTemplates []FixtureMCPResourceTemplate `json:"resource_templates,omitempty"`
+	Prompts           []FixtureMCPPrompt           `json:"prompts,omitempty"`
+	SessionStore      FixtureMCPSessionStore       `json:"session_store,omitempty"`
+	TaskRuntime       *FixtureMCPTaskRuntime       `json:"task_runtime,omitempty"`
+}
+
+type FixtureMCPServer struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type FixtureMCPTool struct {
+	Name         string          `json:"name"`
+	Title        string          `json:"title,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	InputSchema  json.RawMessage `json:"input_schema"`
+	OutputSchema json.RawMessage `json:"output_schema,omitempty"`
+	Handler      string          `json:"handler"`
+	Streaming    bool            `json:"streaming,omitempty"`
+	TaskSupport  string          `json:"task_support,omitempty"`
+}
+
+type FixtureMCPResource struct {
+	URI         string                      `json:"uri"`
+	Name        string                      `json:"name"`
+	Title       string                      `json:"title,omitempty"`
+	Description string                      `json:"description,omitempty"`
+	MimeType    string                      `json:"mime_type,omitempty"`
+	Size        int64                       `json:"size,omitempty"`
+	Contents    []FixtureMCPResourceContent `json:"contents"`
+}
+
+type FixtureMCPResourceTemplate struct {
+	URITemplate string `json:"uri_template"`
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mime_type,omitempty"`
+}
+
+type FixtureMCPResourceContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mime_type,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+type FixtureMCPPrompt struct {
+	Name        string                     `json:"name"`
+	Title       string                     `json:"title,omitempty"`
+	Description string                     `json:"description,omitempty"`
+	Arguments   []FixtureMCPPromptArgument `json:"arguments,omitempty"`
+	Handler     string                     `json:"handler"`
+}
+
+type FixtureMCPPromptArgument struct {
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+type FixtureMCPSessionStore struct {
+	Seed []FixtureMCPSession `json:"seed,omitempty"`
+}
+
+type FixtureMCPSession struct {
+	ID            string            `json:"id"`
+	CreatedUnixMS int64             `json:"created_unix_ms,omitempty"`
+	ExpiresUnixMS int64             `json:"expires_unix_ms"`
+	Data          map[string]string `json:"data,omitempty"`
+}
+
+type FixtureMCPTaskRuntime struct {
+	Enabled                bool   `json:"enabled,omitempty"`
+	DefaultTTLMS           int64  `json:"default_ttl_ms,omitempty"`
+	MaxTTLMS               int64  `json:"max_ttl_ms,omitempty"`
+	PollIntervalMS         int64  `json:"poll_interval_ms,omitempty"`
+	ListLimit              int    `json:"list_limit,omitempty"`
+	ModelImmediateResponse string `json:"model_immediate_response,omitempty"`
+	ClockUnixMS            int64  `json:"clock_unix_ms,omitempty"`
+	UpdateClockUnixMS      int64  `json:"update_clock_unix_ms,omitempty"`
+}
+
+type FixtureMCPInput struct {
+	Steps []FixtureMCPStep `json:"steps"`
+}
+
+type FixtureMCPStep struct {
+	Name     string         `json:"name"`
+	Request  FixtureRequest `json:"request"`
+	ReadBody bool           `json:"read_body,omitempty"`
+}
+
+type FixtureMCPExpect struct {
+	Steps []FixtureMCPExpectedStep `json:"steps"`
+}
+
+type FixtureMCPExpectedStep struct {
+	Status    int                  `json:"status"`
+	Headers   map[string][]string  `json:"headers"`
+	Cookies   []string             `json:"cookies"`
+	Body      *FixtureBody         `json:"body,omitempty"`
+	BodyJSON  json.RawMessage      `json:"body_json,omitempty"`
+	SSEFrames []FixtureMCPSSEFrame `json:"sse_frames,omitempty"`
+	IsBase64  bool                 `json:"is_base64"`
+}
+
+type FixtureMCPSSEFrame struct {
+	ID    string `json:"id"`
+	Event string `json:"event,omitempty"`
+	Data  string `json:"data"`
 }
 
 type FixtureMicroVMContractValidation struct {

--- a/contract-tests/runners/go/runner.go
+++ b/contract-tests/runners/go/runner.go
@@ -45,6 +45,8 @@ func runFixture(f Fixture) error {
 		return runFixtureM15(f)
 	case "m16":
 		return runFixtureM16(f)
+	case "mcp":
+		return runFixtureMCP(f)
 	default:
 		return runFixtureLegacy(f)
 	}

--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -1552,6 +1552,8 @@ def run_fixture(fixture: dict[str, Any]) -> tuple[bool, str, CanonicalResponse, 
         return compare_openapi_contract(fixture)
 
     tier = str(fixture.get("tier", "")).strip().lower()
+    if tier == "mcp":
+        return True, "SP09 MCP fixtures are Go-runtime enforced; Python MCP runtime parity is SP11", {}, {}, _DummyEffectsApp()
     if tier == "p0":
         return run_fixture_p0(fixture)
     if tier == "p1":
@@ -4054,7 +4056,11 @@ def main() -> int:
             print(f"- {fixture['id']}", file=sys.stderr)
         return 1
 
-    print(f"contract-tests(py): PASS ({len(fixtures)} fixtures)")
+    skipped_mcp = sum(1 for fixture in fixtures if str(fixture.get("tier", "")).strip().lower() == "mcp")
+    if skipped_mcp:
+        print(f"contract-tests(py): PASS ({len(fixtures)} fixtures, skipped={skipped_mcp} mcp future-runtime fixtures)")
+    else:
+        print(f"contract-tests(py): PASS ({len(fixtures)} fixtures)")
     return 0
 
 

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -1925,6 +1925,14 @@ async function runFixture(fixture) {
     .trim()
     .toLowerCase();
 
+  if (tier === "mcp") {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "SP09 MCP fixtures are Go-runtime enforced; TS MCP runtime parity is SP10",
+    };
+  }
+
   if (tier === "p0") {
     const result = await runFixtureP0(fixture);
     if (expectsSetupError(fixture)) {
@@ -5080,7 +5088,14 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`contract-tests(ts): PASS (${fixtures.length} fixtures)`);
+  const skippedCount = fixtures.filter((fixture) => String(fixture.tier ?? "").trim().toLowerCase() === "mcp").length;
+  if (skippedCount > 0) {
+    console.log(
+      `contract-tests(ts): PASS (${fixtures.length} fixtures, skipped=${skippedCount} mcp future-runtime fixtures)`,
+    );
+  } else {
+    console.log(`contract-tests(ts): PASS (${fixtures.length} fixtures)`);
+  }
 }
 
 async function runAllFixtures({ fixturesRoot, fixtureID = "" } = {}) {
@@ -5090,12 +5105,17 @@ async function runAllFixtures({ fixturesRoot, fixtureID = "" } = {}) {
   }
 
   const failures = [];
+  const skipped = [];
   for (const fixture of fixtures) {
     const result = await runFixture(fixture);
+    if (result.skipped) {
+      skipped.push({ fixture, result });
+      continue;
+    }
     if (!result.ok) failures.push({ fixture, result });
   }
 
-  return { fixtures, failures };
+  return { fixtures, failures, skipped };
 }
 
 module.exports = {

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ description: >-
   The contract-first serverless runtime for the Theory Cloud stack. One
   application model across Go, TypeScript, and Python for HTTP, AppSync,
   WebSockets, and event-driven workloads on AWS Lambda — with behavioral parity
-  enforced by 192 shared contract test fixtures. Go also provides the MCP
+  enforced by 194 shared contract test fixtures. Go also provides the MCP
   Streamable HTTP runtime and OAuth-adjacent helpers used by Remote MCP deployments.
 
 # Canonical public docs domain. GitHub still serves the Pages artifact for the
@@ -163,7 +163,7 @@ tabletheory:
       cta: See event workloads
   stats:
     - label: Contract fixtures
-      value: "192" # apptheory-fixture-count
+      value: "194" # apptheory-fixture-count
       sub: shared across Go · TS · Python
     - label: Runtimes
       value: "3"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ description: >-
   The contract-first serverless runtime for the Theory Cloud stack. One
   application model across Go, TypeScript, and Python for HTTP, AppSync,
   WebSockets, and event-driven workloads on AWS Lambda — with behavioral parity
-  enforced by 189 shared contract test fixtures. Go also provides the MCP
+  enforced by 192 shared contract test fixtures. Go also provides the MCP
   Streamable HTTP runtime and OAuth-adjacent helpers used by Remote MCP deployments.
 
 # Canonical public docs domain. GitHub still serves the Pages artifact for the
@@ -163,7 +163,7 @@ tabletheory:
       cta: See event workloads
   stats:
     - label: Contract fixtures
-      value: "189" # apptheory-fixture-count
+      value: "192" # apptheory-fixture-count
       sub: shared across Go · TS · Python
     - label: Runtimes
       value: "3"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ description: >-
   The contract-first serverless runtime for the Theory Cloud stack. One
   application model across Go, TypeScript, and Python for HTTP, AppSync,
   WebSockets, and event-driven workloads on AWS Lambda — with behavioral parity
-  enforced by 187 shared contract test fixtures. Go also provides the MCP
+  enforced by 189 shared contract test fixtures. Go also provides the MCP
   Streamable HTTP runtime and OAuth-adjacent helpers used by Remote MCP deployments.
 
 # Canonical public docs domain. GitHub still serves the Pages artifact for the
@@ -163,7 +163,7 @@ tabletheory:
       cta: See event workloads
   stats:
     - label: Contract fixtures
-      value: "187" # apptheory-fixture-count
+      value: "189" # apptheory-fixture-count
       sub: shared across Go · TS · Python
     - label: Runtimes
       value: "3"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ description: >-
   The contract-first serverless runtime for the Theory Cloud stack. One
   application model across Go, TypeScript, and Python for HTTP, AppSync,
   WebSockets, and event-driven workloads on AWS Lambda — with behavioral parity
-  enforced by 183 shared contract test fixtures. Go also provides the MCP
+  enforced by 187 shared contract test fixtures. Go also provides the MCP
   Streamable HTTP runtime and OAuth-adjacent helpers used by Remote MCP deployments.
 
 # Canonical public docs domain. GitHub still serves the Pages artifact for the
@@ -163,7 +163,7 @@ tabletheory:
       cta: See event workloads
   stats:
     - label: Contract fixtures
-      value: "183" # apptheory-fixture-count
+      value: "187" # apptheory-fixture-count
       sub: shared across Go · TS · Python
     - label: Runtimes
       value: "3"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,8 +9,10 @@ description: >-
   The contract-first serverless runtime for the Theory Cloud stack. One
   application model across Go, TypeScript, and Python for HTTP, AppSync,
   WebSockets, and event-driven workloads on AWS Lambda — with behavioral parity
-  enforced by 194 shared contract test fixtures. Go also provides the MCP
-  Streamable HTTP runtime and OAuth-adjacent helpers used by Remote MCP deployments.
+  enforced by the shared non-MCP fixture corpus. Go also provides the MCP
+  Streamable HTTP runtime and OAuth-adjacent helpers used by Remote MCP deployments;
+  11 Go-executed MCP fixtures cover that protocol tier, while TypeScript/Python skip
+  those future-runtime fixtures.
 
 # Canonical public docs domain. GitHub still serves the Pages artifact for the
 # project repository, but the custom domain is mounted at the domain root, so
@@ -164,7 +166,7 @@ tabletheory:
   stats:
     - label: Contract fixtures
       value: "194" # apptheory-fixture-count
-      sub: shared across Go · TS · Python
+      sub: Go all; TS/Py 183 + 11 MCP skips
     - label: Runtimes
       value: "3"
       sub: Go · TypeScript · Python

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 187-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count
+  - { title: "Contract fixtures",         desc: "The 189-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 194-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count
+  - { title: "Contract fixtures",         desc: "194 fixtures: Go executes all; TS/Py skip 11 MCP future-runtime fixtures.", url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 192-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count
+  - { title: "Contract fixtures",         desc: "The 194-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 183-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count
+  - { title: "Contract fixtures",         desc: "The 187-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count

--- a/docs/_data/site-meta.yml
+++ b/docs/_data/site-meta.yml
@@ -25,4 +25,4 @@ quick_start:
   - { title: "Universal Lambda dispatcher", desc: "One HandleLambda for HTTP, AppSync, SQS, and EventBridge.",             url: /api-reference/,                    icon: shuffle }
   - { title: "MCP server in one Lambda",  desc: "Go Streamable HTTP runtime, sessions, and resumable SSE.",                url: /integrations/mcp/,                 icon: share }
   - { title: "Source provenance",         desc: "Safe HTTP source IP from provider context — never client headers.",       url: /features/source-provenance/,       icon: shield-check }
-  - { title: "Contract fixtures",         desc: "The 189-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count
+  - { title: "Contract fixtures",         desc: "The 192-fixture covenant every runtime is tested against.",                url: /reference/contract-fixtures/,      icon: list-checks } # apptheory-fixture-count

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -5,7 +5,7 @@ description: Tiered middleware, routing, normalization, and the AppTheory error 
 
 # HTTP Runtime (P0–P2)
 
-The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [192 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
+The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [194 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
 
 The runtime is **tiered.** You opt into a tier when you create the app:
 
@@ -161,4 +161,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — profile-backed structured JSON log output
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 192-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 194-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -5,7 +5,7 @@ description: Tiered middleware, routing, normalization, and the AppTheory error 
 
 # HTTP Runtime (P0–P2)
 
-The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [183 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
+The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [187 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
 
 The runtime is **tiered.** You opt into a tier when you create the app:
 
@@ -161,4 +161,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — profile-backed structured JSON log output
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 183-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 187-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -5,7 +5,7 @@ description: Tiered middleware, routing, normalization, and the AppTheory error 
 
 # HTTP Runtime (P0–P2)
 
-The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [187 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
+The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [189 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
 
 The runtime is **tiered.** You opt into a tier when you create the app:
 
@@ -161,4 +161,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — profile-backed structured JSON log output
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 187-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 189-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -5,7 +5,7 @@ description: Tiered middleware, routing, normalization, and the AppTheory error 
 
 # HTTP Runtime (P0–P2)
 
-The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [189 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
+The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [192 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
 
 The runtime is **tiered.** You opt into a tier when you create the app:
 
@@ -161,4 +161,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — profile-backed structured JSON log output
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 189-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 192-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -5,7 +5,7 @@ description: Tiered middleware, routing, normalization, and the AppTheory error 
 
 # HTTP Runtime (P0–P2)
 
-The HTTP runtime is AppTheory's largest contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the [194 contract fixtures](../reference/contract-fixtures.md). <!-- apptheory-fixture-count -->
+The HTTP runtime is AppTheory's largest shared contract surface. It defines route matching, the middleware chain, request/response normalization, and the error envelope — and it is enforced identically in all three runtimes by the shared non-MCP fixtures. The [194-fixture corpus](../reference/contract-fixtures.md) also includes 11 SP09 MCP fixtures that Go executes today; TypeScript and Python explicitly skip those future-runtime fixtures pending SP10/SP11. <!-- apptheory-fixture-count -->
 
 The runtime is **tiered.** You opt into a tier when you create the app:
 
@@ -161,4 +161,4 @@ You almost never need these directly — use `HandleLambda` / `handleLambda` / `
 - [Logging Profiles](logging-profiles.md) — profile-backed structured JSON log output
 - [Sanitization](sanitization.md) — safe logging helpers
 - [Event Workloads](event-workloads.md) — the non-HTTP side of the runtime
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 194-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 194-fixture covenant, including Go-executed MCP fixtures and TS/Py future-runtime skips <!-- apptheory-fixture-count -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by 192 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
+    every commit by 194 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
     Streamable HTTP surface used by Remote MCP deployments.
   </p>
   <div class="hero__actions">

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by 183 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
+    every commit by 187 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
     Streamable HTTP surface used by Remote MCP deployments.
   </p>
   <div class="hero__actions">

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by 189 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
+    every commit by 192 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
     Streamable HTTP surface used by Remote MCP deployments.
   </p>
   <div class="hero__actions">

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,8 +19,9 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by 194 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
-    Streamable HTTP surface used by Remote MCP deployments.
+    every commit by the shared non-MCP fixture corpus. <!-- apptheory-fixture-count --> The Go runtime also executes the
+    11 MCP fixtures for the Streamable HTTP surface used by Remote MCP deployments; TS/Py
+    explicitly skip those future-runtime fixtures pending SP10/SP11.
   </p>
   <div class="hero__actions">
     <a class="btn btn--primary" href="{{ '/getting-started/' | relative_url }}">

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by 187 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
+    every commit by 189 shared contract fixtures. <!-- apptheory-fixture-count --> The Go runtime also carries the MCP
     Streamable HTTP surface used by Remote MCP deployments.
   </p>
   <div class="hero__actions">

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 189 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
+description: The 192 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
 ---
 
 # Contract Fixtures
 
-AppTheory ships **189 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **192 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -49,7 +49,7 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 
 ## Categories
 
-The 189 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
+The 192 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
 
 | Category | Covers |
 | --- | --- |

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 192 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
+description: The 194 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
 ---
 
 # Contract Fixtures
 
-AppTheory ships **192 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **194 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -49,7 +49,7 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 
 ## Categories
 
-The 192 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
+The 194 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
 
 | Category | Covers |
 | --- | --- |

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 194 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
+description: The 194 contract fixtures: Go executes all; TypeScript and Python explicitly skip 11 MCP future-runtime fixtures. # apptheory-fixture-count
 ---
 
 # Contract Fixtures
 
-AppTheory ships **194 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **194 contract test fixtures** in `contract-tests/fixtures/`. <!-- apptheory-fixture-count --> Of those, 183 form the shared non-MCP corpus that Go, TypeScript, and Python execute on every commit. The 11 `tier: mcp` fixtures are SP09 Go MCP runtime contracts: Go executes them now; the schema gate checks the same files, and TypeScript/Python runners load them and explicitly report them as future-runtime skips until SP10/SP11 add those runtime legs.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -17,13 +17,13 @@ A contract fixture is a language-neutral description of a scenario:
 - An app configuration (registered routes, tier, error format, event-source bindings, etc.)
 - The expected output (response shape, status, headers, partial-batch failure list, normalized summary, etc.)
 
-Each fixture is loaded by language-specific runners that construct an AppTheory app from the configuration, invoke it with the input, and compare the output to the expected shape. **The fixture is the specification.** The runners are not — they are three independent test harnesses against the same source of truth.
+For implemented tiers, each fixture is loaded by language-specific runners that construct an AppTheory app from the configuration, invoke it with the input, and compare the output to the expected shape. The SP09 MCP tier is intentionally staged: the schema gate validates those 11 fixtures, and the TypeScript/Python runners load them before reporting an explicit future-runtime skip instead of claiming parity. **The fixture is the specification.** The runners are not — they are independent test harnesses against the same source of truth.
 
 ## Why this matters
 
 The single-path philosophy says there is one correct path per domain. The fixtures are how AppTheory enforces that across languages: if Go does something the fixture does not require, and TypeScript does something different, **neither is right** — they are both drifting from the contract.
 
-When the contract needs to grow, the fixture grows first. When the fixture grows, **all three runtimes converge to the new shape in the same change.**
+When the shared runtime contract needs to grow, the fixture grows first. For shared surfaces, **all three runtimes converge to the new shape in the same change.** If a fixture tier is deliberately staged as a future runtime leg, that staging must be visible in the fixture tier and runner output; it is not parity proof until the remaining runtimes execute it.
 
 ## Behavior-domain layout
 
@@ -39,6 +39,7 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 | `middleware-guardrails/` | `p1.*` / `tier = p1` | P1 request-id, tenant, auth, CORS, guardrails, and legacy flat-error behavior. |
 | `appsync-observability-policies/` | `p2.*` / `tier = p2` | P2 AppSync, observability, logging profiles, rate limiting, and load shedding. |
 | `observability/` | `p2.*` / `tier = p2` | Request-duration observability records and first-party CloudWatch EMF metric JSON lines. |
+| `mcp/` | `mcp.*` / `tier = mcp` | SP09 Go MCP protocol, registry, session, Streamable HTTP, resumable SSE, and task-store contracts. The schema gate validates these fixtures; TypeScript/Python runners load and explicitly skip them as future-runtime work pending SP10/SP11. |
 | `event-sources/` | `m1.*` / `tier = m1` | SQS, EventBridge, DynamoDB Streams, Kinesis, SNS, and non-HTTP middleware behavior. |
 | `websockets/` | `m2.*` / `tier = m2` | API Gateway WebSockets and management client fakes. |
 | `api-gateway-rest-sse/` | `m3.*` / `tier = m3` | API Gateway REST v1, Remote MCP path normalization, and SSE. |
@@ -49,7 +50,7 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 
 ## Categories
 
-The 194 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
+The 194 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory). Go executes all 194; TypeScript and Python execute the 183 shared non-MCP fixtures and explicitly skip the 11 MCP future-runtime fixtures pending SP10/SP11. <!-- apptheory-fixture-count -->
 
 | Category | Covers |
 | --- | --- |
@@ -71,7 +72,8 @@ The 194 fixtures span these behavior areas (counts approximate; see `contract-te
 | EventBridge | Envelope normalization, correlation-id, scheduled-event metadata. |
 | DynamoDB Streams | Partial-batch response, record safe-summary shape. |
 | Kinesis | Partial-batch response, stream routing, fail-closed for unregistered streams, CloudWatch Logs subscription envelope decoding. |
-| Remote MCP path dispatch | API Gateway REST proxy path normalization for Remote MCP and protected-resource metadata routes. The shared fixtures do **not** cover MCP JSON-RPC methods, session stores, DCR, PKCE, bearer-token validation, or OAuth challenges. |
+| Remote MCP path dispatch | API Gateway REST proxy path normalization for Remote MCP and protected-resource metadata routes. These shared non-MCP fixtures are separate from the Go MCP runtime tier and do not cover DCR, PKCE, bearer-token validation, or OAuth challenges. |
+| MCP JSON-RPC and Streamable HTTP | The `mcp/` fixture tier pins Go MCP `initialize`, JSON-RPC envelopes, tools/resources/resource-templates/prompts registries, session lifecycle, Streamable HTTP framing, resumable SSE replay, and task-store behavior. The schema gate validates these 11 fixtures; TypeScript and Python runners load them and report explicit future-runtime skips until SP10/SP11. They are not TS/Py parity proof yet. |
 | Sanitization | Token-like value redaction, JSON/XML safe-logging output. |
 | Lambda MicroVM support | M15 foundation fixtures plus M16 real operations `run/get/list/suspend/resume/terminate/auth-token/shell-auth-token`, provider-state mappings, protected controller routes, tenant-bound list/recovery, token no-leak denial, and raw SDK/lifecycle bypass denial. The feature line is evidence-bounded to repo-local runtime/CDK/example/conformance harness proof, not live AWS, EqualToAI/Host, customer workload, or unauthenticated-controller proof. |
 
@@ -81,7 +83,7 @@ The 194 fixtures span these behavior areas (counts approximate; see `contract-te
 ./scripts/verify-contract-tests.sh
 ```
 
-This runs the Go, TypeScript, and Python runners against the full fixture corpus and fails if any runtime produces a divergent output. `make rubric` runs this gate as part of the full repo check, alongside lint, build, API snapshots, and example synthesis.
+This validates the fixture schema for all 194 files, runs the Go runner against all 194 fixtures, and runs the TypeScript and Python runners against the same fixture tree. Today the TS/Py runners execute the 183 shared non-MCP fixtures and explicitly report `skipped=11 mcp future-runtime fixtures` for the SP09 MCP tier. `make rubric` runs this gate as part of the full repo check, alongside lint, build, API snapshots, and example synthesis.
 
 For single-runtime debugging from the repository root:
 
@@ -98,8 +100,8 @@ The TypeScript runner expects dependencies to be installed first; `./scripts/ver
 Any change that affects cross-language behavior follows the same loop:
 
 1. **Write or modify the fixture first.**
-2. **Run the runners.** Confirm they fail in all three languages — and that they fail for the same reason. If only one language fails, the fixture is under-specified.
-3. **Implement each runtime.** Go, TypeScript, and Python land in the same PR. Partial convergence is not a checkpoint.
+2. **Run the runners.** For shared surfaces, confirm they fail in all three languages — and that they fail for the same reason. If only one language fails, the fixture is under-specified.
+3. **Implement each runtime.** For shared surfaces, Go, TypeScript, and Python land in the same PR. Partial convergence is not a checkpoint. A deliberately staged future-runtime tier must name the staged runtime work and report explicit runner skips until the remaining runtimes execute it.
 4. **Update the API snapshot.** If the public surface moved, run `./scripts/update-api-snapshots.sh` and commit the diff alongside the fixture change.
 5. **Verify.** `make rubric` must pass.
 
@@ -126,5 +128,5 @@ Snapshot diffs are intentional signals: a moved snapshot says "a public contract
 - [Event Shape Dispatch](event-shapes.md) — what `HandleLambda` detection fixtures pin
 - [AWS Lambda MicroVM Golden Path](../features/lambda-microvm-contract-foundation.md) — the corrective M16 MicroVM
   golden path and evidence boundary
-- [MCP Method Surface](../integrations/mcp.md) — Go runtime MCP behavior; the shared fixtures only pin Remote MCP/protected-resource API Gateway path dispatch
+- [MCP Method Surface](../integrations/mcp.md) — Go runtime MCP behavior pinned by the `mcp/` fixture tier; TypeScript/Python skip those 11 future-runtime fixtures pending SP10/SP11
 - [Development Guidelines](../development-guidelines.md) — the contract-only scope

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 183 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
+description: The 187 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
 ---
 
 # Contract Fixtures
 
-AppTheory ships **183 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **187 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -49,7 +49,7 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 
 ## Categories
 
-The 183 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
+The 187 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
 
 | Category | Covers |
 | --- | --- |

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -1,11 +1,11 @@
 ---
 title: Contract Fixtures
-description: The 187 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
+description: The 189 shared fixtures that arbitrate behavior across Go, TypeScript, and Python. # apptheory-fixture-count
 ---
 
 # Contract Fixtures
 
-AppTheory ships **187 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
+AppTheory ships **189 contract test fixtures** in `contract-tests/fixtures/` <!-- apptheory-fixture-count --> that define the language-neutral behavior every runtime must produce. The Go, TypeScript, and Python runtimes are each independently verified against the same fixture corpus on every commit.
 
 This page explains what the fixtures are, what they cover, and how to evolve them safely.
 
@@ -49,7 +49,7 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 
 ## Categories
 
-The 187 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
+The 189 fixtures span these behavior areas (counts approximate; see `contract-tests/fixtures/` for the canonical inventory): <!-- apptheory-fixture-count -->
 
 | Category | Covers |
 | --- | --- |

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -5,7 +5,7 @@ description: The Go implementation of the AppTheory contract — routing, middle
 
 # Go Runtime
 
-The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [189 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
+The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [192 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -161,11 +161,11 @@ See the [MCP Method Surface](../integrations/mcp.md) for the full Streamable HTT
 
 ## What's verified
 
-The Go runtime passes all 189 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
+The Go runtime passes all 192 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
 
 ## Next reads
 
 - [API Reference](../api-reference.md) — full surface table
 - [HTTP Runtime tiers](../features/http-runtime.md) — P0 / P1 / P2
 - [Event Shape Dispatch](../reference/event-shapes.md) — when `HandleLambda` calls what
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 189-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 192-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -5,7 +5,7 @@ description: The Go implementation of the AppTheory contract — routing, middle
 
 # Go Runtime
 
-The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [192 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
+The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [194 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -161,11 +161,11 @@ See the [MCP Method Surface](../integrations/mcp.md) for the full Streamable HTT
 
 ## What's verified
 
-The Go runtime passes all 192 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
+The Go runtime passes all 194 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
 
 ## Next reads
 
 - [API Reference](../api-reference.md) — full surface table
 - [HTTP Runtime tiers](../features/http-runtime.md) — P0 / P1 / P2
 - [Event Shape Dispatch](../reference/event-shapes.md) — when `HandleLambda` calls what
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 192-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 194-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -5,7 +5,7 @@ description: The Go implementation of the AppTheory contract — routing, middle
 
 # Go Runtime
 
-The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [187 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
+The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [189 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -161,11 +161,11 @@ See the [MCP Method Surface](../integrations/mcp.md) for the full Streamable HTT
 
 ## What's verified
 
-The Go runtime passes all 187 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
+The Go runtime passes all 189 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
 
 ## Next reads
 
 - [API Reference](../api-reference.md) — full surface table
 - [HTTP Runtime tiers](../features/http-runtime.md) — P0 / P1 / P2
 - [Event Shape Dispatch](../reference/event-shapes.md) — when `HandleLambda` calls what
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 187-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 189-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -5,7 +5,7 @@ description: The Go implementation of the AppTheory contract — routing, middle
 
 # Go Runtime
 
-The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [183 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
+The Go runtime is the most complete implementation of the AppTheory contract and ships with the broadest middleware and CDK surface. It is **a reference implementation, not the source of truth** — the [187 contract fixtures](../reference/contract-fixtures.md) arbitrate when the three runtimes disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -161,11 +161,11 @@ See the [MCP Method Surface](../integrations/mcp.md) for the full Streamable HTT
 
 ## What's verified
 
-The Go runtime passes all 183 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
+The Go runtime passes all 187 contract fixtures on every commit. <!-- apptheory-fixture-count --> Any behavioral divergence between Go, TypeScript, and Python is treated as a contract bug — fix the implementation, or update the fixture and prove the change holds in all three runtimes.
 
 ## Next reads
 
 - [API Reference](../api-reference.md) — full surface table
 - [HTTP Runtime tiers](../features/http-runtime.md) — P0 / P1 / P2
 - [Event Shape Dispatch](../reference/event-shapes.md) — when `HandleLambda` calls what
-- [Contract Fixtures](../reference/contract-fixtures.md) — the 183-fixture covenant <!-- apptheory-fixture-count -->
+- [Contract Fixtures](../reference/contract-fixtures.md) — the 187-fixture covenant <!-- apptheory-fixture-count -->

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: The Python implementation of the AppTheory contract — typed, asyn
 
 # Python Runtime
 
-The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [194 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. It executes the shared non-MCP corpus from the [194 contract fixtures](../reference/contract-fixtures.md); the contract gate schema-checks the 11 SP09 MCP fixtures, and the Python runner loads them and explicitly skips them as future-runtime work pending SP11. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -103,7 +103,7 @@ Applies to HTTP error serialization only.
 
 ## What's verified
 
-The Python runtime passes all 194 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
+The Python runtime passes the 183 shared non-MCP contract fixtures on every commit. <!-- apptheory-fixture-count --> The runner loads the full 194-fixture tree and reports `skipped=11 mcp future-runtime fixtures` for the SP09 MCP tier until SP11 adds the Python MCP runtime. That skip is intentional staging, not parity proof. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: The Python implementation of the AppTheory contract — typed, asyn
 
 # Python Runtime
 
-The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [192 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [194 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -103,7 +103,7 @@ Applies to HTTP error serialization only.
 
 ## What's verified
 
-The Python runtime passes all 192 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
+The Python runtime passes all 194 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: The Python implementation of the AppTheory contract — typed, asyn
 
 # Python Runtime
 
-The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [189 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [192 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -103,7 +103,7 @@ Applies to HTTP error serialization only.
 
 ## What's verified
 
-The Python runtime passes all 189 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
+The Python runtime passes all 192 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: The Python implementation of the AppTheory contract — typed, asyn
 
 # Python Runtime
 
-The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [187 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [189 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -103,7 +103,7 @@ Applies to HTTP error serialization only.
 
 ## What's verified
 
-The Python runtime passes all 187 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
+The Python runtime passes all 189 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: The Python implementation of the AppTheory contract — typed, asyn
 
 # Python Runtime
 
-The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [183 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The Python runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [187 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -103,7 +103,7 @@ Applies to HTTP error serialization only.
 
 ## What's verified
 
-The Python runtime passes all 183 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
+The Python runtime passes all 187 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and TypeScript. Tests live under `py/tests/` and are exercised by `./scripts/verify-python-tests.sh` and `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [189 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [192 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -129,7 +129,7 @@ See [CDK Getting Started](../cdk/getting-started.md).
 
 ## What's verified
 
-The TypeScript runtime passes all 189 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
+The TypeScript runtime passes all 192 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [194 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. It executes the shared non-MCP corpus from the [194 contract fixtures](../reference/contract-fixtures.md); the contract gate schema-checks the 11 SP09 MCP fixtures, and the TypeScript runner loads them and explicitly skips them as future-runtime work pending SP10. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -129,7 +129,7 @@ See [CDK Getting Started](../cdk/getting-started.md).
 
 ## What's verified
 
-The TypeScript runtime passes all 194 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
+The TypeScript runtime passes the 183 shared non-MCP contract fixtures on every commit. <!-- apptheory-fixture-count --> The runner loads the full 194-fixture tree and reports `skipped=11 mcp future-runtime fixtures` for the SP09 MCP tier until SP10 adds the TypeScript MCP runtime. That skip is intentional staging, not parity proof. The `ts/dist/` build output is checked in and gated by `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [183 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [187 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -129,7 +129,7 @@ See [CDK Getting Started](../cdk/getting-started.md).
 
 ## What's verified
 
-The TypeScript runtime passes all 183 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
+The TypeScript runtime passes all 187 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [192 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [194 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -129,7 +129,7 @@ See [CDK Getting Started](../cdk/getting-started.md).
 
 ## What's verified
 
-The TypeScript runtime passes all 192 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
+The TypeScript runtime passes all 194 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
 
 ## Next reads
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [187 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. The [189 contract fixtures](../reference/contract-fixtures.md) arbitrate when Go, TS, and Python disagree. <!-- apptheory-fixture-count -->
 
 ## Install
 
@@ -129,7 +129,7 @@ See [CDK Getting Started](../cdk/getting-started.md).
 
 ## What's verified
 
-The TypeScript runtime passes all 187 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
+The TypeScript runtime passes all 189 contract fixtures on every commit, <!-- apptheory-fixture-count --> against the same fixture corpus as Go and Python. The `ts/dist/` build output is checked in and gated by `make rubric`.
 
 ## Next reads
 

--- a/runtime/mcp/capability.go
+++ b/runtime/mcp/capability.go
@@ -72,7 +72,7 @@ func (s *Server) addToolsCapability(protocolVersion string, capabilities map[str
 }
 
 func (s *Server) addResourcesCapability(protocolVersion string, capabilities map[string]any) {
-	if s.capabilities.Resources && protocolSupportsCapability(protocolVersion, capabilitySurfaceResources) && s.resourceRegistry.Len() > 0 {
+	if s.capabilities.Resources && protocolSupportsCapability(protocolVersion, capabilitySurfaceResources) && (s.resourceRegistry.Len() > 0 || s.resourceRegistry.templateLen() > 0) {
 		capabilities["resources"] = map[string]any{}
 	}
 }
@@ -127,7 +127,7 @@ func (s *Server) methodCapabilityEnabled(method string) bool {
 	switch method {
 	case methodToolsList, methodToolsCall:
 		return s.capabilities.Tools
-	case methodResourcesList, methodResourcesRead, methodResourcesSubscribe, methodResourcesUnsubscribe:
+	case methodResourcesList, methodResourcesRead, methodResourcesTemplatesList, methodResourcesSubscribe, methodResourcesUnsubscribe:
 		return s.capabilities.Resources
 	case methodPromptsList, methodPromptsGet:
 		return s.capabilities.Prompts

--- a/runtime/mcp/resource.go
+++ b/runtime/mcp/resource.go
@@ -18,6 +18,15 @@ type ResourceDef struct {
 	Size        int64  `json:"size,omitempty"`
 }
 
+// ResourceTemplateDef defines an MCP resource template's metadata.
+type ResourceTemplateDef struct {
+	URITemplate string `json:"uriTemplate"`
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
 // ResourceContent is a single content item returned from resources/read.
 //
 // Exactly one of Text or Blob should be set.
@@ -50,20 +59,27 @@ type registeredResource struct {
 
 // ResourceRegistry manages registered MCP resources.
 type ResourceRegistry struct {
-	mu        sync.RWMutex
-	resources []registeredResource
-	index     map[string]int
+	mu            sync.RWMutex
+	resources     []registeredResource
+	index         map[string]int
+	templates     []ResourceTemplateDef
+	templateIndex map[string]int
 }
 
 // NewResourceRegistry creates an empty resource registry.
 func NewResourceRegistry() *ResourceRegistry {
 	return &ResourceRegistry{
-		index: make(map[string]int),
+		index:         make(map[string]int),
+		templateIndex: make(map[string]int),
 	}
 }
 
 func errDuplicateResource(uri string) error {
 	return fmt.Errorf("resource already registered: %s", uri)
+}
+
+func errDuplicateResourceTemplate(uriTemplate string) error {
+	return fmt.Errorf("resource template already registered: %s", uriTemplate)
 }
 
 // RegisterResource registers a resource by URI.
@@ -94,6 +110,31 @@ func (r *ResourceRegistry) RegisterResource(def ResourceDef, handler ResourceHan
 	return nil
 }
 
+// RegisterResourceTemplate registers a parameterized resource template.
+func (r *ResourceRegistry) RegisterResourceTemplate(def ResourceTemplateDef) error {
+	def.URITemplate = strings.TrimSpace(def.URITemplate)
+	if def.URITemplate == "" {
+		return fmt.Errorf("resource template uriTemplate must not be empty")
+	}
+	if !validResourceURI(def.URITemplate) {
+		return fmt.Errorf("resource template uriTemplate must be absolute: %s", def.URITemplate)
+	}
+	if def.Name == "" {
+		return fmt.Errorf("resource template name must not be empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.templateIndex[def.URITemplate]; exists {
+		return errDuplicateResourceTemplate(def.URITemplate)
+	}
+
+	r.templateIndex[def.URITemplate] = len(r.templates)
+	r.templates = append(r.templates, def)
+	return nil
+}
+
 // List returns all registered resource definitions in registration order.
 func (r *ResourceRegistry) List() []ResourceDef {
 	r.mu.RLock()
@@ -106,11 +147,27 @@ func (r *ResourceRegistry) List() []ResourceDef {
 	return defs
 }
 
+// ListTemplates returns all registered resource template definitions in registration order.
+func (r *ResourceRegistry) ListTemplates() []ResourceTemplateDef {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	defs := make([]ResourceTemplateDef, len(r.templates))
+	copy(defs, r.templates)
+	return defs
+}
+
 // Len returns the number of registered resources.
 func (r *ResourceRegistry) Len() int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return len(r.resources)
+}
+
+func (r *ResourceRegistry) templateLen() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.templates)
 }
 
 func (r *ResourceRegistry) exists(uri string) bool {

--- a/runtime/mcp/resources_handlers.go
+++ b/runtime/mcp/resources_handlers.go
@@ -21,6 +21,13 @@ func (s *Server) handleResourcesList(req *Request) *Response {
 	})
 }
 
+func (s *Server) handleResourcesTemplatesList(req *Request) *Response {
+	templates := s.resourceRegistry.ListTemplates()
+	return NewResultResponse(req.ID, map[string]any{
+		"resourceTemplates": templates,
+	})
+}
+
 func (s *Server) handleResourcesRead(ctx context.Context, req *Request) *Response {
 	var params resourcesReadParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {

--- a/runtime/mcp/resources_prompts_test.go
+++ b/runtime/mcp/resources_prompts_test.go
@@ -85,6 +85,52 @@ func TestResourcesListAndRead_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestResourceTemplatesList_RoundTrip(t *testing.T) {
+	s := NewServer("test", "1.0.0")
+	if err := s.Resources().RegisterResourceTemplate(ResourceTemplateDef{
+		URITemplate: "file:///{path}",
+		Name:        "project-file",
+		Title:       "Project file",
+		Description: "Read a project file by path",
+		MimeType:    "text/plain",
+	}); err != nil {
+		t.Fatalf("register resource template: %v", err)
+	}
+
+	caps := s.initializeCapabilities(protocolVersion)
+	if _, ok := caps["resources"].(map[string]any); !ok {
+		t.Fatalf("expected resources capability for template-only server: %+v", caps)
+	}
+
+	sessionID := initializeSession(t, s)
+	headers := sessionHeaders(sessionID)
+	headers["accept"] = []string{"application/json, text/event-stream"}
+
+	req := mustMarshal(t, Request{JSONRPC: "2.0", ID: 1, Method: methodResourcesTemplatesList})
+	resp, err := invokeHandlerWithMethod(context.Background(), s, "POST", req, headers)
+	if err != nil {
+		t.Fatalf("invoke resources/templates/list: %v", err)
+	}
+	rpcResp, err := parseJSONRPCResponse(resp)
+	if err != nil {
+		t.Fatalf("parse resources/templates/list: %v", err)
+	}
+	if rpcResp.Error != nil {
+		t.Fatalf("unexpected error: %+v", rpcResp.Error)
+	}
+
+	resultBytes := mustMarshal(t, rpcResp.Result)
+	var out struct {
+		ResourceTemplates []ResourceTemplateDef `json:"resourceTemplates"`
+	}
+	if err := json.Unmarshal(resultBytes, &out); err != nil {
+		t.Fatalf("unmarshal template result: %v", err)
+	}
+	if len(out.ResourceTemplates) != 1 || out.ResourceTemplates[0].URITemplate != "file:///{path}" {
+		t.Fatalf("unexpected resource templates: %+v", out.ResourceTemplates)
+	}
+}
+
 func TestResourceAndPromptRegistryValidation(t *testing.T) {
 	resources := NewResourceRegistry()
 	if err := resources.RegisterResource(ResourceDef{}, func(context.Context) ([]ResourceContent, error) { return nil, nil }); err == nil {
@@ -103,6 +149,18 @@ func TestResourceAndPromptRegistryValidation(t *testing.T) {
 	}
 	if err := resources.RegisterResource(ResourceDef{URI: "file://x", Name: "x"}, func(context.Context) ([]ResourceContent, error) { return nil, nil }); err == nil {
 		t.Fatalf("expected duplicate resource to fail")
+	}
+	if err := resources.RegisterResourceTemplate(ResourceTemplateDef{}); err == nil {
+		t.Fatalf("expected missing resource template uriTemplate to fail")
+	}
+	if err := resources.RegisterResourceTemplate(ResourceTemplateDef{URITemplate: "file:///{path}"}); err == nil {
+		t.Fatalf("expected missing resource template name to fail")
+	}
+	if err := resources.RegisterResourceTemplate(ResourceTemplateDef{URITemplate: "file:///{path}", Name: "project-file"}); err != nil {
+		t.Fatalf("register resource template: %v", err)
+	}
+	if err := resources.RegisterResourceTemplate(ResourceTemplateDef{URITemplate: "file:///{path}", Name: "project-file"}); err == nil {
+		t.Fatalf("expected duplicate resource template to fail")
 	}
 
 	prompts := NewPromptRegistry()
@@ -226,6 +284,7 @@ func TestCapabilityDisables_RejectResourceAndPromptMethods(t *testing.T) {
 	}{
 		{name: "resources list", method: methodResourcesList},
 		{name: "resources read", method: methodResourcesRead, params: map[string]any{"uri": "file://hello.txt"}},
+		{name: "resources templates list", method: methodResourcesTemplatesList},
 		{name: "resources subscribe", method: methodResourcesSubscribe, params: map[string]any{"uri": "file://hello.txt"}},
 		{name: "resources unsubscribe", method: methodResourcesUnsubscribe, params: map[string]any{"uri": "file://hello.txt"}},
 		{name: "prompts list", method: methodPromptsList},

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -37,6 +37,7 @@ const (
 	methodToolsCall                = "tools/call"
 	methodResourcesList            = "resources/list"
 	methodResourcesRead            = "resources/read"
+	methodResourcesTemplatesList   = "resources/templates/list"
 	methodResourcesSubscribe       = "resources/subscribe"
 	methodResourcesUnsubscribe     = "resources/unsubscribe"
 	methodLoggingSetLevel          = "logging/setLevel"
@@ -605,6 +606,8 @@ func (s *Server) dispatchNonTaskMethod(ctx context.Context, req *Request, sessio
 		return s.handleResourcesList(req)
 	case methodResourcesRead:
 		return s.handleResourcesRead(ctx, req)
+	case methodResourcesTemplatesList:
+		return s.handleResourcesTemplatesList(req)
 	case methodResourcesSubscribe:
 		return s.handleResourcesSubscribe(ctx, req, sessionID)
 	case methodResourcesUnsubscribe:
@@ -659,6 +662,7 @@ func methodAllowedForProtocol(pv string, method string) bool {
 		methodToolsCall,
 		methodResourcesList,
 		methodResourcesRead,
+		methodResourcesTemplatesList,
 		methodResourcesSubscribe,
 		methodResourcesUnsubscribe,
 		methodLoggingSetLevel,

--- a/runtime/mcp/server.go
+++ b/runtime/mcp/server.go
@@ -598,6 +598,13 @@ func (s *Server) dispatchNonTaskMethod(ctx context.Context, req *Request, sessio
 		return s.handleInitialize(req, selectedPV)
 	case methodPing:
 		return NewResultResponse(req.ID, map[string]any{})
+	default:
+		return s.dispatchRegistryMethod(ctx, req, sessionID)
+	}
+}
+
+func (s *Server) dispatchRegistryMethod(ctx context.Context, req *Request, sessionID string) *Response {
+	switch req.Method {
 	case methodToolsList:
 		return s.handleToolsList(req)
 	case methodToolsCall:

--- a/scripts/verify-fixture-schema.sh
+++ b/scripts/verify-fixture-schema.sh
@@ -180,6 +180,7 @@ FIXTURE_DOMAIN_TIERS = {
     "edge-streaming-html": "m14",
     "microvm-foundation": "m15",
     "microvm-operations": "m16",
+    "mcp": "mcp",
     "errors": "p0",
     "routing": "p0",
     "binding": "p0",


### PR DESCRIPTION
## Milestone
SP09 MCP Contract Truth — pin the AppTheory Go MCP runtime contract surface with fixture-first coverage.

## Refs
- THE-2327
- THE-2328
- THE-2329
- THE-2330
- THE-2331

## Tasks
- [x] THE-2327 Pin MCP core protocol surface
- [x] THE-2328 Pin MCP resources and prompts
- [x] THE-2329 Pin MCP sessions and streamable HTTP transport
- [x] THE-2330 Pin MCP resumable SSE and task stores
- [x] THE-2331 Converge Go MCP on pinned fixtures

## Contract impact
Adds `tier: mcp` fixture shape/docs/counts and `contract-tests/fixtures/mcp/**` coverage for initialize/tools/errors/malformed requests, resources/prompts/templates, sessions/streamable HTTP/reserved paths, resumable SSE replay, and deterministic task lifecycle.

Go MCP fixtures are enforced by the Go contract runner. TS/Py runners load and schema-check the same MCP fixtures but explicitly report them as skipped future-runtime fixtures until SP10/SP11; this PR does not claim TS/Py MCP runtime parity or generalized managed/prod MCP proof.

## Runtime impact
- Converges Go MCP behavior on the pinned fixtures.
- Adds Go MCP resource-template registry support for `resources/templates/list`.
- Keeps DynamoDB/task-store provider specifics out of the fixtures; task semantics are pinned against deterministic store fakes.

## Validation
- [x] `./scripts/verify-fixture-schema.sh`
- [x] `./scripts/verify-contract-tests.sh` (Go 194 pass; TS/Py 194 pass with 11 MCP future-runtime skips each)
- [x] `make test-unit`
- [x] `cd ts && npm run check && npm test`
- [x] `uv --directory py run pytest -q` (`py/uv.lock` removed after run)
- [x] `git diff --check project/improvement-program..HEAD`
- [x] `./scripts/verify-api-snapshots.sh`
- [x] `./scripts/verify-cdk-synth.sh`
- [x] `make rubric` (PASS: 29 pass / 0 fail / 0 blocked)
- [x] `git log --show-signature project/improvement-program..HEAD`

## Cross-repo notes
No sibling repos edited. theory-mcp-server depends on the Go MCP runtime; this PR stays at local contract/runtime validation only.
