### PR TITLE
fix(release): validate cdk-go sync via nested module

### DIFF
--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -1120,7 +1120,7 @@ if [[ "${print_plan_requested}" == "true" ]]; then
   exit 0
 fi
 
-go test ./cdk-go/apptheorycdk
+bash scripts/verify-cdk-go.sh
 
 if [[ "${changed}" == "true" ]]; then
   case "${sync_mode}" in

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -912,6 +912,16 @@ require_contains(
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
+    "bash scripts/verify-cdk-go.sh",
+    "release PR sync must validate generated CDK Go bindings through the nested-module verifier",
+)
+require_not_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "go test ./cdk-go/apptheorycdk",
+    "release PR sync must not test the nested cdk-go package from the root Go module",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
     'synced_head="$(git rev-parse HEAD)"',
     "local signed release PR sync must capture the local signed generated-artifact head",
 )


### PR DESCRIPTION
## Intent

Fix the release PR generated-artifact sync gate that failed on premain run 28881137348 by validating the generated CDK Go bindings through the existing nested-module verifier.

## Change

- Replace the root-module `go test ./cdk-go/apptheorycdk` call with `bash scripts/verify-cdk-go.sh`.
- Add a release workflow verifier invariant that requires the nested-module verifier and rejects the old root-module package command.

## Validation

- `bash scripts/sync-release-pr-generated.sh --self-test` — PASS
- `bash scripts/verify-release-workflows.sh` — PASS
- `bash scripts/verify-cdk-go.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-release-branch-signatures.sh --self-test` — PASS
- `git grep -n 'RELEASE_ARTIFACT_SYNC_GPG\|PRIVATE_KEY' -- .github scripts docs || true` — no output
- `make test` — PASS (`version-alignment: PASS (1.15.2)`)

## Notes

- No CI signing secrets or private-key signing path were added.
- PR #792 was only read-inspected (`OPEN`, draft, `release-please--branches--premain` at `c28f7b8`); no release PR content was mutated.
- I did not run `sync-release-pr-generated.sh --print-plan` against the live release PR branch because that mode still draft-locks and regenerates files before printing, so it is not a strictly non-mutating proof on this checkout.
