### PR TITLE
chore(premain): promote release sync cdk-go verification fix

### DIFF
--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -1120,7 +1120,7 @@ if [[ "${print_plan_requested}" == "true" ]]; then
   exit 0
 fi
 
-go test ./cdk-go/apptheorycdk
+bash scripts/verify-cdk-go.sh
 
 if [[ "${changed}" == "true" ]]; then
   case "${sync_mode}" in

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -912,6 +912,16 @@ require_contains(
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
+    "bash scripts/verify-cdk-go.sh",
+    "release PR sync must validate generated CDK Go bindings through the nested-module verifier",
+)
+require_not_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "go test ./cdk-go/apptheorycdk",
+    "release PR sync must not test the nested cdk-go package from the root Go module",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
     'synced_head="$(git rev-parse HEAD)"',
     "local signed release PR sync must capture the local signed generated-artifact head",
 )


### PR DESCRIPTION
Promotes the release/RC automation repair follow-up from staging to premain.

Included staging change:
- PR #797: `fix(release): validate cdk-go sync via nested module`
  - fixes the premain run 28881137348 failure where `sync-release-pr-generated.sh` tested `./cdk-go/apptheorycdk` from the root Go module;
  - routes the sync step through `scripts/verify-cdk-go.sh`, which validates the nested `cdk-go` module;
  - adds a release-workflow invariant so the broken root-module command cannot return.

Factory evidence:
- PR #797 adversarial review ACCEPT: `/home/aron/.claude/tmp/delegate-claude-session/20260707T162505Z-AppTheory-1026908/final.md`.
- PR #797 merged to staging as `8d37ee11ef1e776d0603b5f59655515ac19f9470` after green CI.
- Promotion range signature gate: `bash scripts/verify-release-branch-signatures.sh --range origin/premain..origin/staging --label pr797-promotion-range` PASS.

Residual gate after merge:
- A fresh `Prerelease PR (premain)` run must prove PR #792 generated-artifact sync is fully automated.