### PR TITLE
chore(premain): promote release automation repair

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -29,13 +29,31 @@ The full rubric runs only for PRs targeting `staging` and optional manual `workf
 
 Skipped full-rubric and deterministic-build contexts are not release/security proof. The `Release/security gates` CI job is unconditional and branch-protection-compatible; it verifies release supply-chain wiring, release branch signature history, Release Please provenance self-tests, CI rubric enforcement, workflow invariants, and deterministic release-cycle fixtures even when the full rubric is intentionally skipped.
 
-Generated release PR artifact sync commits on both `release-please--branches--premain` and `release-please--branches--main` must be cryptographically signed before push, but CI is not a signing key holder. The sync workflow may draft-lock the release PR, regenerate artifacts, and prove whether a generated sync commit is needed. If generated files changed, CI fails closed without committing, pushing, importing signing material, or using private signing secrets. A steward/operator must then run the local signed sync path from a clean checkout; that path uses the normal existing git commit signing configuration and verifies the resulting commit before any push.
+Generated release PR artifact sync commits on both `release-please--branches--premain` and
+`release-please--branches--main` are product release-automation commits. CI is not a signing key holder
+and no workflow-held private signing key exists. The sync workflow draft-locks the release PR, regenerates
+artifacts, proves the diff is limited to the generated release-artifact allowlist, and, when a commit is
+needed, creates exactly one GitHub GraphQL `createCommitOnBranch` commit with
+`chore(release): sync generated release artifacts` and `expectedHeadOid` set to the fetched release-branch
+head. GitHub signs that commit server-side, the workflow fetches the resulting head, and the release branch
+signature gate must accept it as GitHub verified-valid before required CI is dispatched or the release PR is
+marked ready. The workflow does not `git push` a CI-created artifact commit, import signing material, set git
+signing config, or use private signing secrets.
 
-Release Please commits created by the GitHub API are only GitHub-verified unless local evidence proves a stronger signer. Do not describe them as Aron/canonical-key signed merely because GitHub marks them verified. Generated artifact sync commits are different: they must be locally verifiable signed commits from the normal steward/operator signing path.
+Release Please commits and generated artifact sync commits created by GitHub automation are GitHub-verified
+unless local evidence proves a stronger signer. Do not describe them as Aron/canonical-key signed merely
+because GitHub marks them verified. Delegate implementation commits for normal PRs remain locally signed by
+the steward/operator under the repository's existing signing configuration; the GitHub-verified release
+automation commits are limited to generated release PR version/artifact synchronization.
 
 The signed-history repair boundary is the repaired branch base `c723c42c71d9220f49702db965d4deffff6183f1`. Protected branch and release-please branch security gates reject commits in the repaired branch ranges unless the commit is either locally trusted-good (`%G?=G`) or GitHub-verified with `verified=true` and `reason=valid`. GitHub Actions runners may report SSH-signed commits as `local_status=N` when they lack the local `gpg.ssh.allowedSignersFile`; that state is accepted only with GitHub verified-valid evidence, and true unsigned commits still fail closed. Immutable v1.15.x release tags are an accepted residual exception: `v1.15.0` contains two historical unsigned generated sync commits, `v1.15.1` contains four, and `v1.15.2` contains six. Those published tags, releases, notes, metadata, and assets must not be changed; recover forward through the normal `staging` → `premain` → `main` train.
 
-Safe provenance claims are scoped: repaired branch tips from `c723c42c71d9220f49702db965d4deffff6183f1` forward are guarded against commits that are neither locally trusted-good nor GitHub verified-valid, generated sync commits must be locally trusted-good before push, and GitHub API release-please commits may be called GitHub-verified when the verification API reports `verified=true` and `reason=valid`. Unsafe claims are rejected: do not claim all released tag history is signed, do not claim GitHub-verified API commits are Aron/canonical-key signed without local evidence, and do not claim CI can sign generated sync commits by holding private signing material.
+Safe provenance claims are scoped: repaired branch tips from `c723c42c71d9220f49702db965d4deffff6183f1`
+forward are guarded against commits that are neither locally trusted-good nor GitHub verified-valid, and
+GitHub API Release Please/generated artifact sync commits may be called GitHub-verified when the verification
+API reports `verified=true` and `reason=valid`. Unsafe claims are rejected: do not claim all released tag
+history is signed, do not claim GitHub-verified API commits are Aron/canonical-key signed without local
+evidence, and do not claim CI can sign generated sync commits by holding private signing material.
 
 ## Full cycle checklist
 
@@ -73,9 +91,10 @@ Safe provenance claims are scoped: repaired branch tips from `c723c42c71d9220f49
 - CI must verify the promotion is `premain` → `main` and that release manifests are synchronized.
 - The stable Release Please workflow must create or update the stable release PR. A Release Please no-op is a failed stable gate.
 - The stable release PR must reset `.release-please-manifest.premain.json` to the stable version and include generated CDK artifact sync before it becomes ready.
-- Generated release-artifact sync commits must be cryptographically signed. The shared sync script fails closed in CI
-  when it needs to create a `chore(release): sync generated release artifacts` commit, leaves the release PR draft, and
-  prints the local signed sync command. Do not add CI-held signing secrets to make this pass; run the local path below.
+- Generated release-artifact sync commits are created automatically by the shared sync script as GitHub-verified
+  product-automation commits. Do not add CI-held signing secrets; the workflow token creates the server-side signed
+  `chore(release): sync generated release artifacts` commit through `createCommitOnBranch`, then verifies the new
+  range before the PR can become ready.
 - Merge the stable release PR only after required checks pass.
 - The stable publisher creates immutable assets for the `vX.Y.Z` GitHub Release.
   `main` owns stable releases only; RC-shaped stable PR titles, versions, or tags are rejected.
@@ -122,8 +141,11 @@ When the release lane is blocked, recover by preserving evidence and re-entering
    - Draft GitHub Release with missing or partial assets: rerun the same publisher workflow; the publisher replaces draft assets safely and verifies branch provenance before publication.
    - Published GitHub Release already exists: rerun the publisher only to verify immutable assets match the source build; do not upload or edit assets.
    - Stale Release Please PR: regenerate or sync Release Please state from the current branch baseline; do not merge the stale PR.
-   - Generated artifact sync pending: keep the release PR draft and run the local signed sync path. Do not configure
-     workflow-held private signing material, do not rewrite existing released commits, and do not bypass signing.
+   - Generated artifact sync pending: keep the release PR draft and rerun the release PR sync workflow so it can
+     create the GitHub-verified generated artifact commit and prove the signature range. Use the local signed
+     fallback below only when GitHub automation is unavailable and an operator deliberately performs the offline
+     recovery. Do not configure workflow-held private signing material, do not rewrite existing released commits,
+     and do not bypass signing.
    - Promotion drift: recreate the promotion PR from the valid branch heads in the cycle.
    - Back-merge drift: merge `main` back into `staging` before accepting further staging work.
 
@@ -140,9 +162,13 @@ When the release lane is blocked, recover by preserving evidence and re-entering
 
 4. If the framework cannot express the needed recovery, add a verifier-backed release-process change first. Do not create a one-off manual path around the train.
 
-## Local signed generated-artifact sync
+## Emergency/offline local signed generated-artifact sync fallback
 
-Use this only for generated release PR branches that are already open and draft-locked. It is the same release train; it is not a direct push to `premain` or `main`.
+The primary path is automated: the release PR workflow creates the generated artifact sync commit as a
+GitHub-verified `createCommitOnBranch` product-automation commit and then dispatches the required checks. Use
+this local path only as an emergency/offline fallback for generated release PR branches that are already open and
+draft-locked, for example when GitHub automation is unavailable and a human operator explicitly accepts the
+offline recovery. It is the same release train; it is not a direct push to `premain` or `main`.
 
 ```bash
 git fetch origin
@@ -153,6 +179,11 @@ git log --show-signature -1
 git verify-commit HEAD
 ```
 
-The script starts from a clean checkout, fetches the release PR branch, regenerates only release artifact files, stages only `.release-please-manifest.premain.json`, `cdk/.jsii`, `cdk/lib`, and `cdk-go/apptheorycdk`, then runs plain `git commit -m "chore(release): sync generated release artifacts"`. It does not set `user.signingkey`, replace the signing program, import keys, or add passphrases. If the normal local signing configuration does not produce a locally trusted-good signature, the script fails before pushing and reports the signature status.
+The script starts from a clean checkout, fetches the release PR branch, regenerates only release artifact files,
+stages only `.release-please-manifest.premain.json`, `cdk/.jsii`, `cdk/lib`, and `cdk-go/apptheorycdk`, then
+runs plain `git commit -m "chore(release): sync generated release artifacts"`. It does not set
+`user.signingkey`, replace the signing program, import keys, or add passphrases. If the normal local signing
+configuration does not produce a locally trusted-good signature, the script fails before pushing and reports the
+signature status.
 
 After the signed sync commit is pushed, the script waits for the release PR head, dispatches the release hygiene/build checks with the full rubric disabled, and marks the release PR ready only after the generated-artifact head still matches and required checks pass.

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+artifact_sync_commit_message="chore(release): sync generated release artifacts"
+
 default_required_checks() {
   cat <<'EOF'
 Version alignment
@@ -211,15 +213,27 @@ release_artifact_sync_can_commit_locally() {
   [[ "${local_signed_sync_requested:-false}" == "true" ]] && ! is_ci_environment
 }
 
+release_artifact_sync_mode() {
+  if is_ci_environment; then
+    echo "github-verified-api"
+    return 0
+  fi
+  if release_artifact_sync_can_commit_locally; then
+    echo "local-signed"
+    return 0
+  fi
+  echo "manual-local-signed-required"
+}
+
 render_local_signed_sync_instructions() {
   local branch="$1"
   cat <<EOF
-sync-release-pr-generated: generated release artifacts changed, but CI is not a signing key holder.
-sync-release-pr-generated: leave the release PR draft and run the local signed sync path from a clean checkout:
+sync-release-pr-generated: generated release artifacts changed outside GitHub Actions.
+sync-release-pr-generated: leave the release PR draft and run the local signed sync fallback from a clean checkout:
 sync-release-pr-generated:   git fetch origin
 sync-release-pr-generated:   bash scripts/sync-release-pr-generated.sh --local-signed-sync ${branch}
 sync-release-pr-generated: The local path uses normal existing git commit signing configuration only.
-sync-release-pr-generated: It does not import signing keys, set signing config, or use CI-held signing secrets.
+sync-release-pr-generated: It does not import signing material, set signing config, or use CI-held signing secrets.
 EOF
 }
 
@@ -233,18 +247,36 @@ run_signed_sync_mode_self_test() {
     echo "sync-release-pr-generated self-test: FAIL (default mode must not create local sync commits)" >&2
     exit 1
   fi
+  if [[ "$(release_artifact_sync_mode)" != "manual-local-signed-required" ]]; then
+    echo "sync-release-pr-generated self-test: FAIL (default non-CI mode must require explicit local signed fallback)" >&2
+    exit 1
+  fi
 
   local_signed_sync_requested=true
   if ! release_artifact_sync_can_commit_locally; then
     echo "sync-release-pr-generated self-test: FAIL (explicit local mode should allow local sync commits outside CI)" >&2
     exit 1
   fi
+  if [[ "$(release_artifact_sync_mode)" != "local-signed" ]]; then
+    echo "sync-release-pr-generated self-test: FAIL (explicit local mode should select local signed fallback outside CI)" >&2
+    exit 1
+  fi
 
   GITHUB_ACTIONS=true
   if release_artifact_sync_can_commit_locally; then
-    echo "sync-release-pr-generated self-test: FAIL (GitHub Actions must never create sync commits)" >&2
+    echo "sync-release-pr-generated self-test: FAIL (GitHub Actions must never use local sync commits)" >&2
     exit 1
   fi
+  if [[ "$(release_artifact_sync_mode)" != "github-verified-api" ]]; then
+    echo "sync-release-pr-generated self-test: FAIL (GitHub Actions must select createCommitOnBranch sync mode)" >&2
+    exit 1
+  fi
+  local_signed_sync_requested=true
+  if [[ "$(release_artifact_sync_mode)" != "github-verified-api" ]]; then
+    echo "sync-release-pr-generated self-test: FAIL (GitHub Actions must not fall back to local signing when local mode is requested)" >&2
+    exit 1
+  fi
+  local_signed_sync_requested=false
   unset GITHUB_ACTIONS
   if [[ -n "${old_github_actions}" ]]; then
     GITHUB_ACTIONS="${old_github_actions}"
@@ -259,7 +291,8 @@ run_signed_sync_mode_self_test() {
     echo "sync-release-pr-generated self-test: FAIL (pending-sync instructions must name local signed sync command)" >&2
     exit 1
   fi
-  if [[ "${instructions}" == *"PRIVATE_KEY"* ]]; then
+  local forbidden_private_key="PRIVATE""_KEY"
+  if [[ "${instructions}" == *"${forbidden_private_key}"* ]]; then
     echo "sync-release-pr-generated self-test: FAIL (pending-sync instructions must not mention private signing secrets)" >&2
     exit 1
   fi
@@ -267,21 +300,82 @@ run_signed_sync_mode_self_test() {
   echo "sync-release-pr-generated self-test: PASS signed-sync-mode"
 }
 
+run_sync_secret_material_self_test() {
+  local script_text
+  script_text="$(cat scripts/sync-release-pr-generated.sh)"
+
+  local forbidden_private_key="PRIVATE""_KEY"
+  local forbidden_release_sync_gpg="RELEASE_ARTIFACT_SYNC_""GPG"
+  local forbidden_gpg_import="gpg ""--import"
+  local forbidden_signing_key="git config user.""signingkey"
+  local forbidden_gpg_program="git config gpg.""program"
+  local forbidden_commit_signing="git config commit.""gpgsign true"
+  local forbidden_commit_dash_s="git commit ""-S"
+
+  for forbidden in \
+    "${forbidden_private_key}" \
+    "${forbidden_release_sync_gpg}" \
+    "${forbidden_gpg_import}" \
+    "${forbidden_signing_key}" \
+    "${forbidden_gpg_program}" \
+    "${forbidden_commit_signing}" \
+    "${forbidden_commit_dash_s}"
+  do
+    if [[ "${script_text}" == *"${forbidden}"* ]]; then
+      echo "sync-release-pr-generated self-test: FAIL (script contains forbidden signing material/config pattern)" >&2
+      exit 1
+    fi
+  done
+
+  if [[ "${script_text}" != *"createCommitOnBranch"* ]]; then
+    echo "sync-release-pr-generated self-test: FAIL (CI artifact sync must use createCommitOnBranch)" >&2
+    exit 1
+  fi
+  if [[ "${script_text}" != *"github-verified-api"* ]]; then
+    echo "sync-release-pr-generated self-test: FAIL (CI artifact sync mode must be named github-verified-api)" >&2
+    exit 1
+  fi
+
+  echo "sync-release-pr-generated self-test: PASS signing-material-policy"
+}
+
 if [[ "${1:-}" == "--self-test" ]]; then
   run_required_check_classifier_self_test
   run_signed_sync_mode_self_test
+  run_sync_secret_material_self_test
   exit 0
 fi
 
 local_signed_sync_requested=false
-if [[ "${1:-}" == "--local-signed-sync" ]]; then
-  local_signed_sync_requested=true
-  shift
-fi
+print_plan_requested=false
+while [[ "${1:-}" == --* ]]; do
+  case "${1:-}" in
+    --local-signed-sync)
+      local_signed_sync_requested=true
+      shift
+      ;;
+    --print-plan)
+      print_plan_requested=true
+      shift
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+usage: scripts/sync-release-pr-generated.sh [--print-plan] [--local-signed-sync] <release-branch>|--self-test
+
+--print-plan prints the non-mutating GitHub API commit plan after regenerating
+release artifacts. It does not send createCommitOnBranch or push.
+USAGE
+      exit 0
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 release_branch="${1:-}"
 if [[ -z "${release_branch}" ]]; then
-  echo "sync-release-pr-generated: FAIL (usage: $0 [--local-signed-sync] <release-branch>|--self-test)" >&2
+  echo "sync-release-pr-generated: FAIL (usage: $0 [--print-plan] [--local-signed-sync] <release-branch>|--self-test)" >&2
   exit 1
 fi
 
@@ -730,6 +824,223 @@ if unexpected:
 PY
 }
 
+build_release_artifact_sync_commit_payload() {
+  local branch="$1"
+  local expected_head="$2"
+  local repo="$3"
+  local payload_file="$4"
+  local summary_file="$5"
+
+  RELEASE_BRANCH="${branch}" \
+    EXPECTED_HEAD_OID="${expected_head}" \
+    REPOSITORY_NAME_WITH_OWNER="${repo}" \
+    ARTIFACT_SYNC_COMMIT_MESSAGE="${artifact_sync_commit_message}" \
+    PAYLOAD_FILE="${payload_file}" \
+    SUMMARY_FILE="${summary_file}" \
+    python3 - <<'PY'
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PATHS = [
+    ".release-please-manifest.premain.json",
+    "cdk/.jsii",
+    "cdk/lib",
+    "cdk-go/apptheorycdk",
+]
+
+
+def zlines(args: list[str]) -> list[str]:
+    raw = subprocess.check_output(args)
+    return [item for item in raw.decode("utf-8", "surrogateescape").split("\0") if item]
+
+
+tracked_additions = zlines(["git", "diff", "--name-only", "-z", "--diff-filter=ACMRT", "HEAD", "--", *PATHS])
+tracked_deletions = zlines(["git", "diff", "--name-only", "-z", "--diff-filter=D", "HEAD", "--", *PATHS])
+untracked_additions = zlines(["git", "ls-files", "--others", "--exclude-standard", "-z", "--", *PATHS])
+
+addition_paths = sorted(set(tracked_additions + untracked_additions))
+deletion_paths = sorted(set(tracked_deletions) - set(addition_paths))
+
+additions = []
+for path in addition_paths:
+    file_path = Path(path)
+    if not file_path.is_file():
+        print(f"sync-release-pr-generated: FAIL (planned addition is not a file: {path})", file=sys.stderr)
+        sys.exit(1)
+    additions.append(
+        {
+            "path": path,
+            "contents": base64.b64encode(file_path.read_bytes()).decode("ascii"),
+        }
+    )
+
+deletions = [{"path": path} for path in deletion_paths]
+
+summary = {
+    "mode": os.environ.get("ARTIFACT_SYNC_MODE", ""),
+    "branch": os.environ["RELEASE_BRANCH"],
+    "expectedHeadOid": os.environ["EXPECTED_HEAD_OID"],
+    "message": os.environ["ARTIFACT_SYNC_COMMIT_MESSAGE"],
+    "additionCount": len(additions),
+    "deletionCount": len(deletions),
+    "additions": addition_paths,
+    "deletions": deletion_paths,
+}
+
+payload = {
+    "query": """
+mutation CreateReleaseArtifactSyncCommit($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit {
+      oid
+      url
+    }
+  }
+}
+""",
+    "variables": {
+        "input": {
+            "branch": {
+                "repositoryNameWithOwner": os.environ["REPOSITORY_NAME_WITH_OWNER"],
+                "branchName": os.environ["RELEASE_BRANCH"],
+            },
+            "message": {
+                "headline": os.environ["ARTIFACT_SYNC_COMMIT_MESSAGE"],
+            },
+            "fileChanges": {
+                "additions": additions,
+                "deletions": deletions,
+            },
+            "expectedHeadOid": os.environ["EXPECTED_HEAD_OID"],
+        },
+    },
+}
+
+Path(os.environ["PAYLOAD_FILE"]).write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+Path(os.environ["SUMMARY_FILE"]).write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+print_release_artifact_sync_plan() {
+  local expected_head="$1"
+  local repo="$2"
+  local mode="$3"
+
+  local payload_file
+  local summary_file
+  payload_file="$(mktemp)"
+  summary_file="$(mktemp)"
+  ARTIFACT_SYNC_MODE="${mode}" build_release_artifact_sync_commit_payload \
+    "${release_branch}" \
+    "${expected_head}" \
+    "${repo}" \
+    "${payload_file}" \
+    "${summary_file}"
+
+  cat "${summary_file}"
+  rm -f "${payload_file}" "${summary_file}"
+}
+
+verify_github_verified_commit() {
+  local sha="$1"
+  local context="$2"
+  local repo="$3"
+
+  local verification
+  if ! verification="$(
+    gh api "repos/${repo}/commits/${sha}" \
+      --jq '[.commit.verification.verified, .commit.verification.reason, (.commit.verification.signer.login // ""), (.commit.verification.key_id // "")] | @tsv'
+  )"; then
+    echo "sync-release-pr-generated: FAIL (${context} GitHub verification evidence unavailable for ${sha})" >&2
+    exit 1
+  fi
+
+  local verified reason signer key
+  IFS=$'\t' read -r verified reason signer key <<<"${verification}"
+  if [[ "${verified}" != "true" || "${reason}" != "valid" ]]; then
+    echo "sync-release-pr-generated: FAIL (${context} is not GitHub verified-valid; verified=${verified:-unknown} reason=${reason:-unknown})" >&2
+    exit 1
+  fi
+
+  echo "sync-release-pr-generated: ${context} GitHub verification verified=${verified} reason=${reason} signer=${signer:-unknown} key=${key:-unknown}"
+}
+
+verify_github_synced_head() {
+  local expected_head="$1"
+  local new_head="$2"
+  local repo="$3"
+
+  git fetch origin "${release_branch}"
+  local fetched_head
+  fetched_head="$(git rev-parse FETCH_HEAD)"
+  if [[ "${fetched_head}" != "${new_head}" ]]; then
+    echo "sync-release-pr-generated: FAIL (${release_branch} fetched head ${fetched_head} does not match created commit ${new_head})" >&2
+    exit 1
+  fi
+
+  verify_github_verified_commit "${new_head}" "generated release-artifact sync" "${repo}"
+  scripts/verify-release-branch-signatures.sh \
+    --range "${expected_head}..${new_head}" \
+    --label "release-artifact-sync:${release_branch}"
+}
+
+commit_release_artifact_sync_via_github() {
+  local expected_head="$1"
+  local repo="$2"
+
+  if [[ -n "${GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
+    export GH_TOKEN="${GITHUB_TOKEN}"
+  fi
+
+  local payload_file
+  local summary_file
+  local response_file
+  payload_file="$(mktemp)"
+  summary_file="$(mktemp)"
+  response_file="$(mktemp)"
+
+  ARTIFACT_SYNC_MODE="github-verified-api" build_release_artifact_sync_commit_payload \
+    "${release_branch}" \
+    "${expected_head}" \
+    "${repo}" \
+    "${payload_file}" \
+    "${summary_file}"
+
+  local addition_count
+  local deletion_count
+  addition_count="$(python3 -c 'import json,sys; data=json.load(open(sys.argv[1])); print(data["additionCount"])' "${summary_file}")"
+  deletion_count="$(python3 -c 'import json,sys; data=json.load(open(sys.argv[1])); print(data["deletionCount"])' "${summary_file}")"
+  if [[ "${addition_count}" == "0" && "${deletion_count}" == "0" ]]; then
+    echo "sync-release-pr-generated: FAIL (generated artifacts changed, but the GitHub commit plan is empty)" >&2
+    rm -f "${payload_file}" "${summary_file}" "${response_file}"
+    exit 1
+  fi
+
+  echo "sync-release-pr-generated: creating GitHub-verified generated release-artifact sync commit on ${release_branch}" >&2
+  echo "sync-release-pr-generated: plan addition_count=${addition_count} deletion_count=${deletion_count} expected_head=${expected_head}" >&2
+
+  if ! gh api graphql --input "${payload_file}" --jq '.data.createCommitOnBranch.commit.oid' >"${response_file}"; then
+    rm -f "${payload_file}" "${summary_file}" "${response_file}"
+    echo "sync-release-pr-generated: FAIL (createCommitOnBranch generated artifact sync mutation failed)" >&2
+    exit 1
+  fi
+
+  local new_head
+  new_head="$(cat "${response_file}")"
+  rm -f "${payload_file}" "${summary_file}" "${response_file}"
+
+  if [[ -z "${new_head}" || "${new_head}" == "null" ]]; then
+    echo "sync-release-pr-generated: FAIL (createCommitOnBranch did not return a commit oid)" >&2
+    exit 1
+  fi
+
+  echo "${new_head}"
+}
+
 require_existing_local_signing_config() {
   local commit_gpgsign
   commit_gpgsign="$(git config --bool --get commit.gpgsign || true)"
@@ -768,11 +1079,15 @@ verify_head_locally_signed() {
 commit_release_artifact_sync_locally() {
   require_existing_local_signing_config
   git add .release-please-manifest.premain.json cdk/.jsii cdk/lib cdk-go/apptheorycdk
-  if ! git commit -m "chore(release): sync generated release artifacts"; then
+  if ! git commit -m "${artifact_sync_commit_message}"; then
     echo "sync-release-pr-generated: FAIL (normal local git commit failed; no CI signing fallback exists)" >&2
     exit 1
   fi
   verify_head_locally_signed "generated release-artifact sync"
+}
+
+push_local_signed_release_artifact_sync() {
+  git push origin HEAD:"${release_branch}"
 }
 
 # The release PR must not be mergeable while generated artifacts are still being
@@ -783,7 +1098,9 @@ require_clean_worktree
 ensure_release_pr_is_draft "before generated artifacts are synced"
 
 git fetch origin "${release_branch}"
-git switch --detach FETCH_HEAD
+expected_head="$(git rev-parse FETCH_HEAD)"
+git switch --detach "${expected_head}"
+require_pr_head "${expected_head}" "after fetching release branch"
 
 sync_stable_release_premain_manifest
 scripts/update-cdk-generated.sh >/dev/null
@@ -793,24 +1110,40 @@ artifact_status="$(git status --porcelain=v1 --untracked-files=all -- .release-p
 if [[ -n "${artifact_status}" ]]; then
   changed=true
   require_only_release_artifact_changes
+fi
 
-  if ! release_artifact_sync_can_commit_locally; then
-    render_local_signed_sync_instructions "${release_branch}" >&2
-    exit 1
-  fi
+repo="$(repo_full_name)"
+sync_mode="$(release_artifact_sync_mode)"
 
-  commit_release_artifact_sync_locally
+if [[ "${print_plan_requested}" == "true" ]]; then
+  print_release_artifact_sync_plan "${expected_head}" "${repo}" "${sync_mode}"
+  exit 0
 fi
 
 go test ./cdk-go/apptheorycdk
 
-ensure_release_pr_is_draft "before generated artifacts are pushed"
-
 if [[ "${changed}" == "true" ]]; then
-  git push origin HEAD:"${release_branch}"
+  case "${sync_mode}" in
+    local-signed)
+      commit_release_artifact_sync_locally
+      synced_head="$(git rev-parse HEAD)"
+      ensure_release_pr_is_draft "before generated artifacts are pushed"
+      push_local_signed_release_artifact_sync
+      ;;
+    github-verified-api)
+      ensure_release_pr_is_draft "before creating GitHub-verified generated artifact sync commit"
+      require_pr_head "${expected_head}" "before creating GitHub-verified generated artifact sync commit"
+      synced_head="$(commit_release_artifact_sync_via_github "${expected_head}" "${repo}")"
+      verify_github_synced_head "${expected_head}" "${synced_head}" "${repo}"
+      ;;
+    *)
+      render_local_signed_sync_instructions "${release_branch}" >&2
+      exit 1
+      ;;
+  esac
+else
+  synced_head="${expected_head}"
 fi
-
-synced_head="$(git rev-parse HEAD)"
 
 wait_for_pr_head "${synced_head}"
 # After the generated-artifact head is visible, rely only on independent PR

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -688,7 +688,7 @@ require_contains(
 )
 for forbidden in (
     "RELEASE_ARTIFACT_SYNC_" + "GPG",
-    "RELEASE_ARTIFACT_SYNC_" + "GPG_PRIVATE_KEY",
+    "RELEASE_ARTIFACT_SYNC_" + "GPG_" + "PRIVATE" + "_KEY",
     "RELEASE_ARTIFACT_SYNC_" + "GPG_KEY_ID",
     "RELEASE_ARTIFACT_SYNC_" + "GPG_PASSPHRASE",
 ):
@@ -726,17 +726,81 @@ require_contains(
 require_contains(
     "scripts/sync-release-pr-generated.sh",
     "--local-signed-sync",
-    "release PR sync must provide an explicit local signed artifact sync path",
+    "release PR sync must retain an explicit offline local signed artifact sync fallback",
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
-    'git commit -m "chore(release): sync generated release artifacts"',
-    "release PR sync must use normal local git commit signing configuration",
+    'artifact_sync_commit_message="chore(release): sync generated release artifacts"',
+    "release PR sync must use one stable generated artifact sync commit message",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'git commit -m "${artifact_sync_commit_message}"',
+    "local signed release PR sync fallback must use normal local git commit signing configuration",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "createCommitOnBranch",
+    "CI release PR sync must create generated artifact commits through GitHub server-side verified automation",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "github-verified-api",
+    "release PR sync self-test must prove CI selects the GitHub-verified API mode",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    '"expectedHeadOid": os.environ["EXPECTED_HEAD_OID"]',
+    "GitHub API generated artifact sync must use optimistic expectedHeadOid concurrency",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "gh api graphql --input",
+    "CI generated artifact sync must send a GraphQL createCommitOnBranch mutation",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "verify_github_synced_head",
+    "CI generated artifact sync must fetch and verify the GitHub-created commit before continuing",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "push_local_signed_release_artifact_sync",
+    "release PR sync must isolate git push to the offline local signed fallback",
+)
+require_order_after(
+    "scripts/sync-release-pr-generated.sh",
+    'case "${sync_mode}" in',
+    "local-signed)",
+    "push_local_signed_release_artifact_sync",
+    "only the local signed fallback may push a generated artifact commit",
+)
+require_order_after(
+    "scripts/sync-release-pr-generated.sh",
+    'case "${sync_mode}" in',
+    "github-verified-api)",
+    "commit_release_artifact_sync_via_github",
+    "CI generated artifact sync must use GitHub API commit creation instead of git push",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'scripts/verify-release-branch-signatures.sh',
+    "CI generated artifact sync must prove the new release branch commit is accepted by the signature gate",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    '--range "${expected_head}..${new_head}"',
+    "CI generated artifact sync signature proof must scan exactly the created commit range",
 )
 require_not_contains(
     "scripts/sync-release-pr-generated.sh",
     'git commit -S -m "chore(release): sync generated release artifacts"',
     "release PR sync must not force a bespoke CI signing path",
+)
+require_not_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "gpg --import",
+    "release PR sync must not import signing material",
 )
 require_not_contains(
     "scripts/sync-release-pr-generated.sh",
@@ -765,8 +829,8 @@ require_contains(
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
-    "GitHub Actions must never create sync commits",
-    "release PR sync self-test must prove CI cannot create generated sync commits",
+    "GitHub Actions must select createCommitOnBranch sync mode",
+    "release PR sync self-test must prove CI uses GitHub-verified product automation instead of a manual stop",
 )
 require_contains(
     ".github/workflows/ci.yml",
@@ -836,7 +900,7 @@ require_order(
 )
 require_order_after(
     "scripts/sync-release-pr-generated.sh",
-    "git switch --detach FETCH_HEAD",
+    'git switch --detach "${expected_head}"',
     "sync_stable_release_premain_manifest",
     "scripts/update-cdk-generated.sh",
     "stable premain manifest reset must happen before regenerating artifacts",
@@ -846,11 +910,32 @@ require_contains(
     "git add .release-please-manifest.premain.json cdk/.jsii cdk/lib cdk-go/apptheorycdk",
     "stable release PR sync must commit the premain manifest reset with generated release artifacts",
 )
-require_order(
+require_contains(
     "scripts/sync-release-pr-generated.sh",
     'synced_head="$(git rev-parse HEAD)"',
+    "local signed release PR sync must capture the local signed generated-artifact head",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'synced_head="$(commit_release_artifact_sync_via_github "${expected_head}" "${repo}")"',
+    "CI release PR sync must capture the GitHub-created generated-artifact head",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'synced_head="${expected_head}"',
+    "release PR sync must preserve the fetched release PR head when generated artifacts are already current",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    'synced_head="$(commit_release_artifact_sync_via_github "${expected_head}" "${repo}")"',
+    'verify_github_synced_head "${expected_head}" "${synced_head}" "${repo}"',
+    "CI release PR sync must verify the GitHub-created generated-artifact head before waiting for it",
+)
+require_order(
+    "scripts/sync-release-pr-generated.sh",
+    'verify_github_synced_head "${expected_head}" "${synced_head}" "${repo}"',
     'wait_for_pr_head "${synced_head}"',
-    "release PR sync must capture the generated-artifact head before waiting for it",
+    "release PR sync must prove the GitHub-created commit signature before checking independent CI",
 )
 require_order(
     "scripts/sync-release-pr-generated.sh",


### PR DESCRIPTION
## Summary
Promotes the AppTheory release automation repair from `staging` to `premain` so the premain prerelease workflow can exercise the automated GitHub-verified generated artifact sync path.

Included staging work:
- PR #795: `fix(release): automate generated artifact sync commits`
- Implementation commit `b919273a012ec352490b25bb6fd1678bf3cd3dc5` is locally SSH-signed (`%G?=G`, signer `aron23@gmail.com`).
- Staging merge commit `a15438f91d2d71005f63ee99d992980edc5d5452` is GitHub verified-valid.

Factory review evidence:
- Full-context adversarial review: `/home/aron/.claude/tmp/delegate-claude-session/20260707T152253Z-AppTheory-948164/final.md` — ACCEPT, no blockers.
- PR #795 checks passed after mark-ready, including `Rubric (full gate set)`, `Release/security gates`, deterministic builds, CodeQL, and runtime matrices.
- `bash scripts/verify-release-branch-signatures.sh --range origin/premain..origin/staging --label staging-to-premain-prereq` — PASS.
- No CI signing secrets: `RELEASE_ARTIFACT_SYNC_GPG_*` remains absent.

Purpose / residual proof
- This PR is the next step toward repairing PR #792. After merge to `premain`, the `Prerelease PR (premain)` workflow must prove the new behavior by creating a GitHub-verified generated-artifact sync commit on the release-please branch and marking the release PR ready.
- Do not claim the release process is fully repaired until that premain workflow receipt exists.

Non-goals
- No release tags or immutable releases are changed by this PR.
- PR #792 remains draft/open until the premain workflow successfully completes the generated artifact sync and checks.