### PR TITLE
fix(release): close framework strengthening follow-ups

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -114,4 +114,7 @@ jobs:
         if: steps.release_pr.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY }}
+          RELEASE_ARTIFACT_SYNC_GPG_KEY_ID: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_KEY_ID }}
+          RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE }}
         run: scripts/sync-release-pr-generated.sh release-please--branches--premain

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -213,4 +213,7 @@ jobs:
         if: steps.release_pr.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY }}
+          RELEASE_ARTIFACT_SYNC_GPG_KEY_ID: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_KEY_ID }}
+          RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE }}
         run: scripts/sync-release-pr-generated.sh release-please--branches--main

--- a/LINEAR-PROJECT-improvement-program.md
+++ b/LINEAR-PROJECT-improvement-program.md
@@ -160,7 +160,7 @@ Deliver the full strengthening program: make the contract covenant actually cove
    - Paths: `gov-infra/verifiers/gov-verify-rubric.sh`, `scripts/verify-rubric.sh`
    - Runtime scope: none
    - Contract impact: internal-only
-   - Acceptance: one rubric invocation runs each language's contract suite exactly once; `npm ci` count reduced; rubric wall-clock measurably drops.
+   - Acceptance: one rubric invocation runs the direct/uninstrumented contract suite once through CON-3; TS/Python coverage may rerun the fixture corpus under instrumentation to prove runtime coverage, and the Go runner package meta-tests stay in QUA-1 without rerunning `TestAllFixturesPass`. `npm ci` count reduced; rubric wall-clock measurably drops.
    - Validation: `make rubric` (inspect log for single contract pass)
    - Commit subject: `chore(rubric): run contract suites once per rubric invocation`
 2. **Cache dependencies in CI** — [`apptheory`, `contract-change`]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,16 +30,18 @@ code/message compatibility, but it is deprecated as the primary framework error 
 | TypeScript | `AppError` | `AppTheoryError` | Supported for v1.x; earliest removal is v2.0. |
 | Python | `AppError` | `AppTheoryError` | Supported for v1.x; earliest removal is v2.0. |
 
-Default nested HTTP error envelopes remap legacy Lift JSON parse codes such as `EMPTY_BODY` and `INVALID_JSON` to the
-canonical `app.bad_request` code. If you temporarily need the old flat shape during a Lift migration, opt into the
-legacy HTTP error format explicitly:
+Default nested HTTP error envelopes remap any error whose code string is `EMPTY_BODY` or `INVALID_JSON` to the
+canonical `app.bad_request` code and message. The remap is keyed by the error code string so that legacy
+JSONHandler-originated errors and callers that still return those Lift-era codes converge to the same nested envelope.
+If you temporarily need the old flat shape during a Lift migration, opt into the legacy HTTP error format explicitly:
 
 - Go: `apptheory.WithHTTPErrorFormat(apptheory.HTTPErrorFormatFlatLegacy)` or `apptheory.WithLegacyHTTPErrorShape()`
 - TypeScript: `createApp({ httpErrorFormat: HTTP_ERROR_FORMAT_FLAT_LEGACY })`
 - Python: `create_app(http_error_format=HTTP_ERROR_FORMAT_FLAT_LEGACY)`
 
-Treat that flat legacy format as a migration bridge, not the target state for new applications. The nested AppTheory
-envelope remains the v1 default and the future-major path.
+Treat that flat legacy format as a migration bridge, not the target state for new applications. Flat legacy preserves
+the Lift-era `EMPTY_BODY` / `INVALID_JSON` codes and messages; the nested AppTheory envelope remains the v1 default
+and the future-major path.
 
 ### Legacy JSON helpers
 
@@ -54,8 +56,9 @@ and stream helpers as appropriate).
 ### Fail-closed route registration
 
 The fluent registration path is now fail-closed across runtimes. Invalid route patterns, duplicate canonical
-method/pattern pairs, and nil/undefined handlers fail during registration instead of producing a dead route at runtime.
-This closes the old silent-registration gap.
+method/pattern pairs, and nil/undefined/None handlers fail during registration instead of producing a dead route at
+runtime. This is an intentional behavior change for misconfigured applications that older v1 lines could silently
+ignore; treat it as action-required upgrade guidance before promoting a service that constructs routes dynamically.
 
 Use the normal registration path for new code:
 
@@ -65,7 +68,11 @@ Use the normal registration path for new code:
 | TypeScript | `app.get(...)`, `app.post(...)`, `app.handle(...)`, and other fluent methods |
 | Python | `app.get(...)`, `app.post(...)`, `app.handle(...)`, and other fluent methods |
 
-Strict helpers are deprecated compatibility wrappers for callers that already depend on their error-returning/throwing shape:
+Strict helpers are deprecated compatibility wrappers for callers that already depend on their error-returning/throwing shape.
+Their failure details now share the canonical AppTheory error path: Python `add_strict` / `handle_strict` raise
+`AppTheoryError` instead of `ValueError`, and Go `GetStrict` / `HandleStrict` / related helpers return canonical
+`AppTheoryError` messages where applicable rather than older segment-specific strings. Update tests that asserted the
+legacy exception class or exact message text:
 
 | Runtime | Deprecated compatibility helper | Replacement | Horizon |
 | --- | --- | --- | --- |
@@ -73,9 +80,10 @@ Strict helpers are deprecated compatibility wrappers for callers that already de
 | TypeScript | `handleStrict` | `handle` / `get` / `post` / normal fluent registration | Supported for v1.x; earliest removal is v2.0. |
 | Python | `handle_strict` | `handle` / `get` / `post` / normal fluent registration | Supported for v1.x; earliest removal is v2.0. |
 
-When upgrading, run application startup tests that construct every route. A route typo that was previously ignored may
-now fail fast during app initialization. That is expected fail-closed behavior; fix the route pattern rather than
-wrapping it in a fallback router.
+When upgrading, run application startup tests that construct every route and include duplicate-route, invalid-pattern,
+and nil/undefined/None-handler cases if your service builds route tables programmatically. A route typo that was
+previously ignored may now fail fast during app initialization. That is expected fail-closed behavior; fix the route
+pattern rather than wrapping it in a fallback router.
 
 ## v1.14.x and older v1 lines
 

--- a/contract-tests/fixtures/README.md
+++ b/contract-tests/fixtures/README.md
@@ -5,7 +5,12 @@ Fixtures are shared, machine-readable test vectors used to prevent cross-languag
 File layout is organized by behavior domain. The historical tier/milestone label remains inside each fixture's
 `tier` metadata and fixture `id`; directory names are not the contract identifier.
 
-- `contract-tests/fixtures/http-core/` — P0 runtime core: routing, normalization, errors, source provenance, Lambda URL/ALB adapters
+- `contract-tests/fixtures/http-core/` — P0 runtime core: request/response normalization, source provenance, Lambda URL/ALB adapters, and baseline routing
+- `contract-tests/fixtures/binding/` — P0 typed-handler body/query/path/header binding and binding-error envelopes
+- `contract-tests/fixtures/validation/` — P0 declarative validation rules and canonical 422 field-error envelopes
+- `contract-tests/fixtures/errors/` — P0 canonical framework error envelopes, panic recovery, 404/405, and Lift flat-legacy JSON parse compatibility
+- `contract-tests/fixtures/routing/` — P0 fail-closed route registration setup errors for duplicate routes, invalid patterns, and nil/undefined/None handlers
+- `contract-tests/fixtures/openapi/` — P0 descriptive OpenAPI generation with byte-pinned canonical JSON output
 - `contract-tests/fixtures/middleware-guardrails/` — P1 request-id, tenant, auth, CORS, guardrails, and legacy flat-error behavior
 - `contract-tests/fixtures/appsync-observability-policies/` — P2 AppSync, logging profiles, rate-limit, and load-shed behavior
 - `contract-tests/fixtures/observability/` — P2 request duration, CloudWatch EMF, and trace-context propagation behavior
@@ -16,12 +21,11 @@ File layout is organized by behavior domain. The historical tier/milestone label
 - `contract-tests/fixtures/edge-streaming-html/` — M14 streaming, catch-all routing, HTML/cache/CloudFront helpers, and Step Functions helpers
 - `contract-tests/fixtures/microvm-foundation/` — M15 Lambda MicroVM validation-only lifecycle/controller/session vocabulary
 - `contract-tests/fixtures/microvm-operations/` — M16 real Lambda MicroVM operation, route, provider-state, tenant, and token-safety contracts
-- `contract-tests/fixtures/openapi/` — P0 descriptive OpenAPI generation with byte-pinned canonical JSON output
-- `contract-tests/fixtures/mcp/` — SP09 Go MCP protocol, registry, session, Streamable HTTP, resumable SSE, and task-store contracts
+- `contract-tests/fixtures/mcp/` — SP09 MCP protocol, registry, session, Streamable HTTP, resumable SSE, and task-store contracts
 - `contract-tests/fixtures/oauth/` — SP12 OAuth protected-resource metadata, bearer validation, dynamic client registration, and PKCE contracts
 - `contract-tests/fixtures/objectstore/` — SP13 bounded object-store Put, capped Get, Delete, deterministic fake behavior, and forbidden operation errors
 
-Each fixture is a single JSON object.
+Each fixture is a single JSON object. The current corpus contains 216 behavior fixtures plus the internal schema file. <!-- apptheory-fixture-count: 216 -->
 
 ## Schema gate
 
@@ -33,13 +37,13 @@ while provider/runtime payload objects remain open so behavior-specific contract
 
 ## Common shape
 
-- `id` (string): stable identifier (use `p0.*`, `p1.*`, `p2.*`, `m1.*`, `m2.*`, `m3.*`, `m12.*`, `m14.*`, `m15.*`, `m16.*`, `mcp.*`, or `oauth.*` prefixes).
+- `id` (string): stable identifier (use `p0.*`, `p1.*`, `p2.*`, `m1.*`, `m2.*`, `m3.*`, `m12.*`, `m14.*`, `m15.*`, `m16.*`, `mcp.*`, `oauth.*`, or `objectstore.*` prefixes).
 - `tier` (string): `p0` / `p1` / `p2` / `m1` / `m2` / `m3` / `m12` / `m14` / `m15` / `m16` / `mcp` / `oauth` / `objectstore`.
 - `name` (string): short human-friendly name.
 - `setup.routes` (array): route table for the fixture runner.
   - `method` (string): HTTP method (e.g. `GET`).
   - `path` (string): route pattern (supports `{param}` segments).
-  - `handler` (string): built-in handler name provided by each language runner.
+  - `handler` (string or null): built-in handler name provided by each language runner. Routing registration fixtures may set this to `null` to pin nil/undefined/None handler fail-closed behavior at setup time.
 - `setup.middlewares` (array, optional): built-in middleware chain names applied in registration order.
   - Timeout fixtures may use cooperative handlers that must observe middleware cancellation before committing
     post-timeout side effects.
@@ -75,11 +79,11 @@ while provider/runtime payload objects remain open so behavior-specific contract
 
 ## SP09 MCP fixtures
 
-MCP fixtures pin the Go MCP runtime contract for protocol `2025-11-25`. They are a Go implementation leg for SP09:
-the TypeScript and Python contract runners must load and explicitly skip `tier: "mcp"` fixtures until SP10/SP11 add
-their MCP runtimes. That skip is intentional and reported by those runners; it is not parity proof for TS/Py.
+MCP fixtures pin the cross-runtime MCP contract for protocol `2025-11-25`. Go, TypeScript, and Python all execute the
+`tier: "mcp"` fixtures; a future runtime skip would have to be explicit in runner output and would not count as
+parity proof.
 
-`setup.mcp` builds a deterministic Go `runtime/mcp.Server`:
+`setup.mcp` builds a deterministic runner-owned MCP server:
 
 - `server.name` / `server.version`: expected `serverInfo` values in `initialize`.
 - `id_sequence`: deterministic server IDs for sessions and task IDs.
@@ -124,7 +128,9 @@ envelopes.
 
 The protected-resource and bearer fixtures pin RFC 9728 metadata at
 `/.well-known/oauth-protected-resource/<resource-path>`, the `WWW-Authenticate` discovery challenge, expiry/audience/scope
-failures, and the accepted-token context shape. The DCR/PKCE fixtures pin RFC 7591 public-client registration constraints,
+failures, and the accepted-token context shape. Missing and expired bearer tokens are challenge cases (`401` with
+`WWW-Authenticate`); invalid-audience and insufficient-scope tokens are authorization failures (`403 app.forbidden`)
+without a challenge. The DCR/PKCE fixtures pin RFC 7591 public-client registration constraints,
 S256 code challenge verification, authorization-code exchange, and canonical failure envelopes.
 
 

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -80,17 +80,15 @@ patterns:
           - "Confusion during migration"
 
   strict_route_registration:
-    name: "Use strict route registration for fast feedback"
-    problem: "Invalid route patterns are fail-closed and may be silently ignored by default for backwards compatibility."
-    solution: "Use the strict variant during tests and CI to fail fast when a route pattern is invalid."
+    name: "Use normal fail-closed route registration"
+    problem: "Invalid route patterns, duplicate method/path pairs, and nil/undefined/None handlers must fail during setup instead of drifting into runtime 404s."
+    solution: "Use normal fluent registration and run startup tests that construct every route."
     correct_example: |
-      # CORRECT (Go): fail fast on invalid patterns
-      if _, err := app.GetStrict("/users/{id}", handleUser); err != nil {
-        panic(err)
-      }
+      # CORRECT (Go): normal registration fails closed during setup
+      app.Get("/users/{id}", handleUser)
     anti_patterns:
       - name: "Assuming all routes register successfully"
-        why: "Silent registration failures can lead to missing routes and unexpected 404s."
+        why: "Ignoring setup failures can block startup or leave tests blind to invalid route tables."
         incorrect_example: |
           # INCORRECT
           app.Get("/{proxy+}/x", handleUser)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -69,6 +69,8 @@ Common helper exports:
 HTTP error compatibility:
 
 - Default HTTP error bodies remain nested under `error`.
+- In the default nested envelope, any error whose code string is `EMPTY_BODY` or `INVALID_JSON` is remapped to
+  canonical `app.bad_request` fields; the opt-in flat legacy format preserves those Lift-era codes/messages.
 - Lift-compatible flat HTTP error bodies are opt-in:
   - Go: `apptheory.WithHTTPErrorFormat(apptheory.HTTPErrorFormatFlatLegacy)` or `apptheory.WithLegacyHTTPErrorShape()`
   - TypeScript: `createApp({ httpErrorFormat: HTTP_ERROR_FORMAT_FLAT_LEGACY })`
@@ -256,15 +258,16 @@ Infrastructure note:
 
 ## Route registration
 
-Invalid route patterns, duplicate method/pattern pairs, and nil/undefined handlers fail closed during registration across
-runtimes. Use the normal fluent registration path for new code:
+Invalid route patterns, duplicate method/pattern pairs, and nil/undefined/None handlers fail closed during registration
+across runtimes. Use the normal fluent registration path for new code:
 
 - Go: `app.Get("/users/{id}", h)` or `app.Handle("GET", "/users/{id}", h)`
 - TypeScript: `app.get("/users/{id}", h)` or `app.handle("GET", "/users/{id}", h)`
 - Python: `app.get("/users/{id}", h)` or `app.handle("GET", "/users/{id}", h)`
 
 Strict helpers remain as deprecated compatibility wrappers for code that already depends on their error-returning or
-throwing shape. See `UPGRADING.md` for per-line deprecation notes.
+throwing shape. Python strict helpers now raise `AppTheoryError` rather than `ValueError`, and Go strict helpers return
+canonical `AppTheoryError` messaging where applicable. See `UPGRADING.md` for per-line deprecation notes.
 
 ## Cross-language feature surfaces
 
@@ -329,7 +332,9 @@ storage SDK and does not expose list, presign, multipart, or raw-client escape h
   or fragment support.
 - Store contract: `Put`, bounded `Get` with required `MaxBytes`, and `Delete` only.
 - S3 implementations: each runtime keeps the cloud client seam inside the framework surface and exposes only bounded
-  `put`/`get`/`delete` operations.
+  `put`/`get`/`delete` operations. TypeScript intentionally carries `@aws-sdk/client-s3` as a hard package dependency
+  because the S3 implementation imports it at module load; Python intentionally keeps `boto3` optional/lazy and fails
+  closed from `create_s3_object_store` if the dependency or required S3 methods are unavailable.
 - Encryption: bucket-default, S3-managed, and KMS modes fail closed on contradictory or missing KMS configuration.
 
 Guide: [Object Store Helper](./features/object-store.md)
@@ -391,11 +396,14 @@ here for operators who need implementation-level details:
 - TypeScript and Python expose matching MCP registries, server/test harnesses, in-memory/Dynamo stores, bearer-token
   validation, protected-resource metadata, DCR, and PKCE helpers through their package API snapshots.
 
-Remote MCP auth hardening note:
+Remote MCP auth hardening notes:
 
 - `oauth.RequireBearerTokenMiddleware(...)` is fail-closed in Go: you must provide a `Validator`, and metadata
   discovery for the `WWW-Authenticate` challenge comes from `ResourceMetadataURL` or `MCP_ENDPOINT`, not request
   headers.
+- Invalid-audience bearer tokens are intentionally fixture-pinned as authorization failures: AppTheory returns
+  `403 app.forbidden` without a `WWW-Authenticate` challenge, matching insufficient-scope denial so a token bound to
+  another resource is not treated as a rediscovery prompt. Missing or expired bearers remain `401` challenge cases.
 
 Related canonical integration guides:
 

--- a/docs/cdk/mcp-server-remote-mcp.md
+++ b/docs/cdk/mcp-server-remote-mcp.md
@@ -196,6 +196,9 @@ Important fail-closed rules:
   with `401`.
 - The middleware no longer derives protected-resource metadata from `Host` / `X-Forwarded-Proto` request headers.
   Use `MCP_ENDPOINT` or pass `ResourceMetadataURL` explicitly.
+- Invalid-audience bearer tokens are intentionally treated as authorization failures: the fixture-pinned response is
+  `403 app.forbidden` without a `WWW-Authenticate` challenge, matching insufficient-scope denial. Missing or expired
+  bearer tokens remain `401` discovery/challenge cases.
 
 For migration notes covering Bearer validation, initial listener keepalive changes, and expired-session fail-closed
 behavior, see `docs/migration/v1-security.md`.

--- a/docs/features/http-runtime.md
+++ b/docs/features/http-runtime.md
@@ -72,8 +72,9 @@ If two routes are equally specific, the router prefers **earlier registration or
 
 ### Fail-closed registration
 
-Default fluent registration fails closed for invalid patterns, duplicate canonical method/pattern pairs, and nil or
-undefined handlers. Use the normal registration path in new code:
+Default fluent registration fails closed for invalid patterns, duplicate canonical method/pattern pairs, and nil,
+undefined, or `None` handlers. Misconfigured applications that older v1 lines could silently ignore now fail during
+startup or test setup instead of drifting into unexpected runtime 404s. Use the normal registration path in new code:
 
 ```go
 app.Get("/users/{id}", handler)
@@ -91,7 +92,8 @@ app.handle("GET", "/users/{id}", handler)
 ```
 
 The strict helpers remain only as deprecated compatibility wrappers for code that depends on their older
-error-returning or throwing shape.
+error-returning or throwing shape. Their failures use the canonical AppTheory error path: Python strict helpers raise
+`AppTheoryError`, and Go strict helpers return canonical `AppTheoryError` messages where applicable.
 
 ## Response helpers
 
@@ -135,7 +137,10 @@ const app = createApp({ httpErrorFormat: HTTP_ERROR_FORMAT_FLAT_LEGACY });
 app = create_app(http_error_format=HTTP_ERROR_FORMAT_FLAT_LEGACY)
 ```
 
-The flat shape applies to **HTTP only.** AppSync and WebSocket error payloads keep their existing shapes regardless of this setting — those surfaces have their own contracts.
+The default nested envelope remaps any error whose code string is `EMPTY_BODY` or `INVALID_JSON` to canonical
+`app.bad_request` fields. The flat legacy HTTP format preserves those Lift-era codes/messages as a migration bridge.
+The flat shape applies to **HTTP only.** AppSync and WebSocket error payloads keep their existing shapes regardless of
+this setting — those surfaces have their own contracts.
 
 ## HTTP entrypoints
 

--- a/docs/features/object-store.md
+++ b/docs/features/object-store.md
@@ -4,9 +4,9 @@ title: Object Store Helper
 
 # Object Store Helper
 
-AppTheory exposes a narrow Go object-store helper in `pkg/objectstore` for framework-owned byte payload storage. It is
-intentionally small: one strict object reference type, one bounded `Store` interface, one S3-backed implementation, and a
-deterministic testkit fake.
+AppTheory exposes a narrow bounded object-store helper for framework-owned byte payload storage across Go,
+TypeScript, and Python. It is intentionally small: one strict object reference type, one bounded store interface, one
+S3-backed implementation per runtime, and deterministic local fakes for contract tests.
 
 This helper exists so AppTheory-owned code paths can share one fail-closed S3 access pattern instead of reimplementing
 S3 get/put/delete, URL parsing, encryption headers, and bounded reads in each package. It is **not** a general storage
@@ -14,18 +14,20 @@ SDK.
 
 ## Surface
 
-- `ObjectRef{Bucket, Key, VersionID}` identifies exactly one object.
-- `ParseObjectRef("s3://bucket/key")` accepts only strict `s3://bucket/key` references.
+- `ObjectRef` identifies exactly one object (`bucket`, `key`, optional version ID).
+- `ParseObjectRef` / `parseObjectRef` / `parse_object_ref` accepts only strict `s3://bucket/key` references.
   - Bucket and key are required.
   - No default bucket or default key is inferred.
   - Query strings and fragments are rejected.
   - Valid bucket and key values are preserved exactly; the parser does not normalize or URL-decode them.
-- `Store` supports only:
-  - `Put(ctx, PutInput) (ObjectRef, error)`
-  - `Get(ctx, GetInput) (*GetOutput, error)` with a required positive `MaxBytes`
-  - `Delete(ctx, DeleteInput) error`
-- `testkit/objectstore.NewStore()` provides an in-memory fake with call recording, failure injection, and copy-on-write
-  safety.
+- The store supports only:
+  - Put
+  - bounded Get with a required positive byte cap
+  - Delete
+- Local fakes provide call recording, failure injection, and copy-on-write safety:
+  - Go: `testkit/objectstore.NewStore()`
+  - TypeScript: `createFakeObjectStore()` / `FakeObjectStore`
+  - Python: `create_fake_object_store()` / `FakeObjectStore`
 
 ## S3 implementation
 
@@ -40,12 +42,38 @@ if err != nil {
 }
 ```
 
-`NewS3Store` loads AWS SDK v2 configuration and keeps the S3 client seam private to AppTheory tests. Public callers get
-only the `Store` contract.
+```ts
+const store = await createS3ObjectStore({
+  encryption: { mode: S3Encryption.S3Managed },
+});
+```
+
+```python
+store = create_s3_object_store(
+    S3ObjectStoreConfig(encryption=S3EncryptionConfig(mode=S3_ENCRYPTION_S3_MANAGED))
+)
+```
+
+Each runtime keeps the cloud-client seam private to AppTheory tests and exposes only the bounded `ObjectStore` contract.
+
+### Dependency posture
+
+The runtime dependency posture is deliberately asymmetric but explicit:
+
+- **TypeScript:** `@aws-sdk/client-s3` is a hard package dependency because `ts/src/objectstore.ts` imports the S3 client
+  at module load. GitHub Release consumers get the S3 implementation with the package, but the public surface still
+  exposes only bounded `put`/`get`/`delete` operations.
+- **Python:** `boto3` is optional and lazy. Importing `apptheory`, parsing object refs, and using the fake store do not
+  require boto3. `create_s3_object_store` fails closed with `ObjectStoreError(objectstore.invalid_store_config)` when
+  boto3 or the required `put_object` / `get_object` / `delete_object` methods are unavailable.
+- **Go:** AWS SDK dependencies are compiled into the Go helper through the normal module dependency graph.
+
+This asymmetry is a distribution policy choice only. It does not add a second object-store contract and it does not
+permit raw S3 client injection or exposure.
 
 ## Bounded reads
 
-Every `Get` call must provide a positive byte cap:
+Every Get call must provide a positive byte cap:
 
 ```go
 out, err := store.Get(ctx, objectstore.GetInput{
@@ -54,18 +82,18 @@ out, err := store.Get(ctx, objectstore.GetInput{
 })
 ```
 
-If the object body would exceed `MaxBytes`, the helper returns `objectstore.ErrObjectTooLarge`. There is no unbounded
-read method.
+If the object body would exceed the cap, the helper returns the runtime's stable `objectstore.object_too_large` error.
+There is no unbounded read method.
 
 ## Fail-closed encryption
 
 S3 encryption configuration is validated before any S3 operation can be built:
 
-- `S3EncryptionBucketDefault` emits no SSE header and relies on the bucket's default encryption policy.
-- `S3EncryptionS3Managed` emits the S3-managed AES256 SSE header.
-- `S3EncryptionKMS` emits the AWS KMS SSE header and requires `KMSKeyID`.
+- Bucket-default mode emits no SSE header and relies on the bucket's default encryption policy.
+- S3-managed mode emits the S3-managed AES256 SSE header.
+- KMS mode emits the AWS KMS SSE header and requires a KMS key ID.
 
-Invalid combinations fail closed with `objectstore.ErrInvalidEncryptionConfig`:
+Invalid combinations fail closed with the runtime's stable `objectstore.invalid_encryption_config` error:
 
 - KMS mode without a key.
 - A blank or whitespace-padded KMS key.
@@ -83,10 +111,9 @@ The helper deliberately does **not** provide:
 - public URLs
 - multipart upload
 - copy or head operations
-- raw `*s3.Client` injection or exposure
+- raw S3 client injection or exposure
 - client-side encryption
-- TypeScript or Python SDKs
 - product-specific schemas such as TheoryMCP records
 
-If an AppTheory-owned code path needs a new object-store behavior, grow this contract with tests instead of bypassing it
-with package-local S3 calls.
+If an AppTheory-owned code path needs a new object-store behavior, grow this contract with fixtures and all three
+runtime implementations instead of bypassing it with package-local S3 calls.

--- a/docs/integrations/remote-mcp.md
+++ b/docs/integrations/remote-mcp.md
@@ -132,6 +132,9 @@ Important fail-closed rules:
 - The middleware derives the RFC9728 protected-resource metadata challenge URL only from an explicit
   `ResourceMetadataURL` or from the injected `MCP_ENDPOINT`. It no longer falls back to `Host` /
   `X-Forwarded-Proto` request headers.
+- Invalid-audience bearer tokens are intentionally treated as authorization failures: the fixture-pinned response is
+  `403 app.forbidden` without a `WWW-Authenticate` challenge, matching insufficient-scope denial. Missing or expired
+  bearer tokens remain `401` discovery/challenge cases.
 
 When you deploy with `AppTheoryRemoteMcpServer`, the construct injects `MCP_ENDPOINT`. That is the canonical metadata
 source when you do not provide `ResourceMetadataURL` explicitly.

--- a/docs/reference/contract-fixtures.md
+++ b/docs/reference/contract-fixtures.md
@@ -32,15 +32,18 @@ its `tier` field and stable `id`. Directory names are organizational metadata, n
 
 | Directory | Fixture metadata | Covers |
 | --- | --- | --- |
-| `http-core/` | `p0.*` / `tier = p0` | P0 runtime core: routing, normalization, errors, source provenance, Lambda URL/ALB adapters. |
+| `http-core/` | `p0.*` / `tier = p0` | P0 runtime core: request/response normalization, source provenance, Lambda URL/ALB adapters, and baseline routing. |
 | `binding/` | `p0.binding.*` / `tier = p0` | Canonical typed-handler body/query/path/header binding, conversions, strict JSON, and binding-error envelopes. |
 | `validation/` | `p0.validation.*` / `tier = p0` | Declarative validation vocabulary, canonical 422 field-error envelope, and binding/validation precedence. |
+| `errors/` | `p0.errors.*` / `tier = p0` | Canonical framework error envelopes, panic recovery, 404/405, and Lift flat-legacy JSON parse compatibility. |
+| `routing/` | `p0.routing.*` / `tier = p0` | Fail-closed route registration setup errors for duplicate routes, invalid patterns, and nil/undefined/None handlers. |
 | `openapi/` | `p0.openapi.*` / `tier = p0` | Descriptive OpenAPI generation and byte-pinned canonical JSON output. |
 | `middleware-guardrails/` | `p1.*` / `tier = p1` | P1 request-id, tenant, auth, CORS, guardrails, and legacy flat-error behavior. |
 | `appsync-observability-policies/` | `p2.*` / `tier = p2` | P2 AppSync, observability, logging profiles, rate limiting, and load shedding. |
 | `observability/` | `p2.*` / `tier = p2` | Request-duration observability records and first-party CloudWatch EMF metric JSON lines. |
 | `mcp/` | `mcp.*` / `tier = mcp` | SP09 MCP protocol, registry, session, Streamable HTTP, resumable SSE, and task-store contracts executed by Go, TypeScript, and Python. |
 | `oauth/` | `oauth.*` / `tier = oauth` | SP12 OAuth protected-resource metadata, bearer expiry/audience/scope validation, dynamic client registration, and PKCE contracts executed by Go, TypeScript, and Python. |
+| `objectstore/` | `objectstore.*` / `tier = objectstore` | SP13 bounded object-store Put, capped Get, Delete, deterministic fake behavior, and forbidden operation errors executed by Go, TypeScript, and Python. |
 | `event-sources/` | `m1.*` / `tier = m1` | SQS, EventBridge, DynamoDB Streams, Kinesis, SNS, and non-HTTP middleware behavior. |
 | `websockets/` | `m2.*` / `tier = m2` | API Gateway WebSockets and management client fakes. |
 | `api-gateway-rest-sse/` | `m3.*` / `tier = m3` | API Gateway REST v1, Remote MCP path normalization, and SSE. |
@@ -55,7 +58,7 @@ The 216 fixtures span these behavior areas (counts approximate; see `contract-te
 
 | Category | Covers |
 | --- | --- |
-| HTTP routing | Method/path matching, parameter extraction, strict vs lenient registration, registration-order tie-breaking. |
+| HTTP routing | Method/path matching, parameter extraction, fail-closed route registration, and registration-order tie-breaking. |
 | HTTP normalization | Header lower-casing, body decoding, query parsing, cookie handling. |
 | HTTP error envelope | Nested vs flat-legacy shape, `error.code` / `error.message` / `error.details`, `request_id` propagation. |
 | Typed handlers | Body/query/path/header binding, typed conversion, strict unknown-field rejection, and binding-error details. |
@@ -75,8 +78,9 @@ The 216 fixtures span these behavior areas (counts approximate; see `contract-te
 | Kinesis | Partial-batch response, stream routing, fail-closed for unregistered streams, CloudWatch Logs subscription envelope decoding. |
 | Remote MCP path dispatch | API Gateway REST proxy path normalization for Remote MCP and protected-resource metadata routes. These HTTP-adapter fixtures are separate from the MCP and OAuth runtime tiers. |
 | MCP JSON-RPC and Streamable HTTP | The `mcp/` fixture tier pins `initialize`, JSON-RPC envelopes, tools/resources/resource-templates/prompts registries, session lifecycle, Streamable HTTP framing, resumable SSE replay, and task-store behavior across Go, TypeScript, and Python. |
-| OAuth protected resources | The `oauth/` fixture tier pins RFC 9728 protected-resource metadata, bearer `WWW-Authenticate` challenges, expiry/audience/scope denial semantics, DCR public-client constraints, and PKCE S256 verification across Go, TypeScript, and Python. |
+| OAuth protected resources | The `oauth/` fixture tier pins RFC 9728 protected-resource metadata, bearer `WWW-Authenticate` challenges, expiry/audience/scope denial semantics, DCR public-client constraints, and PKCE S256 verification across Go, TypeScript, and Python. Missing/expired bearer tokens are `401` challenge cases; invalid audience and insufficient scope are `403 app.forbidden` without a challenge. |
 | Sanitization | Token-like value redaction, JSON/XML safe-logging output. |
+| Object store | The `objectstore/` fixture tier pins strict object refs, Put, bounded Get, Delete, deterministic fake call logs, and forbidden list/presign/multipart operations across Go, TypeScript, and Python. |
 | Lambda MicroVM support | M15 foundation fixtures plus M16 real operations `run/get/list/suspend/resume/terminate/auth-token/shell-auth-token`, provider-state mappings, protected controller routes, deployment execution-role propagation, tenant-bound list/recovery, token no-leak denial, and raw SDK/lifecycle bypass denial. The feature line is evidence-bounded to repo-local runtime/CDK/example/conformance harness proof, not live AWS, EqualToAI/Host, customer workload, or unauthenticated-controller proof. |
 
 ## Running the fixtures

--- a/docs/reference/event-shapes.md
+++ b/docs/reference/event-shapes.md
@@ -25,7 +25,7 @@ def handler(event, ctx):
     return app.handle_lambda(event, ctx)
 ```
 
-You do not import a different entrypoint for SQS vs HTTP vs AppSync. The runtime does the dispatch. Go MCP servers are mounted as ordinary HTTP routes (`POST` / `GET` / `DELETE` on `/mcp`); MCP is not a separate cross-runtime event-shape heuristic.
+You do not import a different entrypoint for SQS vs HTTP vs AppSync. The runtime does the dispatch. MCP servers are mounted as ordinary HTTP routes (`POST` / `GET` / `DELETE` on `/mcp`); MCP is not a separate cross-runtime event-shape heuristic.
 
 ## Detection table
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -29,6 +29,8 @@ The full rubric runs only for PRs targeting `staging` and optional manual `workf
 
 Skipped full-rubric and deterministic-build contexts are not release/security proof. The `Release/security gates` CI job is unconditional and branch-protection-compatible; it verifies release supply-chain wiring, Release Please provenance self-tests, CI rubric enforcement, workflow invariants, and deterministic release-cycle fixtures even when the full rubric is intentionally skipped.
 
+Generated release PR artifact sync commits on both `release-please--branches--premain` and `release-please--branches--main` must be cryptographically signed before push. The sync workflow receives `RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY`, optional `RELEASE_ARTIFACT_SYNC_GPG_KEY_ID`, and optional `RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE`; if generated files changed and signing is unavailable, the workflow fails closed. Historical released bot commits remain immutable and must not be rewritten.
+
 ## Full cycle checklist
 
 ### 1. Integrate on `staging`
@@ -51,6 +53,11 @@ Skipped full-rubric and deterministic-build contexts are not release/security pr
 - CI must run the release train promotion gate and branch version sync checks.
 - The prerelease Release Please workflow must create or update the release-candidate PR. A Release Please no-op is a failed RC gate; annotated `VERSION` markers such as `# x-release-please-version` are ignored only after the leading RC semver is validated.
 - The release-candidate PR remains draft-locked while generated CDK artifacts are synchronized and required checks run.
+- When the release includes a change to `release-please-config*.json` `extra-files` entries, watch the first generated
+  `release-please--branches--premain` RC PR deliberately. Do not claim proof from static config alone: verify the
+  generated PR actually rewrites every configured JSONPath/TOML/generic file, including example
+  `packages['../../../cdk'].version` lockfile entries, and that `scripts/verify-version-alignment.sh` passes on the
+  generated head. Record the RC PR URL and check output in the promotion notes.
 - Merge the release-candidate PR only after generated artifacts are in sync and all required checks are green.
 - The prerelease publisher creates immutable assets for the `vX.Y.Z-rc.N` GitHub Release.
 
@@ -60,6 +67,12 @@ Skipped full-rubric and deterministic-build contexts are not release/security pr
 - CI must verify the promotion is `premain` → `main` and that release manifests are synchronized.
 - The stable Release Please workflow must create or update the stable release PR. A Release Please no-op is a failed stable gate.
 - The stable release PR must reset `.release-please-manifest.premain.json` to the stable version and include generated CDK artifact sync before it becomes ready.
+- Generated release-artifact sync commits must be cryptographically signed. The shared sync script fails closed when it
+  needs to create a `chore(release): sync generated release artifacts` commit and the release-artifact signing key is
+  not configured (`RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY`, optional `RELEASE_ARTIFACT_SYNC_GPG_KEY_ID`, and optional
+  `RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE`). Historical released bot commits are immutable evidence and must not be
+  rewritten; recover forward by configuring signing or by landing an explicitly approved signed-provenance alternative
+  in the release process.
 - Merge the stable release PR only after required checks pass.
 - The stable publisher creates immutable assets for the `vX.Y.Z` GitHub Release.
   `main` owns stable releases only; RC-shaped stable PR titles, versions, or tags are rejected.
@@ -96,14 +109,16 @@ When the release lane is blocked, recover by preserving evidence and re-entering
    ```bash
    bash scripts/diagnose-release-state.sh --live
    bash scripts/verify-release-state.sh --live
-  bash scripts/verify-release-workflows.sh
-  bash scripts/verify-ci-rubric-enforced.sh
+   bash scripts/verify-release-workflows.sh
+   bash scripts/verify-ci-rubric-enforced.sh
    ```
 
 2. Classify the blocker.
    - Draft GitHub Release with missing or partial assets: rerun the same publisher workflow; the publisher replaces draft assets safely and verifies branch provenance before publication.
    - Published GitHub Release already exists: rerun the publisher only to verify immutable assets match the source build; do not upload or edit assets.
    - Stale Release Please PR: regenerate or sync Release Please state from the current branch baseline; do not merge the stale PR.
+   - Unsigned generated artifact sync attempt: configure the release-artifact sync signing key and rerun the generated
+     release PR workflow; do not rewrite existing released commits or bypass signing.
    - Promotion drift: recreate the promotion PR from the valid branch heads in the cycle.
    - Back-merge drift: merge `main` back into `staging` before accepting further staging work.
 

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -100,7 +100,7 @@ func TestHello(t *testing.T) {
 
 ## Route registration
 
-Fluent route registration fails closed: invalid patterns, duplicate method/pattern pairs, and nil handlers panic during registration instead of silently producing a dead route. The strict helpers remain as deprecated compatibility wrappers when a caller still needs an error-returning shape:
+Fluent route registration fails closed: invalid patterns, duplicate method/pattern pairs, and nil handlers panic during registration instead of silently producing a dead route. Strict helpers remain deprecated compatibility wrappers when a caller still needs an error-returning shape, and their errors now use canonical `AppTheoryError` messages where applicable:
 
 ```go
 if _, err := app.GetStrict("/users/{id}", h); err != nil {
@@ -112,7 +112,7 @@ TypeScript and Python follow the same fail-closed registration contract.
 
 ## HTTP error format
 
-Default HTTP error envelopes are nested under `error`. `AppTheoryError` is the canonical client-safe error type for new code; `AppError` remains supported for code/message compatibility. Legacy `JSONHandler` emits Lift-era `EMPTY_BODY` and `INVALID_JSON` internally, but the default HTTP envelope remaps those to `app.bad_request`. To match Lift's flat shape and preserve those legacy codes:
+Default HTTP error envelopes are nested under `error`. `AppTheoryError` is the canonical client-safe error type for new code; `AppError` remains supported for code/message compatibility. Any HTTP error whose code string is `EMPTY_BODY` or `INVALID_JSON` is remapped by the default nested envelope to `app.bad_request`. To match Lift's flat shape and preserve those legacy codes/messages:
 
 ```go
 app := apptheory.New(apptheory.WithHTTPErrorFormat(apptheory.HTTPErrorFormatFlatLegacy))

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -95,7 +95,16 @@ app.get("/users/{id}", handler)
 ```
 
 Normal fluent registration fails closed on invalid patterns, duplicates, and `None` handlers. `handle_strict` remains as
-a deprecated compatibility wrapper for callers that still need the old helper shape.
+a deprecated compatibility wrapper for callers that still need the old helper shape; it now raises `AppTheoryError`
+rather than `ValueError` for registration failures.
+
+
+## Object-store dependency posture
+
+The Python package intentionally keeps `boto3` optional and lazy for `create_s3_object_store`. Importing `apptheory` or
+using the fake object store does not require boto3; constructing the S3-backed store fails closed with a stable
+`ObjectStoreError` if boto3 or the required S3 methods are unavailable. This differs from TypeScript's hard S3 SDK
+dependency by design and does not widen the object-store contract.
 
 ## HTTP error format
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -5,7 +5,7 @@ description: The TypeScript implementation of the AppTheory contract — bundled
 
 # TypeScript Runtime
 
-The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. It executes all [216 contract fixtures](../reference/contract-fixtures.md), including the SP09 MCP fixture tier for JSON-RPC, registries, sessions, Streamable HTTP, resumable SSE, task stores, and the SP13 objectstore tier. <!-- apptheory-fixture-count: 216 -->
+The TypeScript runtime is an independent implementation of the AppTheory contract — not a port of the Go runtime. It executes all [216 contract fixtures](../reference/contract-fixtures.md), including the SP09 MCP fixture tier for JSON-RPC, registries, sessions, Streamable HTTP, resumable SSE, task stores, the SP12 OAuth tier, and the SP13 objectstore tier. <!-- apptheory-fixture-count: 216 -->
 
 ## Install
 
@@ -106,6 +106,14 @@ const app = createApp({ httpErrorFormat: HTTP_ERROR_FORMAT_FLAT_LEGACY });
 ```
 
 Applies to HTTP error serialization only.
+
+
+## Object-store dependency posture
+
+The TypeScript package intentionally declares `@aws-sdk/client-s3` as a hard dependency because `createS3ObjectStore`
+imports the S3 client at module load. This keeps the packaged S3 helper deterministic for GitHub Release consumers while
+still exposing only the bounded AppTheory `ObjectStore` contract — no raw client, list, presign, or multipart escape
+hatches.
 
 ## Lambda Function URL streaming
 

--- a/gov-infra/planning/docs-init-examples/_patterns.yaml
+++ b/gov-infra/planning/docs-init-examples/_patterns.yaml
@@ -39,14 +39,12 @@ patterns:
           - "Parity regressions"
 
   strict_route_registration:
-    name: "Use strict route registration in tests and CI"
-    problem: "Invalid patterns may be ignored on non-strict registration paths."
-    solution: "Use GetStrict/HandleStrict/handleStrict/handle_strict to fail fast."
+    name: "Use normal fail-closed route registration"
+    problem: "Invalid patterns, duplicate method/path pairs, and nil/undefined/None handlers must fail during setup."
+    solution: "Use normal fluent registration and run startup tests that construct every route."
     correct_example: |
       # CORRECT
-      if _, err := app.GetStrict("/users/{id}", h); err != nil {
-        panic(err)
-      }
+      app.Get("/users/{id}", h)
     anti_patterns:
       - name: "Assuming invalid routes will always error"
         why: "Compatibility behavior can hide invalid route declarations."

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -695,9 +695,10 @@ gov_cmd_unit() {
   require_cmd_or_blocked node || return $?
   require_cmd_or_blocked python3 || return $?
 
-  # QUA-1 is the unit-test gate. Contract fixtures run exactly once in CON-3,
-  # so the rubric's Go unit pass excludes the fixture runner package whose
-  # TestAllFixturesPass executes the full corpus.
+  # QUA-1 is the unit-test gate. The direct, uninstrumented contract suite runs
+  # once in CON-3; TS/Python coverage may rerun fixtures under instrumentation
+  # for coverage evidence. Keep Go runner meta-tests in QUA-1 without rerunning
+  # the full corpus by skipping only TestAllFixturesPass.
   local -a go_unit_pkgs=()
   mapfile -t go_unit_pkgs < <(./scripts/list-go-packages.sh | grep -Ev '^\./contract-tests/runners/go$')
   if [[ "${#go_unit_pkgs[@]}" -eq 0 ]]; then
@@ -705,6 +706,7 @@ gov_cmd_unit() {
     return 1
   fi
   go test "${go_unit_pkgs[@]}"
+  go test ./contract-tests/runners/go -skip '^TestAllFixturesPass$'
 
   ensure_ts_runtime_deps_installed || return $?
   scripts/verify-ts-tests.sh
@@ -1251,7 +1253,9 @@ ensure_py_coverage_pinned() {
 
 check_ts_coverage() {
   # Enforces TypeScript runtime coverage >= COV_THRESHOLD for the shipped JS under ts/dist/.
-  # Primary driver: contract fixtures (same semantics as CON-3), but measured against ts/dist/**.
+  # Instrumented coverage deliberately reruns the fixture corpus after CON-3 so
+  # the coverage denominator measures shipped ts/dist/** behavior. This is not
+  # a second direct/uninstrumented contract pass.
   require_cmd_or_blocked node || return $?
   ensure_ts_runtime_deps_installed || return $?
 
@@ -1301,7 +1305,9 @@ check_ts_coverage() {
 
 check_py_coverage() {
   # Enforces Python runtime coverage >= COV_THRESHOLD for the shipped package under py/src/apptheory/.
-  # Primary driver: contract fixtures (same semantics as CON-3), but measured against py/src/apptheory/**.
+  # Instrumented coverage deliberately reruns the fixture corpus after CON-3 so
+  # the coverage denominator measures shipped py/src/apptheory/** behavior. This
+  # is not a second direct/uninstrumented contract pass.
   require_cmd_or_blocked python3 || return $?
   ensure_py_coverage_pinned || return $?
   ensure_py_runtime_deps_installed_into "${GOV_TOOLS_PY_COV_BIN}/python" || return $?

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -618,6 +618,70 @@ path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 PY
 }
 
+configure_release_artifact_sync_signing() {
+  if ! command -v gpg >/dev/null 2>&1; then
+    echo "sync-release-pr-generated: FAIL (gpg not found; generated release-artifact sync commits must be signed)"
+    exit 1
+  fi
+
+  if [[ -z "${RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY:-}" ]]; then
+    echo "sync-release-pr-generated: FAIL (RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY is required to sign generated release-artifact sync commits)"
+    exit 1
+  fi
+
+  local gpg_home
+  gpg_home="$(mktemp -d)"
+  chmod 700 "${gpg_home}"
+  export GNUPGHOME="${gpg_home}"
+  trap 'rm -rf "${GNUPGHOME:-}"' EXIT
+
+  local key_file
+  key_file="$(mktemp)"
+  if grep -Fq "BEGIN PGP PRIVATE KEY BLOCK" <<<"${RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY}"; then
+    printf '%s\n' "${RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY}" >"${key_file}"
+  elif ! printf '%s' "${RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY}" | base64 --decode >"${key_file}" 2>/dev/null; then
+    rm -f "${key_file}"
+    echo "sync-release-pr-generated: FAIL (release-artifact signing key must be armored or base64-encoded GPG private key)"
+    exit 1
+  fi
+
+  if ! gpg --batch --import "${key_file}" >/dev/null 2>&1; then
+    rm -f "${key_file}"
+    echo "sync-release-pr-generated: FAIL (could not import release-artifact signing key)"
+    exit 1
+  fi
+  rm -f "${key_file}"
+
+  local key_id
+  key_id="${RELEASE_ARTIFACT_SYNC_GPG_KEY_ID:-}"
+  if [[ -z "${key_id}" ]]; then
+    key_id="$(
+      gpg --batch --list-secret-keys --with-colons --fingerprint \
+        | awk -F: '$1 == "fpr" { print $10; exit }'
+    )"
+  fi
+  if [[ -z "${key_id}" ]]; then
+    echo "sync-release-pr-generated: FAIL (could not determine release-artifact signing key id)"
+    exit 1
+  fi
+
+  if [[ -n "${RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE:-}" ]]; then
+    local gpg_wrapper
+    gpg_wrapper="${gpg_home}/gpg-wrapper"
+    cat >"${gpg_wrapper}" <<'EOF'
+#!/usr/bin/env bash
+exec gpg --batch --yes --pinentry-mode loopback --passphrase "${RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE}" "$@"
+EOF
+    chmod 700 "${gpg_wrapper}"
+    git config gpg.program "${gpg_wrapper}"
+  else
+    git config gpg.program gpg
+  fi
+
+  git config commit.gpgsign true
+  git config user.signingkey "${key_id}"
+}
+
 # The release PR must not be mergeable while generated artifacts are still being
 # rewritten. This is the release-lane invariant: release-please version files and
 # generated CDK/jsii artifacts land in the same release PR before it becomes
@@ -636,8 +700,10 @@ if ! git diff --quiet -- .release-please-manifest.premain.json cdk/.jsii cdk/lib
 
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  configure_release_artifact_sync_signing
   git add .release-please-manifest.premain.json cdk/.jsii cdk/lib cdk-go/apptheorycdk
-  git commit -m "chore(release): sync generated release artifacts"
+  git commit -S -m "chore(release): sync generated release artifacts"
+  git verify-commit HEAD
 fi
 
 go test ./cdk-go/apptheorycdk

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -672,6 +672,16 @@ require_contains(
     "release PR postcondition verifier self-test must cover annotated RC VERSION values",
 )
 require_contains(
+    "docs/release-process.md",
+    "watch the first generated",
+    "release process runbook must keep an evidence-bounded first-RC watch for release-please extra-files changes",
+)
+require_contains(
+    "docs/release-process.md",
+    "Generated release-artifact sync commits must be cryptographically signed",
+    "release process runbook must document generated artifact sync signing requirements",
+)
+require_contains(
     "scripts/sync-release-pr-generated.sh",
     "--raw-field run_full_rubric=false",
     "automated release PR CI dispatch must disable the full rubric",
@@ -690,6 +700,21 @@ require_contains(
     "scripts/sync-release-pr-generated.sh",
     'gh pr ready "${pr_number}" --undo',
     "release PR sync must force the release PR back to draft before generated artifact work",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY",
+    "release PR sync must require a configured signing key before creating generated artifact commits",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'git commit -S -m "chore(release): sync generated release artifacts"',
+    "release PR sync must cryptographically sign generated artifact commits",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "git verify-commit HEAD",
+    "release PR sync must verify generated artifact commit signatures before pushing",
 )
 require_not_contains(
     "scripts/sync-release-pr-generated.sh",
@@ -712,6 +737,24 @@ for workflow in (".github/workflows/prerelease-pr.yml", ".github/workflows/relea
         "actions/setup-python",
         "Sync generated CDK artifacts on release PR",
         "release PR workflow must install Python before running the full release PR gate set",
+    )
+    require_step_contains(
+        workflow,
+        "Sync generated CDK artifacts on release PR",
+        "RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_PRIVATE_KEY }}",
+        "release PR artifact sync step must receive the configured signing key",
+    )
+    require_step_contains(
+        workflow,
+        "Sync generated CDK artifacts on release PR",
+        "RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_PASSPHRASE }}",
+        "release PR artifact sync step must receive the configured signing passphrase",
+    )
+    require_step_contains(
+        workflow,
+        "Sync generated CDK artifacts on release PR",
+        "RELEASE_ARTIFACT_SYNC_GPG_KEY_ID: ${{ secrets.RELEASE_ARTIFACT_SYNC_GPG_KEY_ID }}",
+        "release PR artifact sync step must receive the configured signing key id when set",
     )
     require_order(
         workflow,


### PR DESCRIPTION
## Summary
- Documented SP04 fail-closed registration / canonical error follow-ups across upgrade, runtime, fixture, and API docs.
- Hardened SP03 release/rubric hygiene: Go runner meta-tests remain in the rubric, TS/Python fixture coverage reruns are explicitly instrumented coverage, and the first Release Please RC extra-files watch is evidence-bounded.
- Required future generated release-artifact sync commits to be GPG-signed before push, with release workflow/meta-gate coverage.
- Made the SP12 OAuth invalid-audience decision explicit: keep fixture-pinned `403 app.forbidden` without `WWW-Authenticate`.
- Documented the SP13 object-store dependency posture: TypeScript keeps hard `@aws-sdk/client-s3`; Python keeps optional/lazy boto3 and fails closed.

## Validation
- Baseline before branch: `make rubric` — PASS on `project/improvement-program@f2144601202fd03a9951fa8446f40d01de6669ba`.
- Targeted checks: `bash -n scripts/sync-release-pr-generated.sh scripts/verify-release-workflows.sh gov-infra/verifiers/gov-verify-rubric.sh`; YAML parse for touched workflow/pattern files; `scripts/sync-release-pr-generated.sh --self-test`; `bash scripts/verify-release-workflows.sh`; `bash scripts/verify-ci-rubric-enforced.sh`; `bash scripts/verify-fixture-count.sh`; `bash scripts/verify-fixture-schema.sh`; `bash scripts/verify-api-docs.sh`; `go test ./contract-tests/runners/go -skip '^TestAllFixturesPass$'` — PASS.
- Final full gate: `make rubric` — PASS.
- Signature verification: `git log --show-signature --pretty=fuller --no-patch project/improvement-program..HEAD` and `git verify-commit` for each new commit — PASS.

## Issue closeout
Closes THE-2529
Closes THE-2530
Closes THE-2531
Closes THE-2532
Closes THE-2526
Closes THE-2528
Closes THE-2539
Closes THE-2542
Closes THE-2543

## Notes
No release was performed, no live cloud/account/DNS/secrets state was touched, and no historical release commits were rewritten.
