### PR TITLE
fix(release): harden token and CI trigger boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,20 @@ on:
         required: false
         type: boolean
         default: true
+      release_pr_number:
+        description: "Generated release PR number for head-bound release checks"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   release-train-promotion:
     name: Release train promotion gate
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_pr_number != '')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted release gate code
@@ -36,6 +42,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR_NUMBER: ${{ inputs.release_pr_number }}
+          DISPATCH_HEAD_REF: ${{ github.ref_name }}
+          DISPATCH_HEAD_SHA: ${{ github.sha }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
@@ -43,6 +53,32 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ ! "${DISPATCH_PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              echo "release-train-promotion: FAIL (workflow_dispatch requires a numeric release_pr_number)" >&2
+              exit 1
+            fi
+
+            pr_line="$(
+              gh api "repos/${GITHUB_REPOSITORY}/pulls/${DISPATCH_PR_NUMBER}" \
+                --jq '[.state, .base.ref, .head.ref, .head.repo.full_name, .head.sha, .title] | @tsv'
+            )"
+            IFS=$'\t' read -r pr_state PR_BASE_REF PR_HEAD_REF PR_HEAD_REPOSITORY PR_HEAD_SHA PR_TITLE <<<"${pr_line}"
+
+            if [[ "${pr_state}" != "open" ]]; then
+              echo "release-train-promotion: FAIL (release PR #${DISPATCH_PR_NUMBER} is ${pr_state:-unknown})" >&2
+              exit 1
+            fi
+            if [[ "${PR_HEAD_REPOSITORY}" != "${GITHUB_REPOSITORY}" ]]; then
+              echo "release-train-promotion: FAIL (release PR head repository ${PR_HEAD_REPOSITORY} != ${GITHUB_REPOSITORY})" >&2
+              exit 1
+            fi
+            if [[ "${PR_HEAD_REF}" != "${DISPATCH_HEAD_REF}" || "${PR_HEAD_SHA}" != "${DISPATCH_HEAD_SHA}" ]]; then
+              echo "release-train-promotion: FAIL (dispatched ref ${DISPATCH_HEAD_REF}@${DISPATCH_HEAD_SHA} != PR head ${PR_HEAD_REF}@${PR_HEAD_SHA})" >&2
+              exit 1
+            fi
+          fi
 
           base_ref_args=()
           pr_title_args=()

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -45,7 +45,9 @@ jobs:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
+          # Wrapper stages release-please@17.1.3 without credentials in npm and
+          # invokes its parser in-process with an environment-only token. It
+          # always applies --draft-pull-request internally.
           scripts/run-release-please-pr.sh \
             --target-branch premain \
             --config-file release-please-config.premain.json \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -128,7 +128,9 @@ jobs:
           # NOTE: release-please-action currently does not apply `release-as` when using
           # `config-file`+`manifest-file` (manifest mode). Use the CLI so the stable
           # release PR can be forced to the premain RC baseline.
-          # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
+          # Wrapper stages release-please@17.1.3 without credentials in npm and
+          # invokes its parser in-process with an environment-only token. It
+          # always applies --draft-pull-request internally.
           scripts/run-release-please-pr.sh \
             --target-branch main \
             --config-file release-please-config.json \
@@ -142,7 +144,9 @@ jobs:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          # Wrapper pins release-please@17.1.3 and always passes --draft-pull-request.
+          # Wrapper stages release-please@17.1.3 without credentials in npm and
+          # invokes its parser in-process with an environment-only token. It
+          # always applies --draft-pull-request internally.
           scripts/run-release-please-pr.sh \
             --target-branch main \
             --config-file release-please-config.json \

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -31,9 +31,11 @@ Generated release PRs have one CI trigger. Release Please version commits and ge
 `[skip ci]` in the commit body so their automation-originated `pull_request` `opened` and `synchronize` events do
 not create stale or duplicate CI runs. After the final generated-artifact head is visible and signature-verified,
 the sync workflow starts one explicit `workflow_dispatch` CI run for that exact head, waits for every required
-context, rechecks that the head is unchanged, and only then marks the PR ready. The skip marker does not bypass
-validation: it suppresses only automatic `push`/`pull_request` triggers; the explicit CI dispatch remains required
-and fails closed.
+context (including the release-train promotion and release/security gates), rechecks that the head is unchanged,
+and only then marks the PR ready. The dispatch carries the exact release PR number; the promotion gate loads that
+PR through GitHub's API and fails unless its repository, branch, and SHA match the dispatched ref. The skip marker
+does not bypass validation: it suppresses only automatic `push`/`pull_request` triggers; the explicit CI dispatch
+remains required and fails closed.
 
 Skipped full-rubric and deterministic-build contexts are not release/security proof. The `Release/security gates` CI job is unconditional and branch-protection-compatible; it verifies release supply-chain wiring, release branch signature history, Release Please provenance self-tests, CI rubric enforcement, workflow invariants, and deterministic release-cycle fixtures even when the full rubric is intentionally skipped.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -27,7 +27,30 @@ Upgrade policy is maintained separately from the generated changelog. When a min
 
 The full rubric runs only for PRs targeting `staging` and optional manual `workflow_dispatch` CI runs. Manual CI dispatch defaults to running the rubric; generated release-PR artifact sync dispatches CI with the full rubric disabled and waits only for release hygiene/build checks. The standalone `Verify deterministic builds` CI job also runs only for PRs targeting `staging`; generated release PR sync must not require or wait for that skipped context. `premain` and `main` run release hygiene, branch version sync, release-branch provenance, package build, and publish postcondition checks; they must not run the full rubric or deterministic-build job on release publish paths.
 
+Generated release PRs have one CI trigger. Release Please version commits and generated-artifact sync commits carry
+`[skip ci]` in the commit body so their automation-originated `pull_request` `opened` and `synchronize` events do
+not create stale or duplicate CI runs. After the final generated-artifact head is visible and signature-verified,
+the sync workflow starts one explicit `workflow_dispatch` CI run for that exact head, waits for every required
+context, rechecks that the head is unchanged, and only then marks the PR ready. The skip marker does not bypass
+validation: it suppresses only automatic `push`/`pull_request` triggers; the explicit CI dispatch remains required
+and fails closed.
+
 Skipped full-rubric and deterministic-build contexts are not release/security proof. The `Release/security gates` CI job is unconditional and branch-protection-compatible; it verifies release supply-chain wiring, release branch signature history, Release Please provenance self-tests, CI rubric enforcement, workflow invariants, and deterministic release-cycle fixtures even when the full rubric is intentionally skipped.
+
+### Release credential boundary
+
+Release Please credentials are environment-only secrets. They must never be placed in shell, npm, Node, or
+operating-system process arguments. `scripts/run-release-please-pr.sh` is the only supported Release Please CLI
+entry point. Its transport stages the pinned `release-please@17.1.3` package in an npm process from which
+`RELEASE_PLEASE_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` have all been removed. Only after npm exits does the
+launcher provide `RELEASE_PLEASE_TOKEN` to the Release Please parser in-process; ambient GitHub credentials are
+removed from that process as well. The package staging step also disables lifecycle scripts and fails closed if
+any GitHub credential reaches the npm boundary.
+
+Do not replace this path with `npx`, `npm exec`, or a direct `release-please --token ...` invocation. npm can log
+its command arguments, and operating-system process arguments are observable outside the invoking process. Run
+`bash scripts/verify-release-please-token-safety.sh` to exercise the sentinel regression test. The release
+workflow verifier runs that test automatically.
 
 Generated release PR artifact sync commits on both `release-please--branches--premain` and
 `release-please--branches--main` are product release-automation commits. CI is not a signing key holder

--- a/scripts/invoke-release-please-pr.mjs
+++ b/scripts/invoke-release-please-pr.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Purpose: invoke release-please with its credential held in memory, never in npm or OS process arguments.
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+class SafeInvocationError extends Error {}
+
+function fail(message) {
+  console.error(`release-please-pr: FAIL (${message})`);
+  process.exitCode = 1;
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name] ?? "";
+  if (value.length === 0) {
+    throw new SafeInvocationError(`missing ${name}`);
+  }
+  if (value.includes("\n") || value.includes("\r")) {
+    throw new SafeInvocationError(`invalid ${name}`);
+  }
+  return value;
+}
+
+function buildReleasePleaseArgs() {
+  const releasePleaseArgs = [
+    "release-pr",
+    "--token",
+    requiredEnvironment("RELEASE_PLEASE_TOKEN"),
+    "--repo-url",
+    requiredEnvironment("RELEASE_PLEASE_REPO_URL"),
+    "--target-branch",
+    requiredEnvironment("RELEASE_PLEASE_TARGET_BRANCH"),
+    "--config-file",
+    requiredEnvironment("RELEASE_PLEASE_CONFIG_FILE"),
+    "--manifest-file",
+    requiredEnvironment("RELEASE_PLEASE_MANIFEST_FILE"),
+    "--draft-pull-request",
+  ];
+
+  const releaseAs = process.env.RELEASE_PLEASE_RELEASE_AS ?? "";
+  if (releaseAs.includes("\n") || releaseAs.includes("\r")) {
+    throw new SafeInvocationError("invalid RELEASE_PLEASE_RELEASE_AS");
+  }
+  if (releaseAs.length > 0) {
+    releasePleaseArgs.push("--release-as", releaseAs);
+  }
+
+  return releasePleaseArgs;
+}
+
+function installAutomatedCommitPolicy(packageRoot) {
+  const codeSuggesterModule = require.resolve("code-suggester", { paths: [packageRoot] });
+  const codeSuggester = require(codeSuggesterModule);
+  if (typeof codeSuggester.createPullRequest !== "function") {
+    throw new SafeInvocationError("pinned release-please commit transport is unavailable");
+  }
+
+  const createPullRequest = codeSuggester.createPullRequest;
+  codeSuggester.createPullRequest = async (octokit, changes, options) => {
+    if (typeof options?.message !== "string" || options.message.length === 0) {
+      throw new SafeInvocationError("pinned release-please commit message is unavailable");
+    }
+
+    const message = options.message.includes("[skip ci]") ? options.message : `${options.message}\n\n[skip ci]`;
+    return createPullRequest(octokit, changes, { ...options, message });
+  };
+}
+
+const launcherArgs = process.argv.slice(2);
+if (launcherArgs.length !== 0) {
+  fail("environment-only launcher does not accept arguments");
+} else {
+  try {
+    const releasePleaseArgs = buildReleasePleaseArgs();
+
+    const releasePleasePackageRoot = requiredEnvironment("RELEASE_PLEASE_PACKAGE_ROOT");
+    const releasePleaseModule = requiredEnvironment("RELEASE_PLEASE_CLI_MODULE");
+    if (!fs.existsSync(releasePleasePackageRoot)) {
+      throw new SafeInvocationError("pinned release-please package is unavailable");
+    }
+    if (!fs.existsSync(releasePleaseModule)) {
+      throw new SafeInvocationError("pinned release-please module is unavailable");
+    }
+
+    installAutomatedCommitPolicy(releasePleasePackageRoot);
+    const { parser } = require(releasePleaseModule);
+    if (typeof parser?.parseAsync !== "function") {
+      throw new SafeInvocationError("pinned release-please parser is unavailable");
+    }
+
+    await parser.parseAsync(releasePleaseArgs);
+  } catch (error) {
+    const message = error instanceof SafeInvocationError ? error.message : "release-please invocation failed";
+    fail(message);
+  }
+}

--- a/scripts/invoke-release-please-pr.sh
+++ b/scripts/invoke-release-please-pr.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Purpose: stage release-please without credentials, then invoke it with an environment-only token.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ $# -ne 0 ]]; then
+  echo "release-please-pr: FAIL (environment-only transport does not accept arguments)" >&2
+  exit 1
+fi
+
+for required_name in \
+  RELEASE_PLEASE_TOKEN \
+  RELEASE_PLEASE_REPO_URL \
+  RELEASE_PLEASE_TARGET_BRANCH \
+  RELEASE_PLEASE_CONFIG_FILE \
+  RELEASE_PLEASE_MANIFEST_FILE; do
+  if [[ -z "${!required_name:-}" ]]; then
+    echo "release-please-pr: FAIL (missing ${required_name})" >&2
+    exit 1
+  fi
+done
+
+package_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/apptheory-release-please.XXXXXX")"
+cleanup() {
+  rm -rf -- "${package_root}"
+}
+trap cleanup EXIT
+
+# npm is only a package-staging boundary. It must never receive any GitHub
+# credential, including ambient credentials that are not used by release-please.
+if ! (
+  unset RELEASE_PLEASE_TOKEN GH_TOKEN GITHUB_TOKEN
+  bash scripts/stage-release-please-package.sh "${package_root}"
+); then
+  echo "release-please-pr: FAIL (could not stage pinned release-please package)" >&2
+  exit 1
+fi
+
+release_please_module="${package_root}/node_modules/release-please/build/src/bin/release-please.js"
+if [[ ! -f "${release_please_module}" ]]; then
+  echo "release-please-pr: FAIL (could not resolve pinned release-please module)" >&2
+  exit 1
+fi
+
+# The in-process launcher needs only the dedicated release-please credential.
+# Keep ambient gh credentials out of this boundary as well.
+set +e
+(
+  unset GH_TOKEN GITHUB_TOKEN
+  RELEASE_PLEASE_PACKAGE_ROOT="${package_root}/node_modules/release-please" \
+  RELEASE_PLEASE_CLI_MODULE="${release_please_module}" \
+    node scripts/invoke-release-please-pr.mjs
+)
+status=$?
+set -e
+exit "${status}"

--- a/scripts/run-release-please-pr.sh
+++ b/scripts/run-release-please-pr.sh
@@ -70,8 +70,18 @@ if [[ -z "${RELEASE_PLEASE_TOKEN:-}" ]]; then
   exit 1
 fi
 
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "release-please-pr: FAIL (GITHUB_REPOSITORY is required)" >&2
+  exit 1
+fi
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "release-please-pr: FAIL (gh not found)" >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "release-please-pr: FAIL (npm not found)" >&2
   exit 1
 fi
 
@@ -140,24 +150,13 @@ draft_lock_existing_open_release_pr_before_refresh() {
 
 draft_lock_existing_open_release_pr_before_refresh
 
-args=(
-  -y
-  release-please@17.1.3
-  release-pr
-  --token "${RELEASE_PLEASE_TOKEN}"
-  --repo-url "${GITHUB_REPOSITORY}"
-  --target-branch "${target_branch}"
-  --config-file "${config_file}"
-  --manifest-file "${manifest_file}"
-  --draft-pull-request
-)
-
-if [[ -n "${release_as}" ]]; then
-  args+=(--release-as "${release_as}")
-fi
-
 set +e
-npx "${args[@]}"
+RELEASE_PLEASE_REPO_URL="${GITHUB_REPOSITORY}" \
+  RELEASE_PLEASE_TARGET_BRANCH="${target_branch}" \
+  RELEASE_PLEASE_CONFIG_FILE="${config_file}" \
+  RELEASE_PLEASE_MANIFEST_FILE="${manifest_file}" \
+  RELEASE_PLEASE_RELEASE_AS="${release_as}" \
+  bash scripts/invoke-release-please-pr.sh
 release_please_status=$?
 set -e
 

--- a/scripts/stage-release-please-package.sh
+++ b/scripts/stage-release-please-package.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Purpose: install the pinned release-please package in a credential-free npm process.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  echo "release-please-package: FAIL (exactly one package-root argument is required)" >&2
+  exit 1
+fi
+
+for credential_name in RELEASE_PLEASE_TOKEN GH_TOKEN GITHUB_TOKEN; do
+  if [[ -n "${!credential_name:-}" ]]; then
+    echo "release-please-package: FAIL (GitHub credentials are forbidden at the npm boundary)" >&2
+    exit 1
+  fi
+done
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "release-please-package: FAIL (npm not found)" >&2
+  exit 1
+fi
+
+package_root="$1"
+mkdir -p -- "${package_root}"
+
+npm_config_loglevel=warn npm install \
+  --ignore-scripts \
+  --no-audit \
+  --no-fund \
+  --no-package-lock \
+  --no-save \
+  --prefix "${package_root}" \
+  release-please@17.1.3

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -10,6 +10,8 @@ artifact_sync_commit_body="[skip ci]"
 default_required_checks() {
   cat <<'EOF'
 Version alignment
+Release train promotion gate
+Release/security gates
 Go (test + vet)
 TypeScript (npm pack)
 Python (build wheel + sdist)
@@ -683,7 +685,10 @@ dispatch_required_checks() {
   local dispatch_args=(workflow run "${required_check_workflow}" --ref "${release_branch}")
 
   if [[ "${required_check_workflow}" == "ci.yml" ]]; then
-    dispatch_args+=(--raw-field run_full_rubric=false)
+    dispatch_args+=(
+      --raw-field run_full_rubric=false
+      --raw-field release_pr_number="${pr_number}"
+    )
   fi
 
   echo "sync-release-pr-generated: dispatching ${required_check_workflow} for ${release_branch} with full rubric disabled"
@@ -1149,10 +1154,10 @@ else
 fi
 
 wait_for_pr_head "${synced_head}"
-# After the generated-artifact head is visible, rely only on independent PR
-# checks for protected required contexts. Bot-authored release PR updates can be
-# suppressed by GitHub's recursive workflow guard, so explicitly dispatch CI on
-# the release branch instead of self-attesting protected statuses from mutable
+# After the generated-artifact head is visible, rely only on independently
+# dispatched checks for protected required contexts. Automation commits suppress
+# their pull_request events, so explicitly dispatch CI with the exact PR number
+# and release head instead of self-attesting protected statuses from mutable
 # release-branch code.
 ensure_release_pr_is_draft "before waiting for independent required checks"
 require_pr_head "${synced_head}" "before dispatching independent required checks"

--- a/scripts/sync-release-pr-generated.sh
+++ b/scripts/sync-release-pr-generated.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 artifact_sync_commit_message="chore(release): sync generated release artifacts"
+artifact_sync_commit_body="[skip ci]"
 
 default_required_checks() {
   cat <<'EOF'
@@ -835,6 +836,7 @@ build_release_artifact_sync_commit_payload() {
     EXPECTED_HEAD_OID="${expected_head}" \
     REPOSITORY_NAME_WITH_OWNER="${repo}" \
     ARTIFACT_SYNC_COMMIT_MESSAGE="${artifact_sync_commit_message}" \
+    ARTIFACT_SYNC_COMMIT_BODY="${artifact_sync_commit_body}" \
     PAYLOAD_FILE="${payload_file}" \
     SUMMARY_FILE="${summary_file}" \
     python3 - <<'PY'
@@ -910,6 +912,7 @@ mutation CreateReleaseArtifactSyncCommit($input: CreateCommitOnBranchInput!) {
             },
             "message": {
                 "headline": os.environ["ARTIFACT_SYNC_COMMIT_MESSAGE"],
+                "body": os.environ["ARTIFACT_SYNC_COMMIT_BODY"],
             },
             "fileChanges": {
                 "additions": additions,
@@ -1079,7 +1082,7 @@ verify_head_locally_signed() {
 commit_release_artifact_sync_locally() {
   require_existing_local_signing_config
   git add .release-please-manifest.premain.json cdk/.jsii cdk/lib cdk-go/apptheorycdk
-  if ! git commit -m "${artifact_sync_commit_message}"; then
+  if ! git commit -m "${artifact_sync_commit_message}" -m "${artifact_sync_commit_body}"; then
     echo "sync-release-pr-generated: FAIL (normal local git commit failed; no CI signing fallback exists)" >&2
     exit 1
   fi

--- a/scripts/verify-release-please-token-safety.sh
+++ b/scripts/verify-release-please-token-safety.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Purpose: prove release-please credentials never cross an npm or OS argument boundary.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+fail() {
+  echo "release-please-token-safety: FAIL ($1)" >&2
+  exit 1
+}
+
+wrapper="scripts/run-release-please-pr.sh"
+transport="scripts/invoke-release-please-pr.sh"
+launcher="scripts/invoke-release-please-pr.mjs"
+stager="scripts/stage-release-please-package.sh"
+
+[[ -f "${transport}" ]] || fail "missing environment-only transport ${transport}"
+[[ -f "${launcher}" ]] || fail "missing environment-only launcher ${launcher}"
+[[ -f "${stager}" ]] || fail "missing credential-free package stager ${stager}"
+
+if grep -Fq -- '--token' "${wrapper}" "${transport}" "${stager}"; then
+  fail "shell release wrappers must never place a token on a command line"
+fi
+
+grep -Fq 'bash scripts/invoke-release-please-pr.sh' "${wrapper}" ||
+  fail "release wrapper must enter the environment-only transport"
+grep -Fq 'unset RELEASE_PLEASE_TOKEN GH_TOKEN GITHUB_TOKEN' "${transport}" ||
+  fail "transport must remove all GitHub credentials before entering npm"
+grep -Fq 'release-please@17.1.3' "${stager}" ||
+  fail "credential-free npm boundary must pin release-please"
+grep -Fq 'GitHub credentials are forbidden at the npm boundary' "${stager}" ||
+  fail "npm boundary must fail closed when any GitHub credential is present"
+
+grep -Fq 'requiredEnvironment("RELEASE_PLEASE_TOKEN")' "${launcher}" ||
+  fail "launcher must read the release credential from the environment"
+grep -Fq 'parser.parseAsync(releasePleaseArgs)' "${launcher}" ||
+  fail "launcher must call the pinned release-please parser in-process"
+grep -Fq '`${options.message}\n\n[skip ci]`' "${launcher}" ||
+  fail "release-please commits must suppress redundant pull_request CI events"
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/apptheory-token-safety.XXXXXX")"
+cleanup() {
+  rm -rf -- "${test_root}"
+}
+trap cleanup EXIT
+
+mkdir -p "${test_root}/bin"
+cat > "${test_root}/bin/npm" <<'FAKE_NPM'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${RELEASE_PLEASE_TOKEN:-}" || -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]]; then
+  echo "fake-npm: FAIL (received a GitHub credential)" >&2
+  exit 1
+fi
+
+prefix=""
+found_pin="false"
+found_ignore_scripts="false"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      prefix="${2:-}"
+      shift 2
+      ;;
+    --ignore-scripts)
+      found_ignore_scripts="true"
+      shift
+      ;;
+    release-please@17.1.3)
+      found_pin="true"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${prefix}" || "${found_pin}" != "true" || "${found_ignore_scripts}" != "true" ]]; then
+  echo "fake-npm: FAIL (unsafe package staging arguments)" >&2
+  exit 1
+fi
+
+module_dir="${prefix}/node_modules/release-please/build/src/bin"
+code_suggester_dir="${prefix}/node_modules/code-suggester/build/src"
+mkdir -p "${module_dir}"
+mkdir -p "${code_suggester_dir}"
+cat > "${prefix}/node_modules/code-suggester/package.json" <<'FAKE_CODE_SUGGESTER_PACKAGE'
+{"name":"code-suggester","main":"build/src/index.js"}
+FAKE_CODE_SUGGESTER_PACKAGE
+cat > "${code_suggester_dir}/index.js" <<'FAKE_CODE_SUGGESTER'
+exports.createPullRequest = async (_octokit, _changes, options) => {
+  if (typeof options?.message !== "string" || !options.message.endsWith("\n\n[skip ci]")) {
+    throw new Error("release-please commit did not suppress redundant pull_request CI");
+  }
+};
+FAKE_CODE_SUGGESTER
+cat > "${module_dir}/release-please.js" <<'FAKE_MODULE'
+const fs = require("node:fs");
+const codeSuggester = require("code-suggester");
+
+exports.parser = {
+  parseAsync: async (args) => {
+    const token = process.env.RELEASE_PLEASE_TOKEN ?? "";
+    const kernelArgv = fs.existsSync("/proc/self/cmdline")
+      ? fs.readFileSync("/proc/self/cmdline").toString("utf8")
+      : process.argv.join("\0");
+
+    if (!token || args[0] !== "release-pr" || args[1] !== "--token" || args[2] !== token) {
+      throw new Error("credential did not reach only the in-memory parser arguments");
+    }
+    if (kernelArgv.includes(token)) {
+      throw new Error("credential crossed the OS process argument boundary");
+    }
+    if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
+      throw new Error("ambient GitHub credentials reached the release-please process");
+    }
+
+    await codeSuggester.createPullRequest(null, null, { message: "chore: release test" });
+    console.log("release-please-token-transport: PASS");
+  },
+};
+FAKE_MODULE
+FAKE_NPM
+chmod +x "${test_root}/bin/npm"
+
+sentinel='release-please-token-safety-sentinel-do-not-log'
+output="$({
+  RELEASE_PLEASE_TOKEN="${sentinel}" \
+    GH_TOKEN="${sentinel}-gh" \
+    GITHUB_TOKEN="${sentinel}-github" \
+    RELEASE_PLEASE_REPO_URL="theory-cloud/AppTheory" \
+    RELEASE_PLEASE_TARGET_BRANCH="premain" \
+    RELEASE_PLEASE_CONFIG_FILE="release-please-config.premain.json" \
+    RELEASE_PLEASE_MANIFEST_FILE=".release-please-manifest.premain.json" \
+    PATH="${test_root}/bin:${PATH}" \
+    bash "${transport}"
+} 2>&1)" || {
+  printf '%s\n' "${output}" >&2
+  fail "environment-only launcher self-test failed"
+}
+
+if [[ "${output}" == *"${sentinel}"* || "${output}" == *"${sentinel}-gh"* || "${output}" == *"${sentinel}-github"* ]]; then
+  fail "launcher emitted the credential sentinel"
+fi
+if [[ "${output}" != *"release-please-token-transport: PASS"* ]]; then
+  printf '%s\n' "${output}" >&2
+  fail "launcher self-test did not report success"
+fi
+
+echo "release-please-token-safety: PASS"

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -620,14 +620,19 @@ require_not_contains(
 require_order(
     "scripts/run-release-please-pr.sh",
     "draft_lock_existing_open_release_pr_before_refresh",
-    'npx "${args[@]}"',
+    "bash scripts/invoke-release-please-pr.sh",
     "release-please PR generation may draft-lock already-open PRs but must still invoke release-please",
 )
 require_order(
     "scripts/run-release-please-pr.sh",
-    'npx "${args[@]}"',
+    "bash scripts/invoke-release-please-pr.sh",
     'if use_existing_open_release_pr "release-please exited ${release_please_status} after creating or finding a release PR"; then',
     "release-please PR generation must recover when stale release-please state errors after a valid PR exists",
+)
+require_not_contains(
+    "scripts/run-release-please-pr.sh",
+    "--token",
+    "release-please credentials must never be forwarded through npm or shell process arguments",
 )
 require_contains(
     "scripts/run-release-please-pr.sh",
@@ -735,8 +740,28 @@ require_contains(
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
-    'git commit -m "${artifact_sync_commit_message}"',
+    'artifact_sync_commit_body="[skip ci]"',
+    "generated artifact commits must suppress redundant pull_request CI events",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    '"body": os.environ["ARTIFACT_SYNC_COMMIT_BODY"]',
+    "GitHub-created generated artifact commits must carry the automatic-event suppression marker",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    'git commit -m "${artifact_sync_commit_message}" -m "${artifact_sync_commit_body}"',
     "local signed release PR sync fallback must use normal local git commit signing configuration",
+)
+require_contains(
+    "scripts/invoke-release-please-pr.mjs",
+    '`${options.message}\\n\\n[skip ci]`',
+    "release-please commits must suppress redundant pull_request CI events",
+)
+require_contains(
+    "docs/release-process.md",
+    "one explicit `workflow_dispatch` CI run",
+    "release runbook must document the single-trigger generated release PR contract",
 )
 require_contains(
     "scripts/sync-release-pr-generated.sh",
@@ -1018,6 +1043,7 @@ subprocess.run(["bash", "scripts/verify-branch-version-sync.sh", "--self-test"],
 subprocess.run(["bash", "scripts/verify-release-pr-postcondition.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/verify-release-publish-postcondition.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/sync-release-pr-generated.sh", "--self-test"], check=True)
+subprocess.run(["bash", "scripts/verify-release-please-token-safety.sh"], check=True)
 
 print("release-workflows: PASS")
 PY

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -399,6 +399,26 @@ require_contains(
 )
 require_contains(
     ".github/workflows/ci.yml",
+    'release_pr_number:\n        description: "Generated release PR number for head-bound release checks"',
+    "generated release CI dispatch must identify the exact release PR",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "github.event_name == 'workflow_dispatch' && inputs.release_pr_number != ''",
+    "release promotion verification must run inside generated release CI dispatches",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    "permissions:\n  contents: read\n  pull-requests: read",
+    "head-bound release CI dispatch must have read-only pull request metadata access",
+)
+require_contains(
+    ".github/workflows/ci.yml",
+    'if [[ "${PR_HEAD_REF}" != "${DISPATCH_HEAD_REF}" || "${PR_HEAD_SHA}" != "${DISPATCH_HEAD_SHA}" ]]; then',
+    "release promotion dispatch must bind the requested PR to the dispatched branch and SHA",
+)
+require_contains(
+    ".github/workflows/ci.yml",
     "if: (github.event_name == 'workflow_dispatch' && (inputs.run_full_rubric == true || inputs.run_full_rubric == 'true')) || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging')",
     "full rubric must run only on staging PRs and opted-in manual dispatch",
 )
@@ -712,6 +732,16 @@ require_contains(
     "scripts/sync-release-pr-generated.sh",
     "--raw-field run_full_rubric=false",
     "automated release PR CI dispatch must disable the full rubric",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    '--raw-field release_pr_number="${pr_number}"',
+    "automated release PR CI dispatch must bind checks to the exact release PR",
+)
+require_contains(
+    "scripts/sync-release-pr-generated.sh",
+    "Release train promotion gate\nRelease/security gates",
+    "release PR sync must wait for promotion and release/security checks in the single dispatched run",
 )
 require_not_contains(
     "scripts/sync-release-pr-generated.sh",


### PR DESCRIPTION
## What changed

- replace the token-bearing `npx` invocation with an environment-only, in-process Release Please launcher
- stage pinned `release-please@17.1.3` in an npm process where `RELEASE_PLEASE_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` are all absent
- disable npm lifecycle scripts at that package-staging boundary
- keep generated release PR validation to one explicit `workflow_dispatch` run on the finalized head
- mark Release Please and generated-artifact automation commits with `[skip ci]` so GitHub does not create stale or duplicate `pull_request` runs
- add a sentinel regression test and release-workflow invariants for both boundaries
- document the credential and single-trigger contracts

## Root cause

The release wrapper placed the GitHub credential in Release Please command arguments. npm 12 logs command arguments, and operating-system process arguments are observable. Separately, GitHub now creates approval-required workflow runs for automation-originated pull request `opened` and `synchronize` events while AppTheory also explicitly dispatches CI after generated artifacts are finalized. That produced stale and duplicate CI runs.

## Security and process impact

npm no longer receives any GitHub credential, and no credential crosses the npm or OS argument boundary. Generated release PRs still run all required release checks, but exactly once through the existing explicit dispatch after artifact and signature verification. The sync workflow remains fail-closed and rechecks the finalized head before marking the PR ready.

## Validation

- `bash scripts/verify-release-please-token-safety.sh`
- `bash scripts/verify-release-workflows.sh`
- `bash scripts/verify-release-gates.sh`
- `make test`
- `bash scripts/verify-builds.sh`
- `make rubric` — 29 passed, 0 failed, 0 blocked
- real pinned Release Please package/parser boundary check without credentials
- `origin/main` and `origin/staging` verified as ancestors of the PR head
