### PR TITLE
fix(release): close AppTheory v2 Go publication

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Verify release supply chain (release preflight)
         run: bash scripts/verify-branch-release-supply-chain.sh
 
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: "1.26.5"
+
       - name: Verify release workflow invariants (release preflight)
         run: bash scripts/verify-release-workflows.sh
 
       - name: Set SOURCE_DATE_EPOCH (release preflight)
         run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
-
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: "1.26.5"
 
       - name: Install golangci-lint (pinned) (release preflight)
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
@@ -69,7 +69,7 @@ jobs:
         env:
           RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
-        run: scripts/verify-release-publish-postcondition.sh prerelease "${RELEASE_CREATED}" "${TAG_NAME}"
+        run: scripts/verify-release-publish-postcondition.sh prerelease "${RELEASE_CREATED}" "${TAG_NAME}" prepublish
 
       - name: Build, upload, and publish prerelease assets
         if: steps.release.outputs.release_created == 'true'
@@ -78,7 +78,7 @@ jobs:
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
         run: scripts/publish-release-assets.sh "${TAG_NAME}"
 
-      - name: Recover existing draft prerelease assets
+      - name: Recover or verify existing prerelease
         if: steps.release.outputs.release_created != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -89,13 +89,18 @@ jobs:
             exit 0
           fi
 
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: SKIP (${TAG_NAME} has no draft release to recover)"
+          if ! gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "release-assets: SKIP (${TAG_NAME} has no release to recover or verify)"
             exit 0
           fi
 
           scripts/publish-release-assets.sh "${TAG_NAME}"
+
+      - name: Verify prerelease publication closure
+        env:
+          RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: scripts/verify-release-publish-postcondition.sh prerelease "${RELEASE_CREATED}" "${TAG_NAME}" complete
 
       - name: Diagnose failed prerelease state (read-only)
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
         if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
         run: bash scripts/verify-branch-release-supply-chain.sh
 
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
+        with:
+          go-version: "1.26.5"
+
       - name: Verify release workflow invariants (stable release preflight)
         if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
         run: bash scripts/verify-release-workflows.sh
@@ -54,11 +59,6 @@ jobs:
       - name: Set SOURCE_DATE_EPOCH (stable release preflight)
         if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
         run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
-
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
-        with:
-          go-version: "1.26.5"
 
       - name: Install golangci-lint (pinned) (stable release preflight)
         if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
@@ -118,7 +118,7 @@ jobs:
         env:
           RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
-        run: scripts/verify-release-publish-postcondition.sh stable "${RELEASE_CREATED}" "${TAG_NAME}"
+        run: scripts/verify-release-publish-postcondition.sh stable "${RELEASE_CREATED}" "${TAG_NAME}" prepublish
 
       - name: Build, upload, and publish release assets
         if: steps.release.outputs.release_created == 'true'
@@ -127,7 +127,7 @@ jobs:
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
         run: scripts/publish-release-assets.sh "${TAG_NAME}"
 
-      - name: Recover existing draft release assets
+      - name: Recover or verify existing stable release
         if: github.ref == 'refs/heads/main' && inputs.tag_name == '' && steps.release.outputs.release_created != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -138,13 +138,19 @@ jobs:
             exit 0
           fi
 
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: SKIP (${TAG_NAME} has no draft release to recover)"
+          if ! gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "release-assets: SKIP (${TAG_NAME} has no release to recover or verify)"
             exit 0
           fi
 
           scripts/publish-release-assets.sh "${TAG_NAME}"
+
+      - name: Verify stable publication closure
+        if: github.ref == 'refs/heads/main' && inputs.tag_name == ''
+        env:
+          RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: scripts/verify-release-publish-postcondition.sh stable "${RELEASE_CREATED}" "${TAG_NAME}" complete
 
       - name: Diagnose failed release state (read-only)
         if: failure()

--- a/cdk-go/README.md
+++ b/cdk-go/README.md
@@ -14,6 +14,23 @@ go get github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v2@v2.0.0-rc
 import "github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v2"
 ```
 
+Each v2+ GitHub Release has two create-only Git refs at the same signed release commit:
+
+- root runtime: `vX.Y.Z[-rc[.N]]`
+- CDK Go module: `cdk-go/apptheorycdk/vX.Y.Z[-rc[.N]]`
+
+The Go command derives the nested tag prefix from the module directory, so consumers still select the ordinary
+version suffix:
+
+```bash
+go get github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v2@v2.0.0
+```
+
+The serialized prerelease/stable publisher creates only absent refs, accepts an existing ref only when it already
+targets the exact release commit, and refuses to move or delete a conflicting tag. It then resolves both the root and
+CDK modules through direct VCS lookup and checks the returned version, tag ref, module directive, and commit hash
+before the draft GitHub Release becomes public.
+
 Immutable AppTheory v1 tags retain the legacy
 `github.com/theory-cloud/apptheory/cdk-go/apptheorycdk` import. AppTheory v2 does not provide an alias or alternate
 module path.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -109,6 +109,9 @@ evidence, and do not claim CI can sign generated sync commits by holding private
   generated head. Record the RC PR URL and check output in the promotion notes.
 - Merge the release-candidate PR only after generated artifacts are in sync and all required checks are green.
 - The prerelease publisher creates immutable assets for the `vX.Y.Z-rc.N` GitHub Release.
+- For v2+, the same serialized publisher creates the root `vX.Y.Z-rc.N` tag and nested
+  `cdk-go/apptheorycdk/vX.Y.Z-rc.N` Go module tag only when absent, proves both target the exact RC commit, and
+  resolves both modules at the exact version through direct VCS lookup before the draft release becomes public.
 
 ### 3. Promote `premain` to `main`
 
@@ -123,6 +126,9 @@ evidence, and do not claim CI can sign generated sync commits by holding private
 - Merge the stable release PR only after required checks pass.
 - The stable publisher creates immutable assets for the `vX.Y.Z` GitHub Release.
   `main` owns stable releases only; RC-shaped stable PR titles, versions, or tags are rejected.
+- For v2+, stable publication applies the same create-only two-tag transaction:
+  `vX.Y.Z` and `cdk-go/apptheorycdk/vX.Y.Z` must target the exact same stable release commit. Any conflicting
+  existing ref fails closed; neither tag is moved, deleted, or recreated.
 
 ### 4. Back-merge `main` to `staging`
 
@@ -144,6 +150,8 @@ Do not use any of these actions to recover a release lane:
 - Manually marking protected checks successful or weakening workflow permissions so a release PR can self-attest.
 - Running a stable release from `staging` or a prerelease from `main`.
 - Creating manual tags or GitHub Releases instead of letting the generated Release Please PR merge publish the expected tag.
+- Moving, deleting, force-updating, or manually repairing either the root release tag or the nested
+  `cdk-go/apptheorycdk/vX.Y.Z[-rc[.N]]` Go module tag.
 - Adding CI-held private signing material so workflow runners can manufacture generated release-artifact sync commits.
 
 Published GitHub Releases are immutable. If a published release is wrong, the recovery is a new version moving through the normal cycle, not mutation of the old release.
@@ -164,7 +172,13 @@ When the release lane is blocked, recover by preserving evidence and re-entering
 
 2. Classify the blocker.
    - Draft GitHub Release with missing or partial assets: rerun the same publisher workflow; the publisher replaces draft assets safely and verifies branch provenance before publication.
-   - Published GitHub Release already exists: rerun the publisher only to verify immutable assets match the source build; do not upload or edit assets.
+   - Root or nested Go tag missing after a partial publisher run: rerun the same serialized publisher. It creates
+     only the absent ref at the already-verified release commit, retains any same-commit ref, and then proves exact
+     root/CDK module resolution.
+   - Root or nested Go tag points at another commit: do not retag. Preserve the conflicting evidence and cut a new
+     version through the normal train.
+   - Published GitHub Release already exists: rerun the publisher only to verify immutable assets and both Go module
+     refs match the source build; do not upload or edit assets.
    - Stale Release Please PR: regenerate or sync Release Please state from the current branch baseline; do not merge the stale PR.
    - Generated artifact sync pending: keep the release PR draft and rerun the release PR sync workflow so it can
      create the GitHub-verified generated artifact commit and prove the signature range. Use the local signed
@@ -179,6 +193,8 @@ When the release lane is blocked, recover by preserving evidence and re-entering
    ```bash
    bash scripts/verify-release-state.sh --self-test
    bash scripts/verify-release-train-promotion.sh --self-test
+   bash scripts/publish-go-module-tags.sh --self-test
+   bash scripts/verify-go-module-tags.sh --self-test
    bash scripts/verify-release-workflows.sh
    bash scripts/verify-ci-rubric-enforced.sh
    bash scripts/verify-release-branch-signatures.sh
@@ -205,8 +221,8 @@ git verify-commit HEAD
 ```
 
 The script starts from a clean checkout, fetches the release PR branch, regenerates only release artifact files,
-stages only `.release-please-manifest.premain.json`, `cdk/.jsii`, `cdk/lib`, and `cdk-go/apptheorycdk`, then
-runs plain `git commit -m "chore(release): sync generated release artifacts"`. It does not set
+stages only `.release-please-manifest.premain.json`, `cdk/.jsii`, `cdk/lib`, `cdk-go/go.mod`, `cdk-go/go.sum`, and
+`cdk-go/apptheorycdk`, then runs plain `git commit -m "chore(release): sync generated release artifacts"`. It does not set
 `user.signingkey`, replace the signing program, import keys, or add passphrases. If the normal local signing
 configuration does not produce a locally trusted-good signature, the script fails before pushing and reports the
 signature status.

--- a/scripts/diagnose-release-state.sh
+++ b/scripts/diagnose-release-state.sh
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -177,6 +178,26 @@ def tag_state(tag: str | None) -> tuple[str, str]:
     return ("absent", "not present in local refs")
 
 
+def module_tag_state(tag: str | None, root_target: str | None) -> tuple[str, str, str]:
+    if not tag:
+        return ("unknown", "none", "no release tag could be inferred")
+    match = re.fullmatch(r"v([0-9]+)\.[0-9]+\.[0-9]+(?:-rc(?:\.[0-9]+)?)?", tag)
+    if not match:
+        return ("unknown", "none", f"unsupported release tag {tag}")
+    if int(match.group(1)) < 2:
+        return ("not-applicable", "none", "v1 predates the nested Go module tag contract")
+
+    module_tag = f"cdk-go/apptheorycdk/{tag}"
+    target = git_commit(f"refs/tags/{module_tag}")
+    if not target:
+        return ("missing", module_tag, "not present in local refs")
+    if not root_target:
+        return ("unpaired", module_tag, target)
+    if target != root_target:
+        return ("conflict", module_tag, target)
+    return ("matching", module_tag, target)
+
+
 def verify_release_state() -> dict[str, Any]:
     completed = run(["bash", "scripts/verify-release-state.sh", "--live", "--json"])
     try:
@@ -198,11 +219,27 @@ def verify_release_state() -> dict[str, Any]:
     return data
 
 
-def safe_next_action(classification: str, release_status: str, tag_status: str, diagnostics: list[dict[str, str]]) -> str:
+def safe_next_action(
+    classification: str,
+    release_status: str,
+    tag_status: str,
+    module_tag_status: str,
+    diagnostics: list[dict[str, str]],
+) -> str:
+    if module_tag_status == "conflict":
+        return (
+            "The nested Go module tag conflicts with the immutable root release commit. "
+            "Do not delete, move, or overwrite either tag; cut a new version through the normal release train."
+        )
     if diagnostics:
         return (
             "Fix the reported branch/manifest/tag/release invariant, then rerun the same publisher. "
             "Do not delete tags/releases or overwrite published assets."
+        )
+    if module_tag_status in {"missing", "unpaired"}:
+        return (
+            "Rerun the same serialized publisher. It will create only the missing root/nested Go tag "
+            "at the immutable release commit and then prove exact module resolution; it never moves an existing ref."
         )
     if release_status == "published":
         return (
@@ -227,6 +264,8 @@ def safe_next_action(classification: str, release_status: str, tag_status: str, 
 def print_diagnostics(tag: str | None) -> None:
     head = git_commit("HEAD")
     tag_status, tag_detail = tag_state(tag)
+    root_target = tag_detail if tag_status == "present" else None
+    module_status, module_tag, module_detail = module_tag_state(tag, root_target)
     release = release_state(tag)
     release_status = str(release.get("state", "unknown"))
     verifier = verify_release_state()
@@ -236,6 +275,10 @@ def print_diagnostics(tag: str | None) -> None:
     print("release-diagnostics: BEGIN")
     print(f"release-diagnostics: branch={current_branch()} head={short_sha(head)}")
     print(f"release-diagnostics: tag={tag or 'unknown'} state={tag_status} target={tag_detail}")
+    print(
+        "release-diagnostics: "
+        f"go-module-tag={module_tag} state={module_status} target={module_detail}"
+    )
     release_line = (
         f"release-diagnostics: release={tag or 'unknown'} state={release_status} "
         f"target={release.get('target', 'unknown')} prerelease={release.get('prerelease', 'unknown')}"
@@ -267,7 +310,13 @@ def print_diagnostics(tag: str | None) -> None:
             )
     print(
         "release-diagnostics: safe-next-action="
-        + safe_next_action(classification, release_status, tag_status, [item for item in diagnostics if isinstance(item, dict)])
+        + safe_next_action(
+            classification,
+            release_status,
+            tag_status,
+            module_status,
+            [item for item in diagnostics if isinstance(item, dict)],
+        )
     )
     print("release-diagnostics: END")
 
@@ -279,6 +328,7 @@ def self_test() -> int:
             "invalid",
             "draft",
             "present",
+            "matching",
             [{"code": "manifest:staging-stable-mismatch", "message": "staging is stale"}],
             "Fix the reported branch/manifest/tag/release invariant",
         ),
@@ -287,6 +337,7 @@ def self_test() -> int:
             "stable-published",
             "published",
             "present",
+            "matching",
             [],
             "already immutable",
         ),
@@ -295,6 +346,7 @@ def self_test() -> int:
             "prerelease-draft",
             "draft",
             "present",
+            "matching",
             [],
             "Draft assets may be replaced only while the release is still draft",
         ),
@@ -303,13 +355,46 @@ def self_test() -> int:
             "prerelease-tagged",
             "absent",
             "present",
+            "matching",
             [],
             "recover the existing immutable tag",
         ),
+        (
+            "missing nested module tag recovers through publisher",
+            "stable-published",
+            "published",
+            "present",
+            "missing",
+            [],
+            "create only the missing root/nested Go tag",
+        ),
+        (
+            "conflicting nested module tag requires a new version",
+            "stable-published",
+            "published",
+            "present",
+            "conflict",
+            [],
+            "cut a new version",
+        ),
     ]
     failures: list[str] = []
-    for name, classification, release_status, tag_status, diagnostics, expected in cases:
-        actual = safe_next_action(classification, release_status, tag_status, diagnostics)
+    for (
+        name,
+        classification,
+        release_status,
+        tag_status,
+        module_status,
+        diagnostics,
+        expected,
+    ) in cases:
+        actual = safe_next_action(
+            classification,
+            release_status,
+            tag_status,
+            module_status,
+            diagnostics,
+        )
         if expected not in actual:
             failures.append(f"{name}: expected {expected!r} in {actual!r}")
     if failures:

--- a/scripts/go-module-release-contract.sh
+++ b/scripts/go-module-release-contract.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Shared fail-closed helpers for the AppTheory v2+ Go module release transaction.
+
+go_release_parse_tag() {
+  local tag="${1:-}"
+  local major
+
+  if [[ ! "${tag}" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?$ ]]; then
+    echo "go-module-release: FAIL (unsupported v2+ release tag '${tag}')" >&2
+    return 1
+  fi
+  major="${BASH_REMATCH[1]}"
+  if (( 10#${major} < 2 )); then
+    echo "go-module-release: FAIL (unsupported v2+ release tag '${tag}')" >&2
+    return 1
+  fi
+
+  GO_RELEASE_TAG="${tag}"
+  GO_RELEASE_VERSION="${tag#v}"
+  GO_RELEASE_MAJOR="${major}"
+  GO_RELEASE_ROOT_MODULE="github.com/theory-cloud/apptheory/v${GO_RELEASE_MAJOR}"
+  GO_RELEASE_CDK_MODULE="github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v${GO_RELEASE_MAJOR}"
+  GO_RELEASE_ROOT_TAG="${tag}"
+  GO_RELEASE_CDK_TAG="cdk-go/apptheorycdk/${tag}"
+}
+
+go_release_module_from_commit() {
+  local commit="$1"
+  local path="$2"
+
+  git show "${commit}:${path}" 2>/dev/null |
+    awk '/^module[[:space:]]+/{print $2; exit}'
+}
+
+go_release_version_from_commit() {
+  local commit="$1"
+  local raw
+
+  raw="$(git show "${commit}:VERSION" 2>/dev/null | head -n 1 || true)"
+  if [[ ! "${raw}" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?)($|[[:space:]]) ]]; then
+    echo "go-module-release: FAIL (${commit} has an invalid VERSION marker)" >&2
+    return 1
+  fi
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+go_release_validate_source_contract() {
+  local tag="$1"
+  local source_ref="$2"
+  local source_commit
+  local source_version
+  local root_module
+  local cdk_module
+
+  go_release_parse_tag "${tag}" || return 1
+
+  source_commit="$(git rev-parse --verify "${source_ref}^{commit}" 2>/dev/null || true)"
+  if [[ ! "${source_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "go-module-release: FAIL (source '${source_ref}' is not a local commit)" >&2
+    return 1
+  fi
+
+  source_version="$(go_release_version_from_commit "${source_commit}")" || return 1
+  if [[ "${source_version}" != "${GO_RELEASE_VERSION}" ]]; then
+    echo \
+      "go-module-release: FAIL (${tag} version ${GO_RELEASE_VERSION} does not match ${source_commit} VERSION ${source_version})" \
+      >&2
+    return 1
+  fi
+
+  root_module="$(go_release_module_from_commit "${source_commit}" "go.mod")"
+  if [[ "${root_module}" != "${GO_RELEASE_ROOT_MODULE}" ]]; then
+    echo \
+      "go-module-release: FAIL (${source_commit} root module '${root_module}' != '${GO_RELEASE_ROOT_MODULE}')" \
+      >&2
+    return 1
+  fi
+
+  cdk_module="$(go_release_module_from_commit "${source_commit}" "cdk-go/apptheorycdk/go.mod")"
+  if [[ "${cdk_module}" != "${GO_RELEASE_CDK_MODULE}" ]]; then
+    echo \
+      "go-module-release: FAIL (${source_commit} CDK module '${cdk_module}' != '${GO_RELEASE_CDK_MODULE}')" \
+      >&2
+    return 1
+  fi
+
+  if git cat-file -e "${source_commit}:cdk-go/go.mod" 2>/dev/null ||
+    git cat-file -e "${source_commit}:cdk-go/go.sum" 2>/dev/null
+  then
+    echo \
+      "go-module-release: FAIL (${source_commit} retains legacy cdk-go parent-module files)" \
+      >&2
+    return 1
+  fi
+
+  GO_RELEASE_SOURCE_COMMIT="${source_commit}"
+}
+
+# Prints the commit targeted by one remote tag.
+# Return codes: 0=present, 1=absent, 2=remote/ref resolution failure.
+go_release_remote_tag_commit() {
+  local remote="$1"
+  local tag="$2"
+  local remote_line
+  local status
+  local safe_tag
+  local temporary_ref
+  local target
+
+  set +e
+  remote_line="$(
+    git ls-remote --exit-code --refs "${remote}" "refs/tags/${tag}" 2>/dev/null
+  )"
+  status=$?
+  set -e
+
+  if (( status == 2 )); then
+    return 1
+  fi
+  if (( status != 0 )) || [[ -z "${remote_line}" ]]; then
+    echo "go-module-release: FAIL (could not inspect ${remote} refs/tags/${tag})" >&2
+    return 2
+  fi
+
+  safe_tag="${tag//\//_}"
+  temporary_ref="refs/apptheory-release-check/$$-${RANDOM}/${safe_tag}"
+  if ! git fetch --quiet --no-tags "${remote}" "refs/tags/${tag}:${temporary_ref}"; then
+    echo "go-module-release: FAIL (could not resolve ${remote} refs/tags/${tag})" >&2
+    git update-ref -d "${temporary_ref}" >/dev/null 2>&1 || true
+    return 2
+  fi
+
+  target="$(git rev-parse --verify "${temporary_ref}^{commit}" 2>/dev/null || true)"
+  git update-ref -d "${temporary_ref}" >/dev/null 2>&1 || true
+  if [[ ! "${target}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "go-module-release: FAIL (${remote} refs/tags/${tag} is not commit-resolvable)" >&2
+    return 2
+  fi
+
+  printf '%s\n' "${target}"
+}

--- a/scripts/publish-go-module-tags.sh
+++ b/scripts/publish-go-module-tags.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Purpose: idempotently create AppTheory root and nested CDK Go tags without ever moving a ref.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=go-module-release-contract.sh
+source "${repo_root}/scripts/go-module-release-contract.sh"
+cd "${repo_root}"
+
+preflight_remote_tag() {
+  local remote="$1"
+  local tag="$2"
+  local source_commit="$3"
+  local observed
+  local status
+
+  set +e
+  observed="$(go_release_remote_tag_commit "${remote}" "${tag}")"
+  status=$?
+  set -e
+
+  case "${status}" in
+    0)
+      if [[ "${observed}" != "${source_commit}" ]]; then
+        echo \
+          "go-module-tags: FAIL (${tag} already targets ${observed}; expected ${source_commit}; refs are immutable)" \
+          >&2
+        return 1
+      fi
+      ;;
+    1) ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ensure_remote_tag() {
+  local remote="$1"
+  local tag="$2"
+  local source_commit="$3"
+  local observed
+  local status
+
+  set +e
+  observed="$(go_release_remote_tag_commit "${remote}" "${tag}")"
+  status=$?
+  set -e
+
+  case "${status}" in
+    0)
+      if [[ "${observed}" != "${source_commit}" ]]; then
+        echo \
+          "go-module-tags: FAIL (${tag} already targets ${observed}; expected ${source_commit}; refs are immutable)" \
+          >&2
+        return 1
+      fi
+      echo "go-module-tags: KEEP (${tag} already targets ${source_commit})"
+      return 0
+      ;;
+    1) ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if git push "${remote}" "${source_commit}:refs/tags/${tag}"; then
+    echo "go-module-tags: CREATE (${tag} -> ${source_commit})"
+  else
+    # A concurrent publisher may have won the create-only race. Accept only
+    # the exact same target; any other ref remains immutable and fails closed.
+    set +e
+    observed="$(go_release_remote_tag_commit "${remote}" "${tag}")"
+    status=$?
+    set -e
+    if (( status != 0 )) || [[ "${observed}" != "${source_commit}" ]]; then
+      echo \
+        "go-module-tags: FAIL (${tag} could not be created at ${source_commit}; observed ${observed:-absent})" \
+        >&2
+      return 1
+    fi
+    echo "go-module-tags: KEEP (${tag} concurrently created at ${source_commit})"
+  fi
+
+  observed="$(go_release_remote_tag_commit "${remote}" "${tag}")" || return 1
+  if [[ "${observed}" != "${source_commit}" ]]; then
+    echo \
+      "go-module-tags: FAIL (${tag} post-create target ${observed} != ${source_commit})" \
+      >&2
+    return 1
+  fi
+}
+
+publish_tag_set() {
+  local remote="$1"
+  local tag="$2"
+  local source_ref="$3"
+
+  go_release_validate_source_contract "${tag}" "${source_ref}" || return 1
+
+  # Detect any known conflict before creating either ref. The ensure step
+  # repeats this check to stay fail-closed across concurrent publishers.
+  preflight_remote_tag \
+    "${remote}" \
+    "${GO_RELEASE_ROOT_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" || return 1
+  preflight_remote_tag \
+    "${remote}" \
+    "${GO_RELEASE_CDK_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" || return 1
+
+  # Sequential create-only writes make partial failure safely retryable:
+  # an existing same-SHA root tag is retained before the nested tag is retried.
+  ensure_remote_tag \
+    "${remote}" \
+    "${GO_RELEASE_ROOT_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" || return 1
+  ensure_remote_tag \
+    "${remote}" \
+    "${GO_RELEASE_CDK_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" || return 1
+
+  echo \
+    "go-module-tags: PASS (root=${GO_RELEASE_ROOT_TAG} cdk=${GO_RELEASE_CDK_TAG} source=${GO_RELEASE_SOURCE_COMMIT})"
+}
+
+commit_fixture_change() {
+  local subject="$1"
+  local path="$2"
+  local contents="$3"
+
+  mkdir -p "$(dirname "${path}")"
+  printf '%s\n' "${contents}" >"${path}"
+  git add "${path}"
+  git \
+    -c user.name="AppTheory Go Tag Self Test" \
+    -c user.email="apptheory-go-tag-self-test@example.invalid" \
+    commit -q -m "${subject}"
+}
+
+run_self_test() {
+  local temporary
+  local remote
+  local work
+  local source_commit
+  local other_commit
+  local output
+
+  temporary="$(mktemp -d)"
+  remote="${temporary}/remote.git"
+  work="${temporary}/work"
+
+  git init -q --bare "${remote}"
+  git init -q "${work}"
+  if ! (
+    cd "${work}"
+    git checkout -q -b main
+    printf '%s\n' "2.0.0-rc" >VERSION
+    printf '%s\n' \
+      "module github.com/theory-cloud/apptheory/v2" \
+      "" \
+      "go 1.23" >go.mod
+    mkdir -p cdk-go/apptheorycdk
+    printf '%s\n' \
+      "module github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v2" \
+      "" \
+      "go 1.23" >cdk-go/apptheorycdk/go.mod
+    printf '%s\n' "package apptheory" >apptheory.go
+    printf '%s\n' "package apptheorycdk" >cdk-go/apptheorycdk/apptheorycdk.go
+    git add VERSION go.mod apptheory.go cdk-go/apptheorycdk
+    git \
+      -c user.name="AppTheory Go Tag Self Test" \
+      -c user.email="apptheory-go-tag-self-test@example.invalid" \
+      commit -q -m "chore: seed v2 release"
+    source_commit="$(git rev-parse HEAD)"
+
+    commit_fixture_change "chore: create conflicting target" "other.txt" "other"
+    other_commit="$(git rev-parse HEAD)"
+    git remote add origin "${remote}"
+    git push -q origin HEAD:refs/heads/main
+
+    publish_tag_set origin "v2.0.0-rc" "${source_commit}" >/dev/null
+    [[ "$(git --git-dir="${remote}" rev-parse refs/tags/v2.0.0-rc)" == "${source_commit}" ]]
+    [[ "$(
+      git --git-dir="${remote}" rev-parse refs/tags/cdk-go/apptheorycdk/v2.0.0-rc
+    )" == "${source_commit}" ]]
+    echo "go-module-tags self-test: PASS absent refs are created"
+
+    output="$(publish_tag_set origin "v2.0.0-rc" "${source_commit}")"
+    grep -Fq "KEEP (v2.0.0-rc already targets ${source_commit})" <<<"${output}"
+    grep -Fq \
+      "KEEP (cdk-go/apptheorycdk/v2.0.0-rc already targets ${source_commit})" \
+      <<<"${output}"
+    echo "go-module-tags self-test: PASS same-SHA refs are idempotent"
+
+    git --git-dir="${remote}" update-ref -d \
+      refs/tags/cdk-go/apptheorycdk/v2.0.0-rc
+    output="$(publish_tag_set origin "v2.0.0-rc" "${source_commit}")"
+    grep -Fq "KEEP (v2.0.0-rc already targets ${source_commit})" <<<"${output}"
+    grep -Fq \
+      "CREATE (cdk-go/apptheorycdk/v2.0.0-rc -> ${source_commit})" \
+      <<<"${output}"
+    [[ "$(git --git-dir="${remote}" rev-parse refs/tags/v2.0.0-rc)" == "${source_commit}" ]]
+    [[ "$(
+      git --git-dir="${remote}" rev-parse refs/tags/cdk-go/apptheorycdk/v2.0.0-rc
+    )" == "${source_commit}" ]]
+    echo "go-module-tags self-test: PASS partial root-only state is repaired create-only"
+
+    git --git-dir="${remote}" update-ref \
+      refs/tags/cdk-go/apptheorycdk/v2.0.0-rc \
+      "${other_commit}"
+    git --git-dir="${remote}" update-ref -d refs/tags/v2.0.0-rc
+    if output="$(publish_tag_set origin "v2.0.0-rc" "${source_commit}" 2>&1)"; then
+      echo "go-module-tags self-test: FAIL (conflicting nested tag was accepted)" >&2
+      exit 1
+    fi
+    grep -Fq "refs are immutable" <<<"${output}"
+    if git --git-dir="${remote}" show-ref --verify --quiet refs/tags/v2.0.0-rc; then
+      echo "go-module-tags self-test: FAIL (root tag was created after a known nested conflict)" >&2
+      exit 1
+    fi
+    [[ "$(
+      git --git-dir="${remote}" rev-parse refs/tags/cdk-go/apptheorycdk/v2.0.0-rc
+    )" == "${other_commit}" ]]
+    echo "go-module-tags self-test: PASS known nested conflict fails before either ref mutates"
+
+    git --git-dir="${remote}" update-ref \
+      refs/tags/cdk-go/apptheorycdk/v2.0.0-rc \
+      "${source_commit}"
+    git --git-dir="${remote}" update-ref refs/tags/v2.0.0-rc "${other_commit}"
+    if output="$(publish_tag_set origin "v2.0.0-rc" "${source_commit}" 2>&1)"; then
+      echo "go-module-tags self-test: FAIL (conflicting root tag was accepted)" >&2
+      exit 1
+    fi
+    grep -Fq "refs are immutable" <<<"${output}"
+    [[ "$(git --git-dir="${remote}" rev-parse refs/tags/v2.0.0-rc)" == "${other_commit}" ]]
+    echo "go-module-tags self-test: PASS conflicting root ref fails without mutation"
+  ); then
+    rm -rf "${temporary}"
+    return 1
+  fi
+
+  rm -rf "${temporary}"
+  echo "go-module-tags self-test: PASS"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  run_self_test
+  exit 0
+fi
+
+tag="${1:-}"
+source_ref="${2:-}"
+if [[ -z "${tag}" || -z "${source_ref}" || $# -ne 2 ]]; then
+  echo "go-module-tags: FAIL (usage: $0 <vX.Y.Z[-rc[.N]]> <source-commit>)" >&2
+  exit 1
+fi
+
+publish_tag_set "${GIT_REMOTE:-origin}" "${tag}" "${source_ref}"

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -65,6 +65,40 @@ collect_release_assets() {
   done
 }
 
+release_major() {
+  local release_tag="$1"
+
+  if [[ ! "${release_tag}" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?$ ]]; then
+    echo "release-assets: FAIL (unsupported release tag '${release_tag}')" >&2
+    return 1
+  fi
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+publish_and_verify_go_modules() {
+  local major
+
+  major="$(release_major "${tag}")" || return 1
+  if (( major < 2 )); then
+    echo "release-assets: SKIP (${tag} predates the v2 Go module tag transaction)"
+    return 0
+  fi
+
+  scripts/publish-go-module-tags.sh "${tag}" "${source_commit}"
+  scripts/verify-go-module-tags.sh "${tag}" "${source_commit}"
+}
+
+verify_go_modules() {
+  local major
+
+  major="$(release_major "${tag}")" || return 1
+  if (( major < 2 )); then
+    return 0
+  fi
+
+  scripts/verify-go-module-tags.sh "${tag}" "${source_commit}"
+}
+
 assert_release_target_matches_source() {
   local current_target="$1"
   local resolved_target=""
@@ -205,6 +239,10 @@ scripts/render-release-notes.sh "${tag}"
 asset_paths=()
 collect_release_assets asset_paths
 
+# Create-only root and nested Go tags are committed before any draft release
+# becomes public. Exact direct resolution is part of the same transaction.
+publish_and_verify_go_modules
+
 is_draft="$(release_is_draft)"
 if [[ "${is_draft}" != "true" ]]; then
   verify_published_release_assets
@@ -251,5 +289,6 @@ gh release edit "${tag}" --target "${source_commit}" --draft=false "${prerelease
 
 git fetch "${remote}" tag "${tag}" --force
 scripts/verify-release-branch.sh "${tag}"
+verify_go_modules
 
 echo "release-assets: PASS (${tag} source=${source_commit})"

--- a/scripts/render-release-notes.sh
+++ b/scripts/render-release-notes.sh
@@ -4,6 +4,30 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+if [[ "${1:-}" == "--self-test" ]]; then
+  temporary="$(mktemp -d)"
+  RELEASE_NOTES_OUTPUT_DIR="${temporary}" \
+    bash scripts/render-release-notes.sh "v2.0.0-rc.1" >/dev/null
+  notes="${temporary}/RELEASE_NOTES.md"
+  grep -Fq \
+    'go get github.com/theory-cloud/apptheory/v2@v2.0.0-rc.1' \
+    "${notes}"
+  grep -Fq \
+    'go get github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v2@v2.0.0-rc.1' \
+    "${notes}"
+  grep -Fq \
+    'cdk-go/apptheorycdk/v2.0.0-rc.1` targets the same immutable commit as `v2.0.0-rc.1' \
+    "${notes}"
+  if grep -Fq 'go get github.com/theory-cloud/apptheory@v2.0.0-rc.1' "${notes}"; then
+    echo "release-notes self-test: FAIL (v2 notes contain the legacy root module)" >&2
+    rm -rf "${temporary}"
+    exit 1
+  fi
+  rm -rf "${temporary}"
+  echo "release-notes self-test: PASS (v2 root + nested CDK commands)"
+  exit 0
+fi
+
 tag="${1:-${GITHUB_REF_NAME:-}}"
 if [[ -z "${tag}" ]]; then
   echo "release-notes: FAIL (missing tag name)"
@@ -11,6 +35,27 @@ if [[ -z "${tag}" ]]; then
 fi
 
 version="${tag#v}"
+if [[ ! "${version}" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?$ ]]; then
+  echo "release-notes: FAIL (unsupported tag ${tag})"
+  exit 1
+fi
+major="${BASH_REMATCH[1]}"
+
+go_runtime_module="github.com/theory-cloud/apptheory"
+go_cdk_module="github.com/theory-cloud/apptheory/cdk-go/apptheorycdk"
+go_cdk_lines="- CDK bindings: import \`${go_cdk_module}\` (legacy v1 tags predate the independently tagged CDK module)."
+if (( major >= 2 )); then
+  go_runtime_module+="/v${major}"
+  go_cdk_module+="/v${major}"
+  go_cdk_lines="$(
+    cat <<EOF
+- CDK: \`go get ${go_cdk_module}@${tag}\`
+- CDK import: \`${go_cdk_module}\`
+- Tag provenance: \`cdk-go/apptheorycdk/${tag}\` targets the same immutable commit as \`${tag}\`.
+EOF
+  )"
+fi
+
 python_version="${version}"
 if [[ "${python_version}" == *"-rc."* ]]; then
   # `X.Y.Z-rc.N` -> `X.Y.ZrcN` (PEP 440 normalized wheel/sdist version)
@@ -23,10 +68,11 @@ fi
 repo="theory-cloud/AppTheory"
 repo_url="https://github.com/${repo}"
 docs_base="${repo_url}/blob/${tag}"
+output_dir="${RELEASE_NOTES_OUTPUT_DIR:-dist}"
 
-mkdir -p dist
+mkdir -p "${output_dir}"
 
-cat > dist/RELEASE_NOTES.md <<EOF
+cat >"${output_dir}/RELEASE_NOTES.md" <<EOF
 # AppTheory ${tag}
 
 ## Highlights
@@ -43,8 +89,8 @@ cat > dist/RELEASE_NOTES.md <<EOF
 
 Go:
 
-- \`go get github.com/theory-cloud/apptheory@${tag}\`
-- CDK bindings: import \`github.com/theory-cloud/apptheory/cdk-go/apptheorycdk\` (included in the same module/tag).
+- Runtime: \`go get ${go_runtime_module}@${tag}\`
+${go_cdk_lines}
 
 TypeScript:
 
@@ -78,4 +124,4 @@ Checksums:
 - \`sha256sum -c SHA256SUMS.txt\`
 EOF
 
-echo "release-notes: PASS (dist/RELEASE_NOTES.md)"
+echo "release-notes: PASS (${output_dir}/RELEASE_NOTES.md)"

--- a/scripts/testdata/release-cycle/happy-path.json
+++ b/scripts/testdata/release-cycle/happy-path.json
@@ -1,6 +1,6 @@
 {
   "case": "happy-path",
-  "coverage": ["happy_path"],
+  "coverage": ["happy_path", "go_module_tags"],
   "expected": { "valid": true },
   "states": [
     {
@@ -37,19 +37,19 @@
           "premain": { "head": "P3", "ancestors": ["M2", "P2", "S2", "M1"] }
         },
         "manifests": {
-          "main": { "stable": "1.7.1", "premain": "1.7.1" },
-          "staging": { "stable": "1.7.1", "premain": "1.7.1" },
-          "premain": { "stable": "1.7.1", "premain": "1.7.1" }
+          "main": { "stable": "2.0.0", "premain": "2.0.0" },
+          "staging": { "stable": "2.0.0", "premain": "2.0.0" },
+          "premain": { "stable": "2.0.0", "premain": "2.0.0" }
         },
         "tags": {
           "v1.7.0": { "target": "M1" },
-          "v1.7.1-rc": { "target": "P2" },
-          "v1.7.1": { "target": "M2" }
+          "v2.0.0-rc": { "target": "P2" },
+          "v2.0.0": { "target": "M2" }
         },
         "releases": {
           "v1.7.0": { "state": "published", "target": "M1", "prerelease": false },
-          "v1.7.1-rc": { "state": "published", "target": "P2", "prerelease": true },
-          "v1.7.1": { "state": "published", "target": "M2", "prerelease": false }
+          "v2.0.0-rc": { "state": "published", "target": "P2", "prerelease": true },
+          "v2.0.0": { "state": "published", "target": "M2", "prerelease": false }
         }
       }
     }
@@ -67,7 +67,20 @@
       "generatedArtifactsSynced": true,
       "checksPassed": true
     },
-    { "kind": "publisher", "source": "premain", "tag": "v1.7.1-rc", "serialized": true, "assetsVerified": true },
+    {
+      "kind": "publisher",
+      "source": "premain",
+      "tag": "v2.0.0-rc",
+      "releaseCommit": "P2",
+      "nestedModuleTag": "cdk-go/apptheorycdk/v2.0.0-rc",
+      "rootModuleTagTarget": "P2",
+      "nestedModuleTagTarget": "P2",
+      "tagsCreatedWithoutOverwrite": true,
+      "exactModuleResolutionVerified": true,
+      "modulesVerifiedBeforePublication": true,
+      "serialized": true,
+      "assetsVerified": true
+    },
     { "kind": "promotion", "from": "premain", "to": "main", "ancestorPresent": true },
     {
       "kind": "release_please_pr",
@@ -80,7 +93,20 @@
       "premainManifestReset": true,
       "checksPassed": true
     },
-    { "kind": "publisher", "source": "main", "tag": "v1.7.1", "serialized": true, "assetsVerified": true },
+    {
+      "kind": "publisher",
+      "source": "main",
+      "tag": "v2.0.0",
+      "releaseCommit": "M2",
+      "nestedModuleTag": "cdk-go/apptheorycdk/v2.0.0",
+      "rootModuleTagTarget": "M2",
+      "nestedModuleTagTarget": "M2",
+      "tagsCreatedWithoutOverwrite": true,
+      "exactModuleResolutionVerified": true,
+      "modulesVerifiedBeforePublication": true,
+      "serialized": true,
+      "assetsVerified": true
+    },
     { "kind": "back_merge", "from": "main", "to": "staging", "beforeFurtherStagingWork": true }
   ]
 }

--- a/scripts/testdata/release-cycle/invalid-go-module-resolution.json
+++ b/scripts/testdata/release-cycle/invalid-go-module-resolution.json
@@ -1,0 +1,24 @@
+{
+  "case": "invalid-go-module-resolution",
+  "coverage": ["go_module_tags"],
+  "expected": {
+    "valid": false,
+    "diagnostic_codes": ["publisher:go-module-resolution-unverified"]
+  },
+  "events": [
+    {
+      "kind": "publisher",
+      "source": "premain",
+      "tag": "v2.0.0-rc",
+      "releaseCommit": "P2",
+      "nestedModuleTag": "cdk-go/apptheorycdk/v2.0.0-rc",
+      "rootModuleTagTarget": "P2",
+      "nestedModuleTagTarget": "P2",
+      "tagsCreatedWithoutOverwrite": true,
+      "exactModuleResolutionVerified": false,
+      "modulesVerifiedBeforePublication": true,
+      "serialized": true,
+      "assetsVerified": true
+    }
+  ]
+}

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -27,6 +27,9 @@ required_files=(
   "scripts/verify-release-publish-postcondition.sh"
   "scripts/verify-release-branch-signatures.sh"
   "scripts/publish-release-assets.sh"
+  "scripts/go-module-release-contract.sh"
+  "scripts/publish-go-module-tags.sh"
+  "scripts/verify-go-module-tags.sh"
   "scripts/render-release-artifact-sync-plan.py"
   "scripts/sync-release-pr-generated.sh"
   "scripts/update-cdk-generated.sh"
@@ -305,6 +308,39 @@ for module_artifact in "cdk-go/go.mod" "cdk-go/go.sum" "cdk-go/apptheorycdk"; do
   }
   grep -Fq "${module_artifact}" "scripts/render-release-artifact-sync-plan.py" || {
     echo "branch-release: GitHub artifact plan must include ${module_artifact}"
+    failures=$((failures + 1))
+  }
+done
+
+for module_script in \
+  "scripts/publish-go-module-tags.sh" \
+  "scripts/verify-go-module-tags.sh"
+do
+  grep -Fq "${module_script}" "scripts/publish-release-assets.sh" || {
+    echo "branch-release: release asset publisher must invoke ${module_script}"
+    failures=$((failures + 1))
+  }
+done
+
+grep -Fq "cdk-go/apptheorycdk/" "scripts/go-module-release-contract.sh" || {
+  echo "branch-release: Go module release contract must derive the nested CDK tag prefix"
+  failures=$((failures + 1))
+}
+grep -Fq "GOPROXY=direct" "scripts/verify-go-module-tags.sh" || {
+  echo "branch-release: Go module postcondition must use exact direct VCS resolution"
+  failures=$((failures + 1))
+}
+if grep -Eq 'git (push --force|push -f|tag -f|push --delete)' "scripts/publish-go-module-tags.sh"; then
+  echo "branch-release: Go module tag publisher must never move or delete refs"
+  failures=$((failures + 1))
+fi
+for workflow in ".github/workflows/prerelease.yml" ".github/workflows/release.yml"; do
+  grep -Fq "prepublish" "${workflow}" || {
+    echo "branch-release: ${workflow} must run the prepublish release postcondition"
+    failures=$((failures + 1))
+  }
+  grep -Fq "complete" "${workflow}" || {
+    echo "branch-release: ${workflow} must run the complete Go module postcondition"
     failures=$((failures + 1))
   }
 done

--- a/scripts/verify-go-module-tags.sh
+++ b/scripts/verify-go-module-tags.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Purpose: prove AppTheory root and CDK Go modules resolve at exact immutable release tags.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=go-module-release-contract.sh
+source "${repo_root}/scripts/go-module-release-contract.sh"
+cd "${repo_root}"
+
+verify_remote_tag_target() {
+  local remote="$1"
+  local tag="$2"
+  local source_commit="$3"
+  local observed
+
+  observed="$(go_release_remote_tag_commit "${remote}" "${tag}")" || {
+    echo "go-module-probe: FAIL (${tag} is absent from ${remote})" >&2
+    return 1
+  }
+  if [[ "${observed}" != "${source_commit}" ]]; then
+    echo \
+      "go-module-probe: FAIL (${tag} targets ${observed}; expected ${source_commit})" \
+      >&2
+    return 1
+  fi
+}
+
+probe_one_module() {
+  local module="$1"
+  local tag="$2"
+  local expected_ref="$3"
+  local source_commit="$4"
+  local probe_root="$5"
+  local attempts="${GO_MODULE_PROBE_ATTEMPTS:-5}"
+  local delay="${GO_MODULE_PROBE_DELAY_SECONDS:-2}"
+  local attempt
+  local output_file
+  local error_file
+
+  for (( attempt = 1; attempt <= attempts; attempt++ )); do
+    output_file="${probe_root}/probe-${attempt}.json"
+    error_file="${probe_root}/probe-${attempt}.err"
+    mkdir -p "${probe_root}/mod-${attempt}" "${probe_root}/cache-${attempt}"
+
+    if GIT_TERMINAL_PROMPT=0 \
+      GOMODCACHE="${probe_root}/mod-${attempt}" \
+      GOCACHE="${probe_root}/cache-${attempt}" \
+      GOPROXY=direct \
+      GONOSUMDB="${GO_MODULE_NOSUMDB:-github.com/theory-cloud/apptheory*}" \
+      GOTOOLCHAIN="${GO_MODULE_GOTOOLCHAIN:-local}" \
+      go mod download -json "${module}@${tag}" \
+      >"${output_file}" 2>"${error_file}" &&
+      python3 - \
+        "${output_file}" \
+        "${module}" \
+        "${tag}" \
+        "${expected_ref}" \
+        "${source_commit}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload_path, expected_path, expected_version, expected_ref, expected_commit = sys.argv[1:]
+data = json.loads(Path(payload_path).read_text(encoding="utf-8"))
+
+if data.get("Error"):
+    raise SystemExit(f"resolver returned Error={data['Error']!r}")
+if data.get("Path") != expected_path:
+    raise SystemExit(f"Path={data.get('Path')!r} != {expected_path!r}")
+if data.get("Version") != expected_version:
+    raise SystemExit(f"Version={data.get('Version')!r} != {expected_version!r}")
+
+origin = data.get("Origin")
+if not isinstance(origin, dict):
+    raise SystemExit("resolver did not return Origin")
+if origin.get("Hash") != expected_commit:
+    raise SystemExit(f"Origin.Hash={origin.get('Hash')!r} != {expected_commit!r}")
+if origin.get("Ref") != expected_ref:
+    raise SystemExit(f"Origin.Ref={origin.get('Ref')!r} != {expected_ref!r}")
+
+go_mod = data.get("GoMod")
+if not isinstance(go_mod, str) or not Path(go_mod).is_file():
+    raise SystemExit("resolver did not materialize GoMod")
+module_line = next(
+    (
+        line.split(maxsplit=1)[1]
+        for line in Path(go_mod).read_text(encoding="utf-8").splitlines()
+        if line.startswith("module ")
+    ),
+    "",
+)
+if module_line != expected_path:
+    raise SystemExit(f"downloaded module directive={module_line!r} != {expected_path!r}")
+PY
+    then
+      echo \
+        "go-module-probe: PASS (${module}@${tag} ref=${expected_ref} source=${source_commit})"
+      return 0
+    fi
+
+    if (( attempt < attempts )); then
+      sleep "${delay}"
+    fi
+  done
+
+  echo \
+    "go-module-probe: FAIL (${module}@${tag} did not resolve exactly after ${attempts} attempts)" \
+    >&2
+  if [[ -s "${error_file}" ]]; then
+    sed -n '1,40p' "${error_file}" >&2
+  fi
+  if [[ -s "${output_file}" ]]; then
+    sed -n '1,80p' "${output_file}" >&2
+  fi
+  return 1
+}
+
+verify_module_set() {
+  local remote="$1"
+  local tag="$2"
+  local source_ref="$3"
+  local temporary
+
+  if ! command -v go >/dev/null 2>&1; then
+    echo "go-module-probe: FAIL (go not found)" >&2
+    return 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "go-module-probe: FAIL (python3 not found)" >&2
+    return 1
+  fi
+
+  go_release_validate_source_contract "${tag}" "${source_ref}" || return 1
+  verify_remote_tag_target \
+    "${remote}" \
+    "${GO_RELEASE_ROOT_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" || return 1
+  verify_remote_tag_target \
+    "${remote}" \
+    "${GO_RELEASE_CDK_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" || return 1
+
+  temporary="$(mktemp -d)"
+  if ! probe_one_module \
+    "${GO_RELEASE_ROOT_MODULE}" \
+    "${GO_RELEASE_ROOT_TAG}" \
+    "refs/tags/${GO_RELEASE_ROOT_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" \
+    "${temporary}/root"
+  then
+    chmod -R u+w "${temporary}" 2>/dev/null || true
+    rm -rf "${temporary}"
+    return 1
+  fi
+  if ! probe_one_module \
+    "${GO_RELEASE_CDK_MODULE}" \
+    "${GO_RELEASE_ROOT_TAG}" \
+    "refs/tags/${GO_RELEASE_CDK_TAG}" \
+    "${GO_RELEASE_SOURCE_COMMIT}" \
+    "${temporary}/cdk"
+  then
+    chmod -R u+w "${temporary}" 2>/dev/null || true
+    rm -rf "${temporary}"
+    return 1
+  fi
+  chmod -R u+w "${temporary}" 2>/dev/null || true
+  rm -rf "${temporary}"
+
+  echo \
+    "go-module-probe: PASS (root=${GO_RELEASE_ROOT_MODULE}@${GO_RELEASE_ROOT_TAG} cdk=${GO_RELEASE_CDK_MODULE}@${GO_RELEASE_ROOT_TAG})"
+}
+
+run_self_test() {
+  local temporary
+  local remote
+  local work
+  local source_commit
+  local other_commit
+  local instead_of
+  local output
+
+  temporary="$(mktemp -d)"
+  remote="${temporary}/remote.git"
+  work="${temporary}/work"
+
+  git init -q --bare "${remote}"
+  git init -q "${work}"
+  if ! (
+    cd "${work}"
+    git checkout -q -b main
+    printf '%s\n' "2.0.0-rc" >VERSION
+    printf '%s\n' \
+      "module github.com/theory-cloud/apptheory/v2" \
+      "" \
+      "go 1.23" >go.mod
+    mkdir -p cdk-go/apptheorycdk
+    printf '%s\n' \
+      "module github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v2" \
+      "" \
+      "go 1.23" >cdk-go/apptheorycdk/go.mod
+    printf '%s\n' "package apptheory" >apptheory.go
+    printf '%s\n' "package apptheorycdk" >cdk-go/apptheorycdk/apptheorycdk.go
+    git add VERSION go.mod apptheory.go cdk-go/apptheorycdk
+    git \
+      -c user.name="AppTheory Go Probe Self Test" \
+      -c user.email="apptheory-go-probe-self-test@example.invalid" \
+      commit -q -m "chore: seed v2 release"
+    source_commit="$(git rev-parse HEAD)"
+
+    printf '%s\n' "other" >other.txt
+    git add other.txt
+    git \
+      -c user.name="AppTheory Go Probe Self Test" \
+      -c user.email="apptheory-go-probe-self-test@example.invalid" \
+      commit -q -m "chore: create conflicting target"
+    other_commit="$(git rev-parse HEAD)"
+
+    git remote add origin "${remote}"
+    git push -q origin HEAD:refs/heads/main
+    git --git-dir="${remote}" update-ref refs/tags/v2.0.0-rc "${source_commit}"
+    git --git-dir="${remote}" update-ref \
+      refs/tags/cdk-go/apptheorycdk/v2.0.0-rc \
+      "${source_commit}"
+
+    instead_of="file://${remote}"
+    GIT_CONFIG_COUNT=1 \
+      GIT_CONFIG_KEY_0="url.${instead_of}.insteadOf" \
+      GIT_CONFIG_VALUE_0="https://github.com/theory-cloud/apptheory" \
+      GO_MODULE_PROBE_ATTEMPTS=1 \
+      verify_module_set origin "v2.0.0-rc" "${source_commit}" >/dev/null
+    echo "go-module-probe self-test: PASS exact root and nested resolution"
+
+    git --git-dir="${remote}" update-ref \
+      refs/tags/cdk-go/apptheorycdk/v2.0.0-rc \
+      "${other_commit}"
+    if output="$(
+      GIT_CONFIG_COUNT=1 \
+        GIT_CONFIG_KEY_0="url.${instead_of}.insteadOf" \
+        GIT_CONFIG_VALUE_0="https://github.com/theory-cloud/apptheory" \
+        GO_MODULE_PROBE_ATTEMPTS=1 \
+        verify_module_set origin "v2.0.0-rc" "${source_commit}" 2>&1
+    )"; then
+      echo "go-module-probe self-test: FAIL (conflicting nested target was accepted)" >&2
+      exit 1
+    fi
+    grep -Fq \
+      "cdk-go/apptheorycdk/v2.0.0-rc targets ${other_commit}; expected ${source_commit}" \
+      <<<"${output}"
+    echo "go-module-probe self-test: PASS conflicting target fails closed"
+  ); then
+    chmod -R u+w "${temporary}" 2>/dev/null || true
+    rm -rf "${temporary}"
+    return 1
+  fi
+
+  chmod -R u+w "${temporary}" 2>/dev/null || true
+  rm -rf "${temporary}"
+  echo "go-module-probe self-test: PASS"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  run_self_test
+  exit 0
+fi
+
+tag="${1:-}"
+source_ref="${2:-}"
+if [[ -z "${tag}" || -z "${source_ref}" || $# -ne 2 ]]; then
+  echo "go-module-probe: FAIL (usage: $0 <vX.Y.Z[-rc[.N]]> <source-commit>)" >&2
+  exit 1
+fi
+
+verify_module_set "${GIT_REMOTE:-origin}" "${tag}" "${source_ref}"

--- a/scripts/verify-release-cycle.sh
+++ b/scripts/verify-release-cycle.sh
@@ -18,6 +18,7 @@ from typing import Any
 
 REQUIRED_COVERAGE = {
     "happy_path": "happy path",
+    "go_module_tags": "root and nested Go module tag closure",
     "publish_recovery_race": "publish/recovery race",
     "stale_release_please_pr": "stale Release Please PR state",
     "promotion_drift": "promotion drift",
@@ -169,6 +170,7 @@ def validate_release_pr(event: dict[str, Any], diags: list[Diagnostic]) -> None:
 def validate_publisher(event: dict[str, Any], diags: list[Diagnostic]) -> None:
     tag = event.get("tag")
     source = event.get("source")
+    release_commit = event.get("releaseCommit")
     if source == "premain":
         if not isinstance(tag, str) or "-rc" not in tag:
             add(diags, "publisher:wrong-prerelease-tag", "premain publisher must use an rc tag")
@@ -182,6 +184,46 @@ def validate_publisher(event: dict[str, Any], diags: list[Diagnostic]) -> None:
         add(diags, "publisher:not-serialized", "release publishers must share the non-cancelling release-publisher queue")
     if event.get("assetsVerified") is not True:
         add(diags, "publisher:assets-not-verified", "release publisher must verify source-built assets before publication or skip")
+
+    expected_nested_tag = f"cdk-go/apptheorycdk/{tag}" if isinstance(tag, str) else None
+    if event.get("nestedModuleTag") != expected_nested_tag:
+        add(
+            diags,
+            "publisher:wrong-nested-module-tag",
+            f"nested Go module tag must be {expected_nested_tag!r}",
+        )
+    if not isinstance(release_commit, str) or not release_commit:
+        add(diags, "publisher:missing-release-commit", "publisher must pin one immutable release commit")
+    if event.get("rootModuleTagTarget") != release_commit:
+        add(
+            diags,
+            "publisher:root-module-target-mismatch",
+            "root Go tag must target the immutable release commit",
+        )
+    if event.get("nestedModuleTagTarget") != release_commit:
+        add(
+            diags,
+            "publisher:nested-module-target-mismatch",
+            "nested CDK Go tag must target the same immutable release commit",
+        )
+    if event.get("tagsCreatedWithoutOverwrite") is not True:
+        add(
+            diags,
+            "publisher:mutable-module-tags",
+            "Go module tags must be create-only and must reject conflicting refs",
+        )
+    if event.get("exactModuleResolutionVerified") is not True:
+        add(
+            diags,
+            "publisher:go-module-resolution-unverified",
+            "publisher must prove exact-version root and CDK Go module resolution",
+        )
+    if event.get("modulesVerifiedBeforePublication") is not True:
+        add(
+            diags,
+            "publisher:module-verification-after-publication",
+            "Go module tags and resolution must be proved before publication completes",
+        )
 
 
 def validate_publisher_race(event: dict[str, Any], diags: list[Diagnostic]) -> None:

--- a/scripts/verify-release-publish-postcondition.sh
+++ b/scripts/verify-release-publish-postcondition.sh
@@ -269,6 +269,52 @@ require_created_tag() {
   fi
 }
 
+run_go_module_verifier() {
+  scripts/verify-go-module-tags.sh "$1" "$2"
+}
+
+verify_go_module_postcondition() {
+  local release_tag
+  local major
+  local source_commit
+
+  if [[ "${phase}" != "complete" ]]; then
+    return 0
+  fi
+
+  release_tag="${tag_name:-${expected_tag}}"
+  if [[ ! "${release_tag}" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?$ ]]; then
+    echo \
+      "release-publish-postcondition: FAIL (cannot derive Go module contract from ${release_tag})" \
+      >&2
+    return 1
+  fi
+  major="${BASH_REMATCH[1]}"
+  if (( major < 2 )); then
+    echo \
+      "release-publish-postcondition: SKIP (${release_tag} predates the v2 Go module tag contract)"
+    return 0
+  fi
+
+  fetch_base_branch_and_tags "${channel_base_branch}" || {
+    echo \
+      "release-publish-postcondition: FAIL (could not fetch ${channel_base_branch} and module tags)" \
+      >&2
+    return 1
+  }
+  source_commit="$(git rev-parse --verify "${release_tag}^{commit}" 2>/dev/null || true)"
+  if [[ ! "${source_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo \
+      "release-publish-postcondition: FAIL (${release_tag} is not a local immutable commit tag)" \
+      >&2
+    return 1
+  fi
+
+  run_go_module_verifier "${release_tag}" "${source_commit}" || return 1
+  echo \
+    "release-publish-postcondition: PASS (${release_tag} root + nested Go modules resolve at ${source_commit})"
+}
+
 commit_self_test_change() {
   local subject="$1"
   local path="$2"
@@ -380,20 +426,87 @@ self_test_prerelease_already_published_noop() {
   rm -rf "${tmp}"
 }
 
+self_test_complete_go_module_postcondition() {
+  local tmp
+  local source_commit
+  local calls
+
+  tmp="$(mktemp -d)"
+  (
+    cd "${tmp}"
+    git init -q
+    git checkout -q -b main
+    commit_self_test_change "chore: seed v2 module postcondition" "self-test.txt" "v2"
+    source_commit="$(git rev-parse HEAD)"
+    git update-ref refs/tags/v2.0.0 "${source_commit}"
+
+    expected_tag="v2.0.0"
+    tag_name="v2.0.0"
+    channel_base_branch="main"
+    calls="${tmp}/calls.txt"
+
+    fetch_base_branch_and_tags() {
+      return 0
+    }
+    run_go_module_verifier() {
+      printf '%s %s\n' "$1" "$2" >>"${calls}"
+    }
+
+    phase="prepublish"
+    verify_go_module_postcondition
+    if [[ -e "${calls}" ]]; then
+      echo \
+        "release-publish-postcondition: FAIL (prepublish phase ran the external Go resolver)" \
+        >&2
+      return 1
+    fi
+
+    phase="complete"
+    verify_go_module_postcondition >/dev/null
+    grep -Fxq "v2.0.0 ${source_commit}" "${calls}" || {
+      echo \
+        "release-publish-postcondition: FAIL (complete phase did not prove the exact Go module tag)" \
+        >&2
+      return 1
+    }
+  )
+  rm -rf "${tmp}"
+  echo \
+    "release-publish-postcondition: PASS (self-test complete phase proves exact Go module resolution)"
+}
+
 if [[ "${1:-}" == "--self-test" ]]; then
   self_test_stable_already_published_noop
   self_test_prerelease_already_published_noop
+  self_test_complete_go_module_postcondition
   exit $?
 fi
 
 channel="${1:-}"
 release_created="${2:-}"
 tag_name="${3:-}"
+phase="${4:-prepublish}"
 
 case "${channel}" in
-  prerelease|stable) ;;
+  prerelease)
+    channel_base_branch="premain"
+    ;;
+  stable)
+    channel_base_branch="main"
+    ;;
   *)
-    echo "release-publish-postcondition: FAIL (usage: $0 prerelease|stable <release_created> <tag_name>)" >&2
+    echo \
+      "release-publish-postcondition: FAIL (usage: $0 prerelease|stable <release_created> <tag_name> prepublish|complete)" \
+      >&2
+    exit 1
+    ;;
+esac
+case "${phase}" in
+  prepublish|complete) ;;
+  *)
+    echo \
+      "release-publish-postcondition: FAIL (phase must be prepublish or complete; got ${phase})" \
+      >&2
     exit 1
     ;;
 esac
@@ -404,6 +517,7 @@ case "${channel}" in
   prerelease)
     if is_rc_tag "${expected_tag}"; then
       require_created_tag "RC" || exit 1
+      verify_go_module_postcondition || exit 1
       if [[ "${release_created}" != "true" ]]; then
         exit 0
       fi
@@ -433,6 +547,7 @@ case "${channel}" in
     fi
 
     require_created_tag "stable" || exit 1
+    verify_go_module_postcondition || exit 1
     if [[ "${release_created}" != "true" ]]; then
       exit 0
     fi

--- a/scripts/verify-release-workflows.sh
+++ b/scripts/verify-release-workflows.sh
@@ -213,14 +213,45 @@ require_contains(
 )
 require_contains(
     ".github/workflows/prerelease.yml",
-    "Recover existing draft prerelease assets",
-    "prerelease reruns must recover draft releases left by a failed first attempt",
+    "Recover or verify existing prerelease",
+    "prerelease reruns must recover drafts and verify already-published immutable releases",
 )
 require_contains(
     ".github/workflows/release.yml",
-    "Recover existing draft release assets",
-    "stable reruns must recover draft releases left by a failed first attempt",
+    "Recover or verify existing stable release",
+    "stable reruns must recover drafts and verify already-published immutable releases",
 )
+for workflow, channel, closure_step in (
+    (".github/workflows/prerelease.yml", "prerelease", "Verify prerelease publication closure"),
+    (".github/workflows/release.yml", "stable", "Verify stable publication closure"),
+):
+    require_not_contains(
+        workflow,
+        "--json isDraft",
+        "release reruns must verify already-published releases instead of skipping non-drafts",
+    )
+    require_contains(
+        workflow,
+        f'scripts/verify-release-publish-postcondition.sh {channel} "${{RELEASE_CREATED}}" "${{TAG_NAME}}" prepublish',
+        "release workflows must validate Release Please output before the publisher mutates tag state",
+    )
+    require_contains(
+        workflow,
+        f'scripts/verify-release-publish-postcondition.sh {channel} "${{RELEASE_CREATED}}" "${{TAG_NAME}}" complete',
+        "release workflows must prove Go module publication closure after the publisher",
+    )
+    require_order(
+        workflow,
+        "prepublish",
+        closure_step,
+        "release workflows must run the prepublish gate before the complete publication postcondition",
+    )
+    require_order(
+        workflow,
+        'scripts/publish-release-assets.sh "${TAG_NAME}"',
+        closure_step,
+        "release workflows must finish the serialized publisher before the complete postcondition",
+    )
 for workflow in (".github/workflows/prerelease.yml", ".github/workflows/release.yml"):
     require_contains(
         workflow,
@@ -241,6 +272,16 @@ require_contains(
     "scripts/diagnose-release-state.sh",
     "release-diagnostics: tag=",
     "release diagnostics must print the active tag state",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "go-module-tag=",
+    "release diagnostics must report nested Go module tag state",
+)
+require_contains(
+    "scripts/diagnose-release-state.sh",
+    "cut a new version",
+    "release diagnostics must refuse repair by moving a conflicting immutable module tag",
 )
 require_contains(
     "scripts/diagnose-release-state.sh",
@@ -302,6 +343,79 @@ require_order(
     "scripts/generate-checksums.sh",
     'gh release upload "${tag}"',
     "release asset publisher must checksum artifacts before upload",
+)
+require_order_after(
+    "scripts/publish-release-assets.sh",
+    "scripts/generate-checksums.sh",
+    "collect_release_assets asset_paths",
+    "publish_and_verify_go_modules",
+    "release asset publisher must finish deterministic source builds before creating module tags",
+)
+require_order(
+    "scripts/publish-release-assets.sh",
+    "scripts/publish-go-module-tags.sh",
+    "scripts/verify-go-module-tags.sh",
+    "release asset publisher must create immutable module tags before exact resolution",
+)
+require_order_after(
+    "scripts/publish-release-assets.sh",
+    "collect_release_assets asset_paths",
+    "publish_and_verify_go_modules",
+    'gh release upload "${tag}"',
+    "release asset publisher must prove Go modules before uploading draft assets",
+)
+require_order_after(
+    "scripts/publish-release-assets.sh",
+    "collect_release_assets asset_paths",
+    "publish_and_verify_go_modules",
+    'gh release edit "${tag}" --target "${source_commit}" --draft=false',
+    "release asset publisher must prove Go modules before publication becomes visible",
+)
+for path in (
+    "scripts/go-module-release-contract.sh",
+    "scripts/publish-go-module-tags.sh",
+    "scripts/verify-go-module-tags.sh",
+):
+    require_contains(
+        "scripts/verify-branch-release-supply-chain.sh",
+        path,
+        f"release supply-chain verifier must require {path}",
+    )
+for forbidden in (
+    "git push --force",
+    "git push -f",
+    "git tag -f",
+    "git push --delete",
+):
+    require_not_contains(
+        "scripts/publish-go-module-tags.sh",
+        forbidden,
+        "Go module tag publisher must never move or delete an existing tag",
+    )
+require_contains(
+    "scripts/publish-go-module-tags.sh",
+    "refs are immutable",
+    "Go module tag publisher must fail closed on a conflicting existing ref",
+)
+require_contains(
+    "scripts/publish-go-module-tags.sh",
+    "concurrently created",
+    "Go module tag publisher must safely accept a same-SHA create race",
+)
+require_contains(
+    "scripts/verify-go-module-tags.sh",
+    "GOPROXY=direct",
+    "Go module postcondition must bypass stale proxy state and resolve the exact Git refs",
+)
+require_contains(
+    "scripts/verify-go-module-tags.sh",
+    'origin.get("Hash")',
+    "Go module postcondition must prove the resolved commit hash",
+)
+require_contains(
+    "scripts/verify-go-module-tags.sh",
+    'origin.get("Ref")',
+    "Go module postcondition must prove the root or nested tag ref",
 )
 require_contains(
     "scripts/publish-release-assets.sh",
@@ -605,6 +719,7 @@ require_contains(
 )
 for coverage in (
     "happy_path",
+    "go_module_tags",
     "publish_recovery_race",
     "stale_release_please_pr",
     "promotion_drift",
@@ -675,6 +790,18 @@ require_order(
     "Verify branch version sync (release preflight)",
     "Verify release workflow invariants (release preflight)",
     "prerelease creation must fail closed on stale branch release state before release workflow checks",
+)
+require_order(
+    ".github/workflows/prerelease.yml",
+    "actions/setup-go",
+    "Verify release workflow invariants (release preflight)",
+    "prerelease workflow checks must use the pinned Go toolchain for module probe self-tests",
+)
+require_order(
+    ".github/workflows/release.yml",
+    "actions/setup-go",
+    "Verify release workflow invariants (stable release preflight)",
+    "stable workflow checks must use the pinned Go toolchain for module probe self-tests",
 )
 require_contains(
     ".github/workflows/prerelease-pr.yml",
@@ -1101,6 +1228,10 @@ for forbidden in (
 subprocess.run(["bash", "scripts/verify-branch-version-sync.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/verify-release-pr-postcondition.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/verify-release-publish-postcondition.sh", "--self-test"], check=True)
+subprocess.run(["bash", "scripts/publish-go-module-tags.sh", "--self-test"], check=True)
+subprocess.run(["bash", "scripts/verify-go-module-tags.sh", "--self-test"], check=True)
+subprocess.run(["bash", "scripts/render-release-notes.sh", "--self-test"], check=True)
+subprocess.run(["bash", "scripts/diagnose-release-state.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/sync-release-pr-generated.sh", "--self-test"], check=True)
 subprocess.run(["bash", "scripts/verify-release-please-token-safety.sh"], check=True)
 


### PR DESCRIPTION
## Milestone
`go-v2-release-closure` — close the AppTheory v2 Go distribution contract in the normal prerelease and stable release train.

## Linear
[AppTheory 2.0: Go v2 Release Contract](https://linear.app/theorycloud/project/apptheory-20-go-v2-release-contract-ca71995ed228) / [THE-2723](https://linear.app/theorycloud/issue/THE-2723/publish-and-verify-immutable-go-module-tags-in-the-release-train)

## Tasks
- [x] THE-2723 — Publish and verify immutable Go module tags in the release train

## Contract impact
Breaking distribution contract; no runtime fixture change. The publisher now treats root and nested CDK Go tags as one create-only, fail-closed release transaction and proves exact Go resolution before publication completes.

## Release safety
- Targets `staging`; `origin/main` is an ancestor of the branch tip.
- `VERSION` and both Release Please manifests are unchanged.
- Conflicting tags are never moved, deleted, or overwritten.
- Partial root-only publication is safe to retry.
- Existing published releases are verified rather than skipped.

## Validation
Commands run on the final commit:
- `make rubric` — PASS (29/29)
- `make test` — PASS
- `make test-unit` — PASS
- `./scripts/verify-contract-tests.sh` — PASS (224 fixtures in Go, TypeScript, and Python)
- `./scripts/verify-version-alignment.sh` — PASS
- `./scripts/publish-go-module-tags.sh --self-test` — PASS (absent, same-SHA, partial, conflicting-SHA)
- `./scripts/verify-go-module-tags.sh --self-test` — PASS
- `./scripts/verify-release-publish-postcondition.sh --self-test` — PASS
- `./scripts/verify-release-cycle.sh` — PASS
- `./scripts/verify-release-workflows.sh` — PASS
- `./scripts/verify-branch-release-supply-chain.sh` — PASS
- `./scripts/verify-release-gates.sh` — PASS

## Cross-repo notes
TableTheory v2.0.5 pins are already present in the inherited `staging` baseline. No TableTheory or FaceTheory repository change is included here.