### PR TITLE
docs: polish SP17 concept paths and override notes

### DIFF
--- a/docs/_concepts.yaml
+++ b/docs/_concepts.yaml
@@ -103,7 +103,9 @@ concepts:
       - deterministic_kinesis_testkit_builders
       - cdk_stream_destination_and_mapping_constructs
     configuration:
-      - runtime/aws_eventsources.go
+      - runtime/aws_kinesis.go
+      - runtime/aws_batch.go
+      - runtime/aws_event_context.go
       - runtime/kinesis_cloudwatch_logs.go
       - runtime/kinesis_producer.go
       - ts/src/kinesis-cloudwatch-logs.ts
@@ -199,8 +201,8 @@ concepts:
       - contract-tests/fixtures/microvm-foundation/
       - contract-tests/fixtures/microvm-operations/
       - runtime/microvm/
-      - ts/src/microvm.ts
-      - py/src/apptheory/microvm.py
+      - ts/src/microvm/
+      - py/src/apptheory/microvm/
       - cdk/lib/microvm-network-connector.ts
       - cdk/lib/microvm-image.ts
       - cdk/lib/microvm-controller.ts

--- a/docs/dependency-automation.md
+++ b/docs/dependency-automation.md
@@ -95,3 +95,21 @@ npm packages. It is not the single path for AppTheory because AppTheory intentio
 registry packages. Do not replace the GitHub Release pins with registry coordinates to make Dependabot work; use
 Renovate for the release-pinned framework assets and Dependabot only for the dependencies that already come from a
 registry.
+
+## Maintainer override notes
+
+AppTheory only carries package-manager `overrides` while a current audit, compatibility, or deterministic-build gate
+requires them. In SP17, the TypeScript runtime package removed stale transitive overrides after the regenerated lockfile
+passed `npm audit` with zero vulnerabilities. The removal rationale was:
+
+- `@typescript-eslint/typescript-estree` → `minimatch`: upstream now resolves to `minimatch@10.2.5`, so the local
+  pin was no longer carrying a security fix.
+- `@eslint/eslintrc` / `eslint` → `ajv`: ESLint selects its compatible `ajv@6.14.0`; AppTheory does not override
+  lint-tool internals without an active advisory.
+- `@eslint/eslintrc` / `eslint` / `eslint-plugin-import` → `minimatch`: the lint stack remains audit-clean on its
+  upstream-selected `minimatch` versions, and none of these packages are runtime dependencies.
+- `fast-xml-parser` / `fast-xml-builder`: the regenerated TypeScript lockfile no longer contains those packages, so
+  keeping orphan overrides would hide dependency graph drift instead of fixing it.
+- `flatted` / `js-yaml`: upstream-selected lint-tool transitive versions remain audit-clean; local pins were redundant.
+- `yaml`: the TableTheory release asset now resolves `yaml@2.9.0`; AppTheory should not override TableTheory's
+  transitive dependency unless a current advisory or contract gate requires it.


### PR DESCRIPTION
## Summary
- refresh `docs/_concepts.yaml` after SP17 source decomposition so live concept paths do not point at deleted files
- add maintainer dependency override rationale for the SP17 TypeScript override removal

Closes THE-2555

## Validation
- `git diff --check HEAD~1..HEAD`
- `./scripts/verify-api-docs.sh`
- `./scripts/verify-version-alignment.sh`
- `bash scripts/verify-docs-standard.sh`
- custom `docs/_concepts.yaml` path check for `kinesis_ingestion` and `lambda_microvm_support`
- `make rubric`

No AWS/cloud/account/DNS/secrets/live deploy/release/customer-workload actions were performed.