### PR TITLE
fix(contract): enforce empty MCP SSE frame assertions

### DIFF
--- a/contract-tests/fixtures/mcp/transport-framing-reserved-paths.json
+++ b/contract-tests/fixtures/mcp/transport-framing-reserved-paths.json
@@ -180,10 +180,7 @@
           },
           "cookies": [],
           "is_base64": false,
-          "body": {
-            "encoding": "utf8",
-            "value": ": keepalive\n\n"
-          }
+          "sse_frames": []
         },
         {
           "status": 400,

--- a/contract-tests/runners/go/apptheory_mcp.go
+++ b/contract-tests/runners/go/apptheory_mcp.go
@@ -428,9 +428,9 @@ func compareMCPExpectedStep(expected FixtureMCPExpectedStep, actual fixtureMCPAc
 	if !equalHeaders(canonicalizeHeaders(expected.Headers), actual.Headers) {
 		return fmt.Errorf("headers mismatch: expected %s, got %s", string(marshalIndentOrPlaceholder(canonicalizeHeaders(expected.Headers))), string(marshalIndentOrPlaceholder(actual.Headers)))
 	}
-	if len(expected.SSEFrames) > 0 {
-		if !reflectMCPFramesEqual(expected.SSEFrames, actual.SSEFrames) {
-			return fmt.Errorf("sse_frames mismatch: expected %s, got %s", string(marshalIndentOrPlaceholder(expected.SSEFrames)), string(marshalIndentOrPlaceholder(actual.SSEFrames)))
+	if expected.SSEFrames != nil {
+		if !reflectMCPFramesEqual(*expected.SSEFrames, actual.SSEFrames) {
+			return fmt.Errorf("sse_frames mismatch: expected %s, got %s", string(marshalIndentOrPlaceholder(*expected.SSEFrames)), string(marshalIndentOrPlaceholder(actual.SSEFrames)))
 		}
 		return nil
 	}

--- a/contract-tests/runners/go/fixture.go
+++ b/contract-tests/runners/go/fixture.go
@@ -292,13 +292,13 @@ type FixtureMCPExpect struct {
 }
 
 type FixtureMCPExpectedStep struct {
-	Status    int                  `json:"status"`
-	Headers   map[string][]string  `json:"headers"`
-	Cookies   []string             `json:"cookies"`
-	Body      *FixtureBody         `json:"body,omitempty"`
-	BodyJSON  json.RawMessage      `json:"body_json,omitempty"`
-	SSEFrames []FixtureMCPSSEFrame `json:"sse_frames,omitempty"`
-	IsBase64  bool                 `json:"is_base64"`
+	Status    int                   `json:"status"`
+	Headers   map[string][]string   `json:"headers"`
+	Cookies   []string              `json:"cookies"`
+	Body      *FixtureBody          `json:"body,omitempty"`
+	BodyJSON  json.RawMessage       `json:"body_json,omitempty"`
+	SSEFrames *[]FixtureMCPSSEFrame `json:"sse_frames,omitempty"`
+	IsBase64  bool                  `json:"is_base64"`
 }
 
 type FixtureMCPSSEFrame struct {

--- a/contract-tests/runners/ts/run.cjs
+++ b/contract-tests/runners/ts/run.cjs
@@ -2350,7 +2350,7 @@ function compareMCPStep(expected, actual) {
   if (!compareHeaders(expected.headers ?? {}, actual.headers ?? {})) {
     return { ok: false, reason: "headers mismatch", actual, expected };
   }
-  if (Array.isArray(expected.sse_frames) && expected.sse_frames.length > 0) {
+  if (Array.isArray(expected.sse_frames)) {
     if (!deepEqual(expected.sse_frames, actual.sse_frames)) {
       return { ok: false, reason: "sse_frames mismatch", actual, expected };
     }


### PR DESCRIPTION
## Summary
- Treat present `expect.mcp.steps[].sse_frames` arrays as explicit assertions in the TypeScript MCP contract runner, including `[]`.
- Preserve absent `sse_frames` body/body_json fallback semantics while making Go distinguish absent from present empty lists.
- Pin the behavior in the shared MCP transport-framing fixture by asserting the GET listener produces no parsed SSE frames.

Closes THE-2562

## Contract impact
Shared MCP contract-runner parity fixture update. The `get_listener` step in `mcp.transport.streamable_http_framing_reserved_paths` now uses `sse_frames: []` as the explicit no-frames assertion.

## Validation
- Baseline before branch: `make rubric` — PASS
- Fails-before proof using old Go/TS empty-SSE guards with the updated shared fixture:
  - `go run ./contract-tests/runners/go --id mcp.transport.streamable_http_framing_reserved_paths` — expected FAIL (`body mismatch: expected "", got ": keepalive\n\n"`)
  - `node contract-tests/runners/ts/run.cjs --id mcp.transport.streamable_http_framing_reserved_paths` — expected FAIL (`body mismatch`)
- `go run ./contract-tests/runners/go --id mcp.transport.streamable_http_framing_reserved_paths` — PASS
- `node contract-tests/runners/ts/run.cjs --id mcp.transport.streamable_http_framing_reserved_paths` — PASS
- `python3 contract-tests/runners/py/run.py --id mcp.transport.streamable_http_framing_reserved_paths` — PASS
- `bash scripts/verify-fixture-schema.sh` — PASS
- `bash scripts/verify-contract-tests.sh` — PASS
- `git diff --check` — PASS
- `make lint` — PASS
- `make test` — PASS
- Final `make rubric` — PASS

## Cross-repo notes
None. THE-2256/TableTheory floor lowering remains untouched and blocked separately.
