### PR TITLE
fix(docs): harden api docs truth verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Use AppTheory when you want AWS-Lambda-backed services that are:
 
 ## MCP server runtime
 
-AppTheory's Go runtime includes a complete [Model Context Protocol](https://modelcontextprotocol.io) production stack: Streamable HTTP transport, session management, OAuth protected resources, resumable SSE streaming, and CDK deployment constructs. The Go MCP runtime is a **first-class part of the contract**, not an experimental add-on — `theory-mcp-server` itself runs on it. The TypeScript MCP runtime now executes those MCP fixtures; Python MCP runtime parity remains intentionally staged for SP11 and represented by explicit Python skips of the MCP tier.
+AppTheory includes a complete [Model Context Protocol](https://modelcontextprotocol.io) runtime surface: Streamable HTTP transport, session management, OAuth protected resources, resumable SSE streaming, and CDK deployment constructs. MCP is a **first-class part of the contract**, not an experimental add-on — Go, TypeScript, and Python execute the shared MCP fixtures alongside OAuth and objectstore fixtures.
 
 - [MCP integration guide](https://apptheory.theorycloud.ai/integrations/mcp/) — transport, JSON-RPC surface, registries, sessions, streaming
 - [Remote MCP deployment](https://apptheory.theorycloud.ai/integrations/remote-mcp/) — OAuth, protected resource metadata, Autheory integration

--- a/cdk/docs/README.md
+++ b/cdk/docs/README.md
@@ -61,6 +61,21 @@
 
 AppTheory CDK provides jsii constructs that deploy AppTheory apps with consistent defaults (and keep infra patterns consistent across Go/TypeScript/Python services).
 
+## CDK semantic construct map
+
+The generated jsii coverage index below proves construct-name coverage only; it is not a substitute for
+operator-facing deployment guidance. Keep these human-authored groups current when the CDK surface grows:
+
+- HTTP and routing: `AppTheoryHttpApi`, `AppTheoryRestApi`, `AppTheoryRestApiRouter`, domains, CORS, logging, and WAF
+  guardrails.
+- MCP deployment: `AppTheoryMcpServer`, `AppTheoryRemoteMcpServer`, and `AppTheoryMcpProtectedResource`.
+- Event and ingestion surfaces: `AppTheoryQueue`, `AppTheoryEventBridgeBus`, `AppTheoryKinesisStream`,
+  `AppTheoryCloudWatchLogsDestination`, `AppTheoryS3Ingest`, and `AppTheoryHttpIngestionEndpoint`.
+- Job and data foundations: `AppTheoryJobsTable`, `AppTheoryEventBusTable`, `AppTheoryDynamoTable`, and
+  `AppTheoryLambdaRole`.
+- MicroVM and frontend delivery: `AppTheoryMicrovmController`, `AppTheoryMicrovmImage`,
+  `AppTheoryMicrovmNetworkConnector`, path-routed frontends, media CDN, and `AppTheorySsrSite`.
+
 <!-- apptheory-api-docs:cdk:start -->
 ## CDK jsii coverage index
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -153,9 +153,9 @@ tabletheory:
     - id: mcp
       name: MCP servers
       domain: streamable-http
-      desc: Go Streamable HTTP transport, sessions, resumable SSE, and OAuth-protected remote MCP — packaged as Lambda-native constructs Claude and Claude Code consume directly.
+      desc: Streamable HTTP transport, sessions, resumable SSE, and OAuth-protected remote MCP — packaged as Lambda-native AppTheory constructs.
       url: /integrations/mcp/
-      cta: See the Go MCP runtime
+      cta: See the MCP runtime
     - id: core
       name: Event workloads
       domain: lambda-events
@@ -165,7 +165,7 @@ tabletheory:
   stats:
     - label: Contract fixtures
       value: "203" # apptheory-fixture-count
-      sub: Go+TS all; Py 183 + 11 MCP skips
+      sub: Go, TypeScript, and Python execute all shared fixtures
     - label: Runtimes
       value: "3"
       sub: Go · TypeScript · Python

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -316,18 +316,20 @@ idempotency, and leases.
 Guide: [Jobs Ledger](./features/jobs-ledger.md)
 Reference stack: `examples/cdk/import-pipeline/`
 
-### Object store helper (Go)
+### Object store helper
 
-AppTheory includes a narrow Go object-store helper for framework-owned byte payload storage. It is not a general storage
-SDK.
+AppTheory includes a narrow bounded object-store helper for framework-owned byte payload storage. It is not a general
+storage SDK and does not expose list, presign, multipart, or raw-client escape hatches.
 
 - Go: `pkg/objectstore`
-- Testkit: `testkit/objectstore`
-- Object refs: strict `s3://bucket/key` parsing into `ObjectRef{Bucket, Key, VersionID}` with no default bucket/key and
-  no query or fragment support.
+- TypeScript: `ObjectStore`, `ObjectRef`, `createS3ObjectStore`, and `FakeObjectStore`
+- Python: `ObjectStore`, `ObjectRef`, `create_s3_object_store`, and `FakeObjectStore`
+- Testkit/fakes: `testkit/objectstore` in Go plus package-local fake stores in TypeScript and Python
+- Object refs: strict `s3://bucket/key` parsing into bucket/key/version fields with no default bucket/key and no query
+  or fragment support.
 - Store contract: `Put`, bounded `Get` with required `MaxBytes`, and `Delete` only.
-- S3 implementation: `NewS3Store(ctx, S3StoreConfig{...})` uses AWS SDK v2 config loading while keeping the S3 client
-  seam private/test-only.
+- S3 implementations: each runtime keeps the cloud client seam inside the framework surface and exposes only bounded
+  `put`/`get`/`delete` operations.
 - Encryption: bucket-default, S3-managed, and KMS modes fail closed on contradictory or missing KMS configuration.
 
 Guide: [Object Store Helper](./features/object-store.md)
@@ -374,7 +376,8 @@ Known configuration keys surfaced by canonical docs:
 
 ### MCP and OAuth
 
-AppTheory includes Go runtime support for MCP and OAuth-adjacent remote-MCP flows:
+AppTheory includes fixture-backed MCP and OAuth support across the runtime family, with the Go package paths listed
+here for operators who need implementation-level details:
 
 - `runtime/mcp`: Streamable HTTP `POST/GET/DELETE /mcp`, protocol negotiation, origin validation, sessions, resumable
   SSE, and the MCP request surface (`initialize`, `ping`, `tools/*`, `resources/*`, `prompts/*`, plus accepted
@@ -385,6 +388,8 @@ AppTheory includes Go runtime support for MCP and OAuth-adjacent remote-MCP flow
 - `runtime/oauth`: protected-resource metadata, challenges, DCR, PKCE, and token-store helpers
 - `testkit/oauth`: Claude-like end-to-end OAuth flow helpers for remote MCP tests (`NewClaudePublicClient`,
   `AuthorizeOptions`, `Authorize`)
+- TypeScript and Python expose matching MCP registries, server/test harnesses, in-memory/Dynamo stores, bearer-token
+  validation, protected-resource metadata, DCR, and PKCE helpers through their package API snapshots.
 
 Remote MCP auth hardening note:
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -3,10 +3,12 @@ title: MCP Method Surface
 render_with_liquid: false
 ---
 
-# MCP (Model Context Protocol) Server (Go runtime)
+# MCP (Model Context Protocol) Method Surface
 
-This document describes AppTheory's MCP server implementation (`github.com/theory-cloud/apptheory/runtime/mcp`) for
-the Go runtime: transport behavior, JSON-RPC surface, registries, sessions, streaming, and test helpers.
+This document describes AppTheory's fixture-backed MCP server method surface: transport behavior, JSON-RPC methods,
+registries, sessions, streaming, and test helpers. Go implementation package paths such as
+`github.com/theory-cloud/apptheory/runtime/mcp` are listed where operators need source-level details; TypeScript and
+Python expose the matching runtime/test surfaces through their package API snapshots.
 
 If you're specifically integrating with Bedrock AgentCore, start with `docs/integrations/agentcore-mcp.md`.
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -30,10 +30,12 @@ Python 3.14+ is required.
 
 | Module | Purpose |
 | --- | --- |
-| `apptheory` | Core Python runtime exports: `create_app`, `Context`, request/response helpers, event builders, testkit helpers, jobs-ledger primitives, logging profiles, and sanitization helpers. Rate-limiter classes are not root exports. |
+| `apptheory` | Core Python runtime exports: `create_app`, `Context`, request/response helpers, event builders, testkit helpers, MCP/OAuth helpers, jobs-ledger primitives, logging profiles, object-store helpers, and sanitization helpers. Rate-limiter classes are not root exports. |
+| `apptheory.mcp` | Streamable HTTP MCP server, registries, session/stream/task stores, SSE parsing, and deterministic test harness helpers. |
+| `apptheory.oauth` | Protected-resource metadata, bearer-token validation, DCR, PKCE, and Remote MCP OAuth helper surfaces. |
 | `apptheory.limited` | DynamoDB-backed rate limiter exports (`DynamoRateLimiter`, `FixedWindowStrategy`, `SlidingWindowStrategy`, `MultiWindowStrategy`). |
 
-There are no Python MCP or OAuth runtime modules. See `api-snapshots/py.txt` for the exact exported surface — that file is the release gate.
+See `api-snapshots/py.txt` for the exact exported surface — that file is the release gate.
 
 ## Minimal app
 
@@ -111,5 +113,5 @@ The Python runtime passes the full contract corpus on every commit. <!-- apptheo
 
 - [API Reference](../api-reference.md)
 - [HTTP Runtime tiers](../features/http-runtime.md)
-- [MCP Method Surface](../integrations/mcp.md) — Go runtime MCP surface
+- [MCP Method Surface](../integrations/mcp.md) — transport and JSON-RPC method contract
 - [Contract Fixtures](../reference/contract-fixtures.md)

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -137,5 +137,5 @@ The TypeScript runtime passes all 203 contract fixtures on every commit. <!-- ap
 
 - [API Reference](../api-reference.md)
 - [HTTP Runtime tiers](../features/http-runtime.md)
-- [MCP Method Surface](../integrations/mcp.md) — Go runtime MCP surface
+- [MCP Method Surface](../integrations/mcp.md) — transport and JSON-RPC method contract
 - [Contract Fixtures](../reference/contract-fixtures.md)

--- a/py/docs/README.md
+++ b/py/docs/README.md
@@ -38,6 +38,21 @@
 Portable behavior is defined by the fixture-backed contract:
 `docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
 
+## Python semantic API map
+
+The generated snapshot coverage index below proves export-name coverage only; it is not a substitute for
+operator-facing API guidance. Keep these human-authored groups current when the Python surface grows:
+
+- Runtime app model: `App`, `create_app`, `Context`, `Request`, `Response`, `create_test_env`, middleware hooks, and
+  response helpers.
+- AWS adapters and test builders: `build_apigw_v2_request`, `build_lambda_function_url_request`,
+  `build_appsync_event`, `build_sqs_event`, `build_kinesis_event`, and the corresponding `serve_*` entrypoints.
+- MCP/OAuth surfaces: `McpServer`, registries, in-memory/Dynamo stores, bearer-token middleware, metadata handlers,
+  DCR, PKCE, and protected-resource helpers.
+- Storage and data helpers: `ObjectStore`, `ObjectRef`, `create_s3_object_store`, `DynamoJobLedger`, and rate-limit
+  primitives.
+- MicroVM and generated contract helpers: `MicroVMController`, provider/session validators, and `generate_openapi`.
+
 <!-- apptheory-api-docs:py:start -->
 ## Python snapshot coverage index
 

--- a/scripts/verify-api-docs.sh
+++ b/scripts/verify-api-docs.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
-# Purpose: verify handwritten API docs mention every exported top-level symbol.
+# Purpose: verify handwritten API docs cover exported top-level symbols and semantic docs anchors.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-python3 - <<'PY'
+python3 - "$@" <<'PY'
 from __future__ import annotations
 
+from collections import Counter
 import json
+import os
 import re
+import sys
 from pathlib import Path
 
-ROOT = Path('.')
+ROOT = Path(os.environ.get('APPTHEORY_API_DOCS_ROOT', '.'))
+
+
+class CheckError(Exception):
+    pass
 
 
 def fail(message: str) -> None:
-    raise SystemExit(message)
+    raise CheckError(message)
 
 
 def go_symbols() -> list[str]:
@@ -74,6 +81,132 @@ def mentioned(doc_text: str, symbol: str) -> bool:
     return re.search(rf'(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])', doc_text) is not None
 
 
+def strip_coverage_block(label: str, doc_path: str, text: str) -> tuple[str, str]:
+    start = f'<!-- apptheory-api-docs:{label}:start -->'
+    end = f'<!-- apptheory-api-docs:{label}:end -->'
+    if text.count(start) != 1:
+        fail(f'api-docs: FAIL ({label}: {doc_path} must contain exactly one {start} marker)')
+    if text.count(end) != 1:
+        fail(f'api-docs: FAIL ({label}: {doc_path} must contain exactly one {end} marker)')
+    start_index = text.index(start)
+    end_index = text.index(end)
+    if end_index <= start_index:
+        fail(f'api-docs: FAIL ({label}: {doc_path} coverage end marker appears before start marker)')
+    block = text[start_index + len(start) : end_index]
+    outside = text[:start_index] + text[end_index + len(end) :]
+    return block, outside
+
+
+def index_symbols(label: str, doc_path: str, block: str) -> list[str]:
+    fences = re.findall(r'```text\s*\n(.*?)\n```', block, flags=re.DOTALL)
+    if len(fences) != 1:
+        fail(f'api-docs: FAIL ({label}: {doc_path} coverage block must contain exactly one ```text code fence)')
+    return re.findall(r'\b[A-Za-z_][A-Za-z0-9_]*\b', fences[0])
+
+
+def check_coverage_index(label: str, source: str, doc_path: str, block: str, symbols: list[str]) -> None:
+    summary_match = re.search(r'<summary>\s*(\d+)\s+exported top-level symbols\s*</summary>', block)
+    if not summary_match:
+        fail(f'api-docs: FAIL ({label}: {doc_path} coverage block missing exported-symbol summary)')
+    summary_count = int(summary_match.group(1))
+    if summary_count != len(symbols):
+        fail(
+            f'api-docs: FAIL ({label}: {doc_path} summary count {summary_count} != '
+            f'{len(symbols)} symbols from {source})'
+        )
+
+    listed = index_symbols(label, doc_path, block)
+    counts = Counter(listed)
+    duplicates = sorted(symbol for symbol, count in counts.items() if count > 1)
+    if duplicates:
+        preview = ', '.join(duplicates[:40])
+        more = '' if len(duplicates) <= 40 else f' (+{len(duplicates) - 40} more)'
+        fail(f'api-docs: FAIL ({label}: {doc_path} duplicates {len(duplicates)} coverage symbols: {preview}{more})')
+
+    expected = set(symbols)
+    observed = set(listed)
+    missing = sorted(expected - observed, key=str.lower)
+    extra = sorted(observed - expected, key=str.lower)
+    if missing or extra:
+        parts = []
+        if missing:
+            preview = ', '.join(missing[:40])
+            more = '' if len(missing) <= 40 else f' (+{len(missing) - 40} more)'
+            parts.append(f'missing {len(missing)} from {source}: {preview}{more}')
+        if extra:
+            preview = ', '.join(extra[:40])
+            more = '' if len(extra) <= 40 else f' (+{len(extra) - 40} more)'
+            parts.append(f'extra {len(extra)} not in {source}: {preview}{more}')
+        fail(f'api-docs: FAIL ({label}: {doc_path} coverage index drift: {"; ".join(parts)})')
+
+
+def human_anchor_present(text: str, anchor: str) -> bool:
+    if re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', anchor):
+        return mentioned(text, anchor)
+    return anchor.lower() in text.lower()
+
+
+HUMAN_DOC_ANCHORS: dict[str, list[str]] = {
+    'go': [
+        'Core runtime entrypoints',
+        'HTTP source provenance',
+        'Universal Lambda entrypoint',
+        'Route registration',
+        'Rate limiting',
+        'Sanitization',
+        'Object store helper',
+        'AWS Lambda MicroVM support',
+        'MCP and OAuth',
+        'CDK construct overview',
+    ],
+    'ts': [
+        'TypeScript semantic API map',
+        'App',
+        'createApp',
+        'Context',
+        'createTestEnv',
+        'buildAPIGatewayV2Request',
+        'McpServer',
+        'ObjectStore',
+        'MicroVMController',
+        'generate_openapi',
+    ],
+    'py': [
+        'Python semantic API map',
+        'create_app',
+        'Context',
+        'create_test_env',
+        'build_apigw_v2_request',
+        'McpServer',
+        'ObjectStore',
+        'MicroVMController',
+        'generate_openapi',
+    ],
+    'cdk': [
+        'CDK semantic construct map',
+        'AppTheoryHttpApi',
+        'AppTheoryRestApi',
+        'AppTheoryMcpServer',
+        'AppTheoryRemoteMcpServer',
+        'AppTheoryQueue',
+        'AppTheoryKinesisStream',
+        'AppTheoryMicrovmController',
+        'AppTheorySsrSite',
+    ],
+}
+
+
+def check_human_depth(label: str, doc_path: str, outside_coverage: str) -> None:
+    anchors = HUMAN_DOC_ANCHORS[label]
+    missing = [anchor for anchor in anchors if not human_anchor_present(outside_coverage, anchor)]
+    if missing:
+        preview = ', '.join(missing)
+        fail(
+            f'api-docs: FAIL ({label}: {doc_path} missing semantic docs anchors outside '
+            f'generated coverage index: {preview})'
+        )
+
+
 def check(label: str, source: str, doc_path: str, symbols: list[str]) -> None:
     doc = ROOT / doc_path
     if not doc.exists():
@@ -84,12 +217,73 @@ def check(label: str, source: str, doc_path: str, symbols: list[str]) -> None:
         preview = ', '.join(missing[:80])
         more = '' if len(missing) <= 80 else f' (+{len(missing) - 80} more)'
         fail(f'api-docs: FAIL ({label}: {doc_path} missing {len(missing)} symbols from {source}: {preview}{more})')
-    print(f'api-docs: {label} PASS ({len(symbols)} symbols in {doc_path})')
+    block, outside_coverage = strip_coverage_block(label, doc_path, text)
+    check_coverage_index(label, source, doc_path, block, symbols)
+    check_human_depth(label, doc_path, outside_coverage)
+    print(
+        f'api-docs: {label} PASS '
+        f'({len(symbols)} symbols + {len(HUMAN_DOC_ANCHORS[label])} semantic anchors in {doc_path})'
+    )
 
 
-check('go', 'api-snapshots/go.txt', 'docs/api-reference.md', go_symbols())
-check('ts', 'api-snapshots/ts.txt', 'ts/docs/README.md', ts_symbols())
-check('py', 'api-snapshots/py.txt', 'py/docs/README.md', py_symbols())
-check('cdk', 'cdk/.jsii', 'cdk/docs/README.md', cdk_symbols())
-print('api-docs: PASS')
+def self_test() -> None:
+    symbols = ['App', 'Context', 'createApp']
+    block = '''
+<details>
+<summary>3 exported top-level symbols</summary>
+
+```text
+App, Context, createApp
+```
+</details>
+'''
+    check_coverage_index('ts', 'self-test.md', 'fixture', block, symbols)
+
+    try:
+        check_coverage_index('ts', 'self-test.md', 'fixture', block.replace('3 exported', '2 exported'), symbols)
+    except CheckError:
+        pass
+    else:  # pragma: no cover - this is the proof condition
+        fail('api-docs self-test: stale summary count was not rejected')
+
+    try:
+        check_coverage_index('ts', 'self-test.md', 'fixture', block.replace('createApp', 'staleSymbol'), symbols)
+    except CheckError:
+        pass
+    else:  # pragma: no cover - this is the proof condition
+        fail('api-docs self-test: stale coverage symbols were not rejected')
+
+    try:
+        check_human_depth('ts', 'self-test.md', 'This document only has generated coverage, not narrative docs.')
+    except CheckError:
+        pass
+    else:  # pragma: no cover - this is the proof condition
+        fail('api-docs self-test: missing semantic anchors were not rejected')
+
+    rich_text = '''
+## TypeScript semantic API map
+Use App and createApp with Context, createTestEnv, buildAPIGatewayV2Request,
+McpServer, ObjectStore, MicroVMController, and generate_openapi.
+'''
+    check_human_depth('ts', 'self-test.md', rich_text)
+    print('api-docs: self-test PASS')
+
+
+def main(argv: list[str]) -> None:
+    if argv == ['--self-test']:
+        self_test()
+        return
+    if argv:
+        fail(f'api-docs: FAIL (unknown arguments: {" ".join(argv)})')
+    check('go', 'api-snapshots/go.txt', 'docs/api-reference.md', go_symbols())
+    check('ts', 'api-snapshots/ts.txt', 'ts/docs/README.md', ts_symbols())
+    check('py', 'api-snapshots/py.txt', 'py/docs/README.md', py_symbols())
+    check('cdk', 'cdk/.jsii', 'cdk/docs/README.md', cdk_symbols())
+    print('api-docs: PASS')
+
+
+try:
+    main(sys.argv[1:])
+except CheckError as exc:
+    raise SystemExit(str(exc))
 PY

--- a/scripts/verify-api-docs.sh
+++ b/scripts/verify-api-docs.sh
@@ -169,7 +169,7 @@ HUMAN_DOC_ANCHORS: dict[str, list[str]] = {
         'McpServer',
         'ObjectStore',
         'MicroVMController',
-        'generate_openapi',
+        'generateOpenAPI',
     ],
     'py': [
         'Python semantic API map',
@@ -263,7 +263,7 @@ App, Context, createApp
     rich_text = '''
 ## TypeScript semantic API map
 Use App and createApp with Context, createTestEnv, buildAPIGatewayV2Request,
-McpServer, ObjectStore, MicroVMController, and generate_openapi.
+McpServer, ObjectStore, MicroVMController, and generateOpenAPI.
 '''
     check_human_depth('ts', 'self-test.md', rich_text)
     print('api-docs: self-test PASS')

--- a/ts/docs/README.md
+++ b/ts/docs/README.md
@@ -56,7 +56,7 @@ operator-facing API guidance. Keep these human-authored groups current when the 
   DCR, PKCE, and protected-resource helpers.
 - Storage and data helpers: `ObjectStore`, `ObjectRef`, `createS3ObjectStore`, `DynamoJobLedger`, and rate-limit
   primitives.
-- MicroVM and generated contract helpers: `MicroVMController`, provider/session validators, and `generate_openapi`.
+- MicroVM and generated contract helpers: `MicroVMController`, provider/session validators, and `generateOpenAPI`.
 
 <!-- apptheory-api-docs:ts:start -->
 ## TypeScript snapshot coverage index

--- a/ts/docs/README.md
+++ b/ts/docs/README.md
@@ -44,6 +44,20 @@ AppTheory TypeScript provides:
 Contract note: portable behavior is defined by the fixture-backed contract:
 `docs/development/planning/apptheory/supporting/apptheory-runtime-contract-v0.md`.
 
+## TypeScript semantic API map
+
+The generated snapshot coverage index below proves export-name coverage only; it is not a substitute for
+operator-facing API guidance. Keep these human-authored groups current when the TypeScript surface grows:
+
+- Runtime app model: `App`, `createApp`, `Context`, `Request`, `Response`, middleware hooks, and response helpers.
+- AWS adapters and test builders: `buildAPIGatewayV2Request`, `buildLambdaFunctionURLRequest`, `buildAppSyncEvent`,
+  `buildSQSEvent`, `buildKinesisEvent`, and the corresponding `serve*` entrypoints.
+- MCP/OAuth surfaces: `McpServer`, registries, in-memory/Dynamo stores, bearer-token middleware, metadata handlers,
+  DCR, PKCE, and protected-resource helpers.
+- Storage and data helpers: `ObjectStore`, `ObjectRef`, `createS3ObjectStore`, `DynamoJobLedger`, and rate-limit
+  primitives.
+- MicroVM and generated contract helpers: `MicroVMController`, provider/session validators, and `generate_openapi`.
+
 <!-- apptheory-api-docs:ts:start -->
 ## TypeScript snapshot coverage index
 


### PR DESCRIPTION
## Summary
- harden `scripts/verify-api-docs.sh` so coverage indexes must match exported snapshots exactly and include semantic docs anchors outside generated symbol lists
- add `--self-test` proof that stale counts, stale symbols, and missing semantic anchors fail the verifier
- polish stale MCP/objectstore fixture-truth wording in public docs and package-local API maps

Closes THE-2552

## Validation
- `git diff --check`
- `./scripts/verify-api-docs.sh`
- `./scripts/verify-version-alignment.sh`
- `bash scripts/verify-docs-standard.sh`
- `./scripts/verify-api-docs.sh --self-test`
- `make rubric`

## Scope notes
- Repo-local docs/verifier hygiene only
- No runtime behavior, package versions, lockfiles, release config, workflows, API snapshots, contract fixtures, cloud/deploy surfaces, agent material, or sibling/parent repos changed
- No AWS/cloud/account/DNS/secrets/live deploy/receipt changes performed