### PR TITLE
chore(premain): promote prerelease version alignment fix

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,7 +21,7 @@ No branch may skip a leg of that cycle. `premain` only receives `staging`, `main
 | `premain` | Prerelease branch. | Human `staging` promotion PRs and generated `release-please--branches--premain` RC PRs only. |
 | `main` | Stable release branch. | Human `premain` promotion PRs and generated `release-please--branches--main` stable PRs only. |
 
-Release automation is driven by Conventional Commits. `feat:` and `fix:` entries ship; `docs:`, `test:`, `chore:`, and `refactor:` do not trigger a release by themselves. Version state must remain aligned across `VERSION`, TypeScript and CDK package manifests and lockfiles, Python metadata, and both Release Please manifests.
+Release automation is driven by Conventional Commits. `feat:` and `fix:` entries ship; `docs:`, `test:`, `chore:`, and `refactor:` do not trigger a release by themselves. Version state must remain aligned across `VERSION`, TypeScript and CDK package manifests and lockfiles, Python metadata, and the active Release Please manifest for the release lane. Stable releases align both Release Please manifests to the stable version; prerelease branches keep `.release-please-manifest.json` on the last stable version while `.release-please-manifest.premain.json` tracks the RC version.
 
 Upgrade policy is maintained separately from the generated changelog. When a minor line changes runtime behavior, deployment defaults, dependency floors, generated-artifact expectations, or deprecation posture, update `UPGRADING.md` in the same change or release-prep PR. The changelog lists commits; `UPGRADING.md` lists consumer action and per-line compatibility notes.
 

--- a/scripts/verify-version-alignment.sh
+++ b/scripts/verify-version-alignment.sh
@@ -6,27 +6,108 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if [[ "${1:-}" == "--self-test" ]]; then
   tmp_dir="$(mktemp -d)"
-  tmp_log="$(mktemp)"
   cleanup() {
     rm -rf "${tmp_dir}"
-    rm -f "${tmp_log}"
   }
   trap cleanup EXIT
 
-  mkdir -p "${tmp_dir}/scripts" "${tmp_dir}/ts" "${tmp_dir}/cdk" "${tmp_dir}/cdk-go" "${tmp_dir}/py" "${tmp_dir}/examples/cdk"
-  cp VERSION go.mod .release-please-manifest.json .release-please-manifest.premain.json \
-    release-please-config.json release-please-config.premain.json "${tmp_dir}/"
-  cp cdk-go/go.mod "${tmp_dir}/cdk-go/"
-  cp scripts/read-version.sh scripts/verify-version-alignment.sh "${tmp_dir}/scripts/"
-  cp ts/package.json ts/package-lock.json "${tmp_dir}/ts/"
-  cp cdk/package.json cdk/package-lock.json cdk/.jsii "${tmp_dir}/cdk/"
-  cp py/pyproject.toml "${tmp_dir}/py/"
-  while IFS= read -r lockfile; do
-    mkdir -p "${tmp_dir}/$(dirname "${lockfile}")"
-    cp "${lockfile}" "${tmp_dir}/${lockfile}"
-  done < <(find examples/cdk -maxdepth 2 -name package-lock.json -print | sort)
+  copy_fixture() {
+    local fixture_dir="$1"
 
-  python3 - "${tmp_dir}/cdk/.jsii" <<'PY'
+    mkdir -p "${fixture_dir}/scripts" "${fixture_dir}/ts" "${fixture_dir}/cdk" \
+      "${fixture_dir}/cdk-go" "${fixture_dir}/py" "${fixture_dir}/examples/cdk"
+    cp VERSION go.mod .release-please-manifest.json .release-please-manifest.premain.json \
+      release-please-config.json release-please-config.premain.json "${fixture_dir}/"
+    cp cdk-go/go.mod "${fixture_dir}/cdk-go/"
+    cp scripts/read-version.sh scripts/verify-version-alignment.sh "${fixture_dir}/scripts/"
+    cp ts/package.json ts/package-lock.json "${fixture_dir}/ts/"
+    cp cdk/package.json cdk/package-lock.json cdk/.jsii "${fixture_dir}/cdk/"
+    cp py/pyproject.toml "${fixture_dir}/py/"
+    while IFS= read -r lockfile; do
+      mkdir -p "${fixture_dir}/$(dirname "${lockfile}")"
+      cp "${lockfile}" "${fixture_dir}/${lockfile}"
+    done < <(find examples/cdk -maxdepth 2 -name package-lock.json -print | sort)
+  }
+
+  write_version_state() {
+    local fixture_dir="$1"
+    local version="$2"
+    local stable_manifest="$3"
+    local premain_manifest="$4"
+
+    python3 - "${fixture_dir}" "${version}" "${stable_manifest}" "${premain_manifest}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+version = sys.argv[2]
+stable_manifest = sys.argv[3]
+premain_manifest = sys.argv[4]
+
+root.joinpath("VERSION").write_text(f"{version} # x-release-please-version\n", encoding="utf-8")
+root.joinpath(".release-please-manifest.json").write_text(
+    json.dumps({".": stable_manifest}, indent=2) + "\n", encoding="utf-8"
+)
+root.joinpath(".release-please-manifest.premain.json").write_text(
+    json.dumps({".": premain_manifest}, indent=2) + "\n", encoding="utf-8"
+)
+
+for rel in ("ts/package.json", "ts/package-lock.json", "cdk/package.json", "cdk/package-lock.json", "cdk/.jsii"):
+    path = root / rel
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["version"] = version
+    packages = data.get("packages")
+    if isinstance(packages, dict) and isinstance(packages.get(""), dict):
+        packages[""]["version"] = version
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+for lock_path in root.glob("examples/cdk/*/package-lock.json"):
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    packages = data.get("packages")
+    cdk_package = packages.get("../../../cdk") if isinstance(packages, dict) else None
+    if isinstance(cdk_package, dict) and "version" in cdk_package:
+        cdk_package["version"] = version
+        lock_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+pyproject = root.joinpath("py/pyproject.toml")
+text = pyproject.read_text(encoding="utf-8")
+text, count = re.subn(r'(?m)^version = "[^"]+"', f'version = "{version}"', text, count=1)
+if count != 1:
+    raise SystemExit("could not update py/pyproject.toml version")
+pyproject.write_text(text, encoding="utf-8")
+PY
+  }
+
+  run_self_test_case() {
+    local label="$1"
+    local fixture_dir="$2"
+    local expected_exit="$3"
+    local expected_output="$4"
+    local output
+    local status
+
+    set +e
+    output="$(cd "${fixture_dir}" && bash scripts/verify-version-alignment.sh 2>&1)"
+    status=$?
+    set -e
+
+    if [[ "${status}" != "${expected_exit}" ]]; then
+      echo "version-alignment-self-test: FAIL (${label}; expected exit ${expected_exit}, got ${status})" >&2
+      echo "${output}" >&2
+      exit 1
+    fi
+    if [[ "${output}" != *"${expected_output}"* ]]; then
+      echo "version-alignment-self-test: FAIL (${label}; missing ${expected_output@Q})" >&2
+      echo "${output}" >&2
+      exit 1
+    fi
+  }
+
+  jsii_skew_dir="${tmp_dir}/jsii-skew"
+  copy_fixture "${jsii_skew_dir}"
+  python3 - "${jsii_skew_dir}/cdk/.jsii" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -36,17 +117,22 @@ data = json.loads(path.read_text(encoding="utf-8"))
 data["version"] = "0.0.0-self-test"
 path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 PY
+  run_self_test_case "deliberate cdk/.jsii skew" "${jsii_skew_dir}" 1 "cdk/.jsii"
 
-  if (cd "${tmp_dir}" && bash scripts/verify-version-alignment.sh >"${tmp_log}" 2>&1); then
-    echo "version-alignment-self-test: FAIL (deliberate cdk/.jsii skew passed)" >&2
-    cat "${tmp_log}" >&2
-    exit 1
-  fi
-  if ! grep -Fq "cdk/.jsii" "${tmp_log}"; then
-    echo "version-alignment-self-test: FAIL (skew failure did not mention cdk/.jsii)" >&2
-    cat "${tmp_log}" >&2
-    exit 1
-  fi
+  prerelease_split_dir="${tmp_dir}/prerelease-split"
+  copy_fixture "${prerelease_split_dir}"
+  write_version_state "${prerelease_split_dir}" "1.16.0-rc" "1.15.2" "1.16.0-rc"
+  run_self_test_case "prerelease manifest split" "${prerelease_split_dir}" 0 "version-alignment: PASS (1.16.0-rc)"
+
+  wrong_premain_dir="${tmp_dir}/wrong-premain"
+  copy_fixture "${wrong_premain_dir}"
+  write_version_state "${wrong_premain_dir}" "1.16.0-rc" "1.15.2" "1.15.2"
+  run_self_test_case "wrong prerelease premain manifest" "${wrong_premain_dir}" 1 ".release-please-manifest.premain.json"
+
+  stable_manifest_skew_dir="${tmp_dir}/stable-manifest-skew"
+  copy_fixture "${stable_manifest_skew_dir}"
+  write_version_state "${stable_manifest_skew_dir}" "1.16.0" "1.15.2" "1.16.0"
+  run_self_test_case "stable manifest skew" "${stable_manifest_skew_dir}" 1 ".release-please-manifest.json"
 
   echo "version-alignment-self-test: PASS"
   exit 0
@@ -240,6 +326,7 @@ fi
 
 python3 - "${expected_version}" <<'PY'
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -265,11 +352,27 @@ def load_json(path: Path) -> dict:
         errors.append(f"{path}: failed to parse JSON: {exc}")
         return {}
 
-for manifest_path in (Path(".release-please-manifest.json"), Path(".release-please-manifest.premain.json")):
-    data = load_json(manifest_path)
-    observed = data.get(".") if isinstance(data, dict) else None
-    if observed != expected:
-        errors.append(f"{manifest_path}: . version {observed!r} != {expected!r}")
+expected_is_rc = re.match(r"^[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$", expected) is not None
+stable_version_pattern = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+stable_manifest_path = Path(".release-please-manifest.json")
+stable_manifest = load_json(stable_manifest_path)
+stable_observed = stable_manifest.get(".") if isinstance(stable_manifest, dict) else None
+if expected_is_rc:
+    if not isinstance(stable_observed, str) or stable_version_pattern.match(stable_observed) is None:
+        errors.append(
+            f"{stable_manifest_path}: . version {stable_observed!r} must remain a stable X.Y.Z version "
+            f"when VERSION is prerelease {expected!r}"
+        )
+else:
+    if stable_observed != expected:
+        errors.append(f"{stable_manifest_path}: . version {stable_observed!r} != {expected!r}")
+
+premain_manifest_path = Path(".release-please-manifest.premain.json")
+premain_manifest = load_json(premain_manifest_path)
+premain_observed = premain_manifest.get(".") if isinstance(premain_manifest, dict) else None
+if premain_observed != expected:
+    errors.append(f"{premain_manifest_path}: . version {premain_observed!r} != {expected!r}")
 
 jsii = load_json(Path("cdk/.jsii"))
 if jsii.get("version") != expected:


### PR DESCRIPTION
Promotes the prerelease Version alignment repair from staging to premain.

Included staging change:
- PR #799: `fix(release): allow prerelease manifest split`
  - fixes PR #792 CI failure where prerelease branches have `VERSION=1.16.0-rc`, `.release-please-manifest.premain.json=1.16.0-rc`, and stable `.release-please-manifest.json=1.15.2`;
  - preserves stable release fail-closed behavior while allowing prerelease lanes to keep the stable manifest at the last stable version;
  - adds self-test coverage for the exact prerelease split and wrong-manifest failure cases.

Factory evidence:
- PR #799 adversarial review ACCEPT: `/home/aron/.claude/tmp/delegate-claude-session/20260707T171132Z-AppTheory-1054148/final.md`.
- PR #799 merged to staging as `e5a17fc96150b55ee12b72a00fe373dbfda0c000` after green CI.
- Promotion range signature gate: `bash scripts/verify-release-branch-signatures.sh --range origin/premain..origin/staging --label pr799-promotion-range` PASS.

Residual gate after merge:
- A fresh `Prerelease PR (premain)` run and/or dispatched PR #792 CI must prove the release candidate flow is fully automated and green.