### PR TITLE
fix(contract): assert empty MCP SSE frames

### DIFF
--- a/contract-tests/runners/py/run.py
+++ b/contract-tests/runners/py/run.py
@@ -2457,8 +2457,9 @@ def _compare_mcp_step(
         return False, "cookies mismatch"
     if not compare_headers(expected.get("headers"), actual.get("headers")):
         return False, "headers mismatch"
-    if isinstance(expected.get("sse_frames"), list) and expected.get("sse_frames"):
-        if expected.get("sse_frames") != actual.get("sse_frames"):
+    expected_sse_frames = expected.get("sse_frames")
+    if isinstance(expected_sse_frames, list):
+        if expected_sse_frames != actual.get("sse_frames"):
             return False, "sse_frames mismatch"
         return True, ""
     if "body_json" in expected:

--- a/contract-tests/runners/py/run_self_test.py
+++ b/contract-tests/runners/py/run_self_test.py
@@ -147,5 +147,77 @@ class CloudWatchLogsSubscriptionScaffoldTests(unittest.TestCase):
             missing_helper_handler(None, {"eventID": "r1"})
 
 
+class McpComparatorTests(unittest.TestCase):
+    def test_explicit_empty_sse_frames_rejects_stray_sse_body(self) -> None:
+        body = b"id: stray\nevent: message\ndata: {\"jsonrpc\":\"2.0\"}\n\n"
+        expected = {
+            "status": 200,
+            "headers": {},
+            "cookies": [],
+            "is_base64": False,
+            "sse_frames": [],
+            # Keep the body equal so this proof fails unless sse_frames=[] is
+            # itself an explicit assertion.
+            "body": {"encoding": "utf8", "value": body.decode("utf-8")},
+        }
+        actual = {
+            "status": 200,
+            "headers": {},
+            "cookies": [],
+            "is_base64": False,
+            "sse_frames": runner._parse_mcp_sse_frames(body),
+            "body": body,
+        }
+
+        ok, reason = runner._compare_mcp_step(expected, actual)
+
+        self.assertFalse(ok)
+        self.assertEqual("sse_frames mismatch", reason)
+
+    def test_mcp_body_json_comparison_still_applies_without_sse_frames(self) -> None:
+        expected = {
+            "status": 200,
+            "headers": {},
+            "cookies": [],
+            "is_base64": False,
+            "body_json": {"jsonrpc": "2.0", "id": "ok"},
+        }
+        actual = {
+            "status": 200,
+            "headers": {},
+            "cookies": [],
+            "is_base64": False,
+            "sse_frames": [],
+            "body": b'{"jsonrpc":"2.0","id":"ok"}',
+        }
+
+        ok, reason = runner._compare_mcp_step(expected, actual)
+
+        self.assertTrue(ok, reason)
+
+    def test_non_empty_sse_frames_comparison_still_applies(self) -> None:
+        body = b"id: stream-1\nevent: message\ndata: {\"jsonrpc\":\"2.0\"}\n\n"
+        frames = runner._parse_mcp_sse_frames(body)
+        expected = {
+            "status": 200,
+            "headers": {},
+            "cookies": [],
+            "is_base64": False,
+            "sse_frames": frames,
+        }
+        actual = {
+            "status": 200,
+            "headers": {},
+            "cookies": [],
+            "is_base64": False,
+            "sse_frames": frames,
+            "body": body,
+        }
+
+        ok, reason = runner._compare_mcp_step(expected, actual)
+
+        self.assertTrue(ok, reason)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Treat any list-valued `expect.mcp.steps[].sse_frames` as an explicit Python MCP comparator assertion, including `[]`.
- Add a Python runner self-test proving explicit empty `sse_frames: []` rejects a stray SSE body even when the body bytes would otherwise match.
- Preserve body/body_json comparison when `sse_frames` is absent and preserve non-empty SSE frame comparison.

Closes THE-2540

## Validation
- Failing-before proof: `python3 contract-tests/runners/py/run_self_test.py` failed before the comparator fix with `AssertionError: True is not false` in `test_explicit_empty_sse_frames_rejects_stray_sse_body`.
- `python3 contract-tests/runners/py/run_self_test.py` — PASS (`Ran 5 tests ... OK`)
- `python3 contract-tests/runners/py/run.py --id mcp.sse.resumable_replay_from_last_event_id` — PASS (`contract-tests(py): PASS (1 fixtures)`)
- `python3 contract-tests/runners/py/run.py` — PASS (`contract-tests(py): PASS (216 fixtures)`)
- `bash scripts/verify-fixture-schema.sh` — PASS (`fixture-schema: PASS (fixtures=216, negative=PASS)`)
- `bash scripts/verify-contract-tests.sh` — PASS (`go/ts/py: PASS (216 fixtures)`; emitted the expected negative-schema parse-error line before PASS)
- `git diff --check` — PASS
- `python3 -m py_compile contract-tests/runners/py/run.py contract-tests/runners/py/run_self_test.py` — PASS
- `make lint` — PASS
- `make test` — PASS (`version-alignment: PASS (1.15.2)`)

## Notes
- No contract fixture files changed; the fixture schema gate was still run for proof.
- No release assets, TableTheory/FaceTheory paths, signing configuration, or THE-2256 floor-lowering scope touched.
