### PR TITLE
fix(security): clear brace-expansion SEC-2/SEC-4 advisory drift

### DIFF
--- a/docs/dependency-automation.md
+++ b/docs/dependency-automation.md
@@ -120,7 +120,14 @@ passed `npm audit` with zero vulnerabilities. The removal rationale was:
   transitive dependency unless a current advisory or contract gate requires it.
 
 AWS CDK `2.261.0` currently bundles `brace-expansion@5.0.6` inside its published tarball. That copy is affected by
-`GHSA-3jxr-9vmj-r5cp`, and `npm audit fix` cannot replace a bundled dependency. AppTheory therefore carries a visible,
-exact-match exception in its CDK npm-audit and GovTheory OSV gates through **2026-08-05**. The exception applies only to
-the fixed-input CDK synthesis toolchain, not shipped Lambda assets, and fails closed if the advisory, package path,
-AWS CDK version, bundled graph, or expiry changes. Remove it as soon as AWS CDK bundles `brace-expansion>=5.0.7`.
+`GHSA-3jxr-9vmj-r5cp` and `GHSA-mh99-v99m-4gvg`, and `npm audit fix` cannot replace a bundled dependency. AppTheory
+therefore carries a visible, exact-match exception in its CDK npm-audit and GovTheory OSV gates through **2026-08-05**.
+The exception applies only to the fixed-input CDK synthesis toolchain, not shipped Lambda assets, and fails closed if
+the advisory, package path, AWS CDK version, bundled graph, or expiry changes. Remove it as soon as AWS CDK bundles
+`brace-expansion>=5.0.8`.
+
+The TypeScript lint graph still requires `minimatch@3.1.4 -> brace-expansion@1.1.16`; `GHSA-mh99-v99m-4gvg` has no
+patched 1.x release, and forcing the ESM/object-exporting 5.x package into minimatch 3 breaks the linter. AppTheory
+therefore carries one separate, exact, development-only SEC-2 exception for that path through **2026-08-05**. The
+independently resolvable minimatch 10 path is pinned by the lockfile to fixed `brace-expansion@5.0.8`. Any lint-parent,
+minimatch, package, advisory, path, or expiry drift fails closed.

--- a/gov-infra/README.md
+++ b/gov-infra/README.md
@@ -21,10 +21,15 @@ Notes:
   plus lightweight scans of `go.mod` and Python dependency files. Use the allowlist only with justification:
   `gov-infra/planning/apptheory-supply-chain-allowlist.txt`.
 - `SEC-2` vulnerability exceptions are not a general allowlist. The current AWS CDK `2.261.0` tarball bundles
-  `brace-expansion@5.0.6`, which cannot be replaced by npm and is affected by `GHSA-3jxr-9vmj-r5cp`. The verifier keeps
-  that exact build-tool-only finding visible through a narrow exception that expires on **2026-08-05**; any advisory,
-  package graph, version, path, or expiry drift fails closed. Remove the exception as soon as AWS CDK bundles
-  `brace-expansion>=5.0.7`.
+  `brace-expansion@5.0.6`, which cannot be replaced by npm and is affected by `GHSA-3jxr-9vmj-r5cp` and
+  `GHSA-mh99-v99m-4gvg`. The verifier keeps exactly those two build-tool-only findings visible through a narrow
+  exception that expires on **2026-08-05**; any advisory, package graph, version, path, or expiry drift fails closed.
+  Remove the exception as soon as AWS CDK bundles `brace-expansion>=5.0.8`.
+- The TypeScript lint graph still requires `minimatch@3.1.4 -> brace-expansion@1.1.16`; the new advisory has no patched
+  1.x release, and forcing the ESM/object-exporting 5.x package into minimatch 3 breaks the linter. SEC-2 therefore
+  records one separate, exact, development-only exception for `GHSA-mh99-v99m-4gvg` on that path, also expiring on
+  **2026-08-05**. The independently resolvable minimatch 10 path is pinned by the lockfile to fixed
+  `brace-expansion@5.0.8`. Any lint-parent, minimatch, package, advisory, path, or expiry drift fails closed.
 
 ## What’s In Here
 

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -753,10 +753,238 @@ gov_cmd_sast() {
   scripts/verify-go-lint.sh
 }
 
+check_visible_ts_brace_finding() {
+  local report_path="$1"
+  local lockfile_path="$2"
+
+  OSV_REPORT="${report_path}" OSV_LOCKFILE="${lockfile_path}" node <<'NODE'
+const fs = require("fs");
+
+function fail(message) {
+  console.error(`osv-scanner: FAIL (${message})`);
+  process.exit(1);
+}
+
+function readJson(path, description) {
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (err) {
+    fail(`could not parse ${description} ${path}: ${err.message}`);
+  }
+}
+
+function normalizePath(path) {
+  return String(path ?? "").replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function sameStringSet(actual, expected) {
+  if (actual.length !== expected.length) return false;
+  const actualSorted = [...actual].sort();
+  const expectedSorted = [...expected].sort();
+  return actualSorted.every((value, index) => value === expectedSorted[index]);
+}
+
+function fixedVersions(vuln, packageName) {
+  const versions = [];
+  for (const affected of vuln.affected ?? []) {
+    if (affected?.package?.ecosystem !== "npm" || affected.package.name !== packageName) {
+      continue;
+    }
+    for (const range of affected.ranges ?? []) {
+      for (const event of range.events ?? []) {
+        if (event?.fixed) {
+          versions.push(String(event.fixed));
+        }
+      }
+    }
+  }
+  return [...new Set(versions)];
+}
+
+const report = readJson(process.env.OSV_REPORT, "scanner report");
+const lock = readJson(process.env.OSV_LOCKFILE, "lockfile");
+const exception = {
+  advisoryId: "GHSA-mh99-v99m-4gvg",
+  advisoryUrl: "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+  alias: "CVE-2026-14257",
+  expiresOn: "2026-08-05",
+  fixedVersions: ["5.0.8"],
+  lockfile: normalizePath(process.env.OSV_LOCKFILE),
+  packageName: "brace-expansion",
+  packagePath: "node_modules/brace-expansion",
+  packageVersion: "1.1.16",
+  legacyParents: [
+    {
+      dependencyRange: "^3.1.2",
+      path: "node_modules/@eslint/config-array",
+      version: "0.21.1",
+    },
+    {
+      dependencyRange: "^3.1.2",
+      path: "node_modules/@eslint/eslintrc",
+      version: "3.3.3",
+    },
+    {
+      dependencyRange: "^3.1.2",
+      path: "node_modules/eslint",
+      version: "9.39.2",
+    },
+    {
+      dependencyRange: "^3.1.2",
+      path: "node_modules/eslint-plugin-import",
+      version: "2.32.0",
+    },
+  ],
+  patchedParent: {
+    dependencyRange: "^10.2.2",
+    path: "node_modules/@typescript-eslint/typescript-estree",
+    version: "8.57.2",
+  },
+  patchedPackagePath: "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion",
+  patchedPackageVersion: "5.0.8",
+  patchedTransitivePath: "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch",
+  patchedTransitiveVersion: "10.2.5",
+  vulnerableTransitivePath: "node_modules/minimatch",
+  vulnerableTransitiveVersion: "3.1.4",
+};
+
+if (new Date().toISOString().slice(0, 10) > exception.expiresOn) {
+  fail(
+    `TypeScript lint-tool ${exception.packageName} exception expired on ${exception.expiresOn}; update the lint dependency graph or re-review the finding`,
+  );
+}
+
+const packages = lock.packages ?? {};
+const bracePaths = Object.keys(packages).filter(
+  (path) => path === "node_modules/brace-expansion" || path.endsWith("/node_modules/brace-expansion"),
+);
+const minimatchParents = Object.entries(packages)
+  .filter(([, pkg]) => pkg?.dependencies?.minimatch)
+  .map(([path, pkg]) => ({
+    dependencyRange: pkg.dependencies.minimatch,
+    path,
+    version: pkg.version,
+  }));
+const expectedParents = [...exception.legacyParents, exception.patchedParent].map((parent) =>
+  JSON.stringify(parent),
+);
+const actualParents = minimatchParents.map((parent) => JSON.stringify(parent));
+const vulnerablePackage = packages[exception.packagePath];
+const patchedPackage = packages[exception.patchedPackagePath];
+const patchedTransitivePackage = packages[exception.patchedTransitivePath];
+const vulnerableTransitivePackage = packages[exception.vulnerableTransitivePath];
+
+if (
+  !sameStringSet(bracePaths, [exception.packagePath, exception.patchedPackagePath]) ||
+  !sameStringSet(actualParents, expectedParents) ||
+  vulnerablePackage?.version !== exception.packageVersion ||
+  vulnerablePackage?.dev !== true ||
+  vulnerablePackage?.dependencies?.["balanced-match"] !== "^1.0.0" ||
+  vulnerablePackage?.dependencies?.["concat-map"] !== "0.0.1" ||
+  patchedPackage?.version !== exception.patchedPackageVersion ||
+  patchedPackage?.dev !== true ||
+  patchedPackage?.dependencies?.["balanced-match"] !== "^4.0.2" ||
+  patchedTransitivePackage?.version !== exception.patchedTransitiveVersion ||
+  patchedTransitivePackage?.dev !== true ||
+  patchedTransitivePackage?.dependencies?.[exception.packageName] !== "^5.0.5" ||
+  vulnerableTransitivePackage?.version !== exception.vulnerableTransitiveVersion ||
+  vulnerableTransitivePackage?.dev !== true ||
+  vulnerableTransitivePackage?.dependencies?.[exception.packageName] !== "^1.1.7"
+) {
+  fail(`lockfile graph no longer matches the reviewed TypeScript lint-tool ${exception.packageName} exception`);
+}
+
+const visible = [];
+const unexpected = [];
+for (const result of report.results ?? []) {
+  for (const pkg of result.packages ?? []) {
+    for (const vuln of pkg.vulnerabilities ?? []) {
+      const sourcePath = normalizePath(result?.source?.path);
+      const packageInfo = pkg?.package ?? {};
+      const aliases = (vuln.aliases ?? []).map(String);
+      const dependencyGroups = (pkg.dependency_groups ?? []).map(String);
+      const matches =
+        (sourcePath === exception.lockfile || sourcePath.endsWith(`/${exception.lockfile}`)) &&
+        packageInfo.ecosystem === "npm" &&
+        packageInfo.name === exception.packageName &&
+        packageInfo.version === exception.packageVersion &&
+        sameStringSet(dependencyGroups, ["dev"]) &&
+        vuln.id === exception.advisoryId &&
+        sameStringSet(aliases, [exception.alias]) &&
+        sameStringSet(fixedVersions(vuln, exception.packageName), exception.fixedVersions);
+
+      if (matches) {
+        visible.push(vuln);
+      } else {
+        unexpected.push({
+          id: vuln.id ?? "<unknown>",
+          packageName: packageInfo.name ?? "<unknown>",
+          source: result?.source?.path ?? "<unknown>",
+          version: packageInfo.version ?? "<unknown>",
+        });
+      }
+    }
+  }
+}
+
+if (unexpected.length > 0 || visible.length !== 1) {
+  for (const vuln of unexpected) {
+    console.error(
+      `osv-scanner: unexpected vulnerability ${vuln.id} in ${vuln.packageName}@${vuln.version} from ${vuln.source}`,
+    );
+  }
+  fail(`expected exactly one visible TypeScript lint-tool finding, matched ${visible.length}`);
+}
+
+console.error(
+  `osv-scanner: WARN ${JSON.stringify({
+    recordType: "reviewed-vulnerability-exception",
+    exceptionId: "typescript-legacy-minimatch-brace-expansion",
+    advisoryId: exception.advisoryId,
+    advisoryUrl: exception.advisoryUrl,
+    alias: exception.alias,
+    fixedVersions: exception.fixedVersions,
+    expiresOn: exception.expiresOn,
+    lockfile: exception.lockfile,
+    package: {
+      name: exception.packageName,
+      path: exception.packagePath,
+      version: exception.packageVersion,
+    },
+    provenance: {
+      legacyMinimatch: {
+        dependencyRange: "^1.1.7",
+        path: exception.vulnerableTransitivePath,
+        version: exception.vulnerableTransitiveVersion,
+      },
+      legacyParents: exception.legacyParents,
+      patchedBranch: {
+        braceExpansion: {
+          path: exception.patchedPackagePath,
+          version: exception.patchedPackageVersion,
+        },
+        minimatch: {
+          dependencyRange: "^5.0.5",
+          path: exception.patchedTransitivePath,
+          version: exception.patchedTransitiveVersion,
+        },
+        parent: exception.patchedParent,
+      },
+    },
+  })}`,
+);
+NODE
+}
+
 osv_scan_lockfile() {
   local lf="$1"
+  local exception_kind=""
 
-  if ! grep -Fq '"node_modules/aws-cdk-lib/node_modules/brace-expansion"' "${lf}"; then
+  if [[ "${lf}" == "ts/package-lock.json" ]]; then
+    exception_kind="ts"
+  elif grep -Fq '"node_modules/aws-cdk-lib/node_modules/brace-expansion"' "${lf}"; then
+    exception_kind="aws-cdk"
+  else
     osv-scanner scan --lockfile="${lf}"
     return $?
   fi
@@ -769,16 +997,21 @@ osv_scan_lockfile() {
   local scan_status=$?
   set -e
 
-  if [[ "${scan_status}" -eq 0 ]]; then
-    rm -f "${tmp_report}"
-    return 0
-  fi
-
   set +e
-  node scripts/check-visible-aws-cdk-finding.mjs osv "${tmp_report}" "${lf}"
+  if [[ "${exception_kind}" == "ts" ]]; then
+    check_visible_ts_brace_finding "${tmp_report}" "${lf}"
+  else
+    node scripts/check-visible-aws-cdk-finding.mjs osv "${tmp_report}" "${lf}"
+  fi
   local filter_status=$?
   set -e
   rm -f "${tmp_report}"
+
+  if [[ "${scan_status}" -eq 0 && "${filter_status}" -eq 0 ]]; then
+    echo "FAIL: vulnerability exception checker accepted an empty scanner report" >&2
+    return 1
+  fi
+
   return "${filter_status}"
 }
 

--- a/scripts/check-visible-aws-cdk-finding.mjs
+++ b/scripts/check-visible-aws-cdk-finding.mjs
@@ -1,4 +1,4 @@
-// Purpose: validate the one visible, expiring vulnerability exception for an
+// Purpose: validate the visible, expiring vulnerability exceptions for one
 // upstream dependency bundled inside the published aws-cdk-lib tarball.
 import fs from "node:fs";
 
@@ -38,13 +38,24 @@ function sameStringSet(actual, expected) {
 const report = readJson(reportPath, "scanner report");
 const lock = readJson(lockfilePath, "lockfile");
 const exception = {
-  advisoryId: "GHSA-3jxr-9vmj-r5cp",
-  advisoryUrl: "https://github.com/advisories/GHSA-3jxr-9vmj-r5cp",
-  affectedRange: ">=3.0.0 <5.0.7",
-  alias: "CVE-2026-13149",
+  advisories: [
+    {
+      advisoryId: "GHSA-3jxr-9vmj-r5cp",
+      advisoryUrl: "https://github.com/advisories/GHSA-3jxr-9vmj-r5cp",
+      affectedRange: ">=3.0.0 <5.0.7",
+      alias: "CVE-2026-13149",
+      fixedVersions: ["1.1.16", "2.1.2", "5.0.7"],
+    },
+    {
+      advisoryId: "GHSA-mh99-v99m-4gvg",
+      advisoryUrl: "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+      affectedRange: "<=5.0.7",
+      alias: "CVE-2026-14257",
+      fixedVersions: ["5.0.8"],
+    },
+  ],
   cdkVersion: "2.261.0",
   expiresOn: "2026-08-05",
-  fixedVersion: "5.0.7",
   lockfile: normalizePath(lockfilePath),
   minimatchVersion: "10.2.5",
   packageName: "brace-expansion",
@@ -84,20 +95,21 @@ if (!lockfileMatchesException()) {
   fail(`lockfile graph no longer matches the reviewed ${exception.packageName} exception`);
 }
 
-function hasFixedVersion(vuln) {
+function fixedVersions(vuln) {
+  const versions = [];
   for (const affected of vuln.affected ?? []) {
     if (affected?.package?.ecosystem !== "npm" || affected.package.name !== exception.packageName) {
       continue;
     }
     for (const range of affected.ranges ?? []) {
       for (const event of range.events ?? []) {
-        if (event?.fixed === exception.fixedVersion) {
-          return true;
+        if (event?.fixed) {
+          versions.push(String(event.fixed));
         }
       }
     }
   }
-  return false;
+  return [...new Set(versions)];
 }
 
 function expectedOsvDependencyGroups() {
@@ -121,10 +133,20 @@ function matchesNpmFinding(vuln) {
     vuln.name === exception.packageName &&
     vuln.severity === "high" &&
     vuln.isDirect === false &&
+    vuln.range === "<=5.0.7" &&
     Array.isArray(vuln.nodes) &&
     sameStringSet(vuln.nodes, [exception.packagePath]) &&
-    sameStringSet(viaUrls, [exception.advisoryUrl]) &&
-    sameStringSet(viaRanges, [exception.affectedRange])
+    Array.isArray(vuln.effects) &&
+    vuln.effects.length === 0 &&
+    viaObjects.length === exception.advisories.length &&
+    sameStringSet(
+      viaUrls,
+      exception.advisories.map((advisory) => advisory.advisoryUrl),
+    ) &&
+    sameStringSet(
+      viaRanges,
+      exception.advisories.map((advisory) => advisory.affectedRange),
+    )
   );
 }
 
@@ -151,7 +173,7 @@ function verifyNpmReport() {
   }
 }
 
-function matchesOsvFinding(result, pkg, vuln) {
+function matchesOsvFinding(result, pkg, vuln, advisory) {
   const sourcePath = normalizePath(result?.source?.path);
   const packageInfo = pkg?.package ?? {};
   const aliases = (vuln.aliases ?? []).map(String);
@@ -163,20 +185,23 @@ function matchesOsvFinding(result, pkg, vuln) {
     packageInfo.name === exception.packageName &&
     packageInfo.version === exception.packageVersion &&
     sameStringSet(dependencyGroups, expectedOsvDependencyGroups()) &&
-    vuln.id === exception.advisoryId &&
-    aliases.includes(exception.alias) &&
-    hasFixedVersion(vuln)
+    vuln.id === advisory.advisoryId &&
+    sameStringSet(aliases, [advisory.alias]) &&
+    sameStringSet(fixedVersions(vuln), advisory.fixedVersions)
   );
 }
 
 function verifyOsvReport() {
   const unexpected = [];
-  let visibleCount = 0;
+  const visibleCounts = new Map(exception.advisories.map((advisory) => [advisory.advisoryId, 0]));
   for (const result of report.results ?? []) {
     for (const pkg of result.packages ?? []) {
       for (const vuln of pkg.vulnerabilities ?? []) {
-        if (matchesOsvFinding(result, pkg, vuln)) {
-          visibleCount += 1;
+        const advisory = exception.advisories.find((candidate) =>
+          matchesOsvFinding(result, pkg, vuln, candidate),
+        );
+        if (advisory) {
+          visibleCounts.set(advisory.advisoryId, visibleCounts.get(advisory.advisoryId) + 1);
         } else {
           unexpected.push({
             id: vuln.id ?? "<unknown>",
@@ -189,13 +214,19 @@ function verifyOsvReport() {
     }
   }
 
-  if (unexpected.length > 0 || visibleCount !== 1) {
+  const incorrectCounts = [...visibleCounts].filter(([, count]) => count !== 1);
+  if (unexpected.length > 0 || incorrectCounts.length > 0) {
     for (const vuln of unexpected) {
       console.error(
         `osv-scanner: unexpected vulnerability ${vuln.id} in ${vuln.packageName}@${vuln.version} from ${vuln.source}`,
       );
     }
-    fail(`expected exactly one visible AWS CDK bundled finding, matched ${visibleCount}`);
+    for (const [advisoryId, count] of incorrectCounts) {
+      console.error(
+        `osv-scanner: expected exactly one visible AWS CDK bundled ${advisoryId} finding, matched ${count}`,
+      );
+    }
+    fail("visible AWS CDK bundled findings did not match the reviewed exception set");
   }
 }
 
@@ -205,6 +236,34 @@ if (mode === "npm") {
   verifyOsvReport();
 }
 
-console.error(
-  `${mode}-scanner: WARN (visible upstream AWS CDK bundle finding ${exception.advisoryId} / ${exception.alias} in ${exception.lockfile}; expires ${exception.expiresOn}; remove when aws-cdk-lib bundles >=${exception.fixedVersion})`,
-);
+for (const advisory of exception.advisories) {
+  console.error(
+    `${mode}-scanner: WARN ${JSON.stringify({
+      recordType: "reviewed-vulnerability-exception",
+      exceptionId: "aws-cdk-lib-bundled-brace-expansion",
+      advisoryId: advisory.advisoryId,
+      advisoryUrl: advisory.advisoryUrl,
+      affectedRange: advisory.affectedRange,
+      alias: advisory.alias,
+      fixedVersions: advisory.fixedVersions,
+      expiresOn: exception.expiresOn,
+      lockfile: exception.lockfile,
+      package: {
+        name: exception.packageName,
+        path: exception.packagePath,
+        version: exception.packageVersion,
+      },
+      provenance: {
+        awsCdkLib: {
+          path: "node_modules/aws-cdk-lib",
+          version: exception.cdkVersion,
+        },
+        minimatch: {
+          dependencyRange: "^5.0.5",
+          path: "node_modules/aws-cdk-lib/node_modules/minimatch",
+          version: exception.minimatchVersion,
+        },
+      },
+    })}`,
+  );
+}

--- a/scripts/verify-cdk-audit.sh
+++ b/scripts/verify-cdk-audit.sh
@@ -28,14 +28,21 @@ npm --prefix cdk audit --audit-level=moderate --json >"${tmp_report}"
 audit_status=$?
 set -e
 
-if [[ "${audit_status}" -eq 0 ]]; then
-  echo "cdk-audit: PASS"
-  exit 0
-fi
-
 # Fail closed with one intentionally narrow, visible exception for an upstream
 # AWS CDK bundled dependency. The shared checker pins the advisory, dependency
 # graph, lockfile path, expiry, and scanner-specific report shape.
+set +e
 node scripts/check-visible-aws-cdk-finding.mjs npm "${tmp_report}" cdk/package-lock.json
+filter_status=$?
+set -e
+
+if [[ "${audit_status}" -eq 0 && "${filter_status}" -eq 0 ]]; then
+  echo "cdk-audit: FAIL (vulnerability exception checker accepted an empty audit report)" >&2
+  exit 1
+fi
+
+if [[ "${filter_status}" -ne 0 ]]; then
+  exit "${filter_status}"
+fi
 
 echo "cdk-audit: PASS"

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -2144,16 +2144,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {


### PR DESCRIPTION
## Summary

- update the directly resolvable TypeScript lint graph from `brace-expansion@5.0.7` to fixed `5.0.8`
- record one separate, exact, development-only SEC-2 exception for the legacy `minimatch@3.1.4 -> brace-expansion@1.1.16` path, because the new advisory has no patched 1.x release and forcing 5.x breaks the current lint consumer
- extend the existing AWS CDK bundled-copy exception for `aws-cdk-lib@2.261.0 -> minimatch@10.2.5 -> brace-expansion@5.0.6` to cover exactly both `GHSA-3jxr-9vmj-r5cp` and the newly published `GHSA-mh99-v99m-4gvg`

## Advisory drift and exception controls

The new `GHSA-mh99-v99m-4gvg` / `CVE-2026-14257` finding affects `brace-expansion<=5.0.7` and is fixed in `5.0.8`. The existing `GHSA-3jxr-9vmj-r5cp` / `CVE-2026-13149` finding is fixed on the relevant lines in `1.1.16`, `2.1.2`, and `5.0.7`.

Both exceptions remain fail-closed and expire on **2026-08-05**. They match exact advisory IDs, aliases, fixed-version sets, package versions and paths, dependency provenance, scanner output, and lockfile graph. Each accepted advisory is emitted as a distinct machine-readable governance evidence record. An additional advisory, changed upstream package/version/path, changed provenance, empty finding set, or expiry turns SEC-2/SEC-4 red again.

This intentionally does **not** upgrade AppTheory's AWS CDK peer solely to clear a dependency bundled inside the published `aws-cdk-lib` tarball.

## Validation

- `make rubric` — PASS: 29 pass, 0 fail, 0 blocked (rerun on committed tip)
- `./scripts/verify-contract-tests.sh` — PASS: 224 fixtures in Go, TypeScript, and Python
- `make test-unit` — PASS
- `cd ts && npm run check` — PASS
- `./scripts/verify-python-tests.sh` — PASS
- `make test` — PASS, including version alignment
- fail-closed mutation probes — PASS for a future TS advisory, a future bundled-CDK advisory, and upstream bundled-version drift
- existing MCP fixture immutability — PASS: all 11 fixtures byte-identical to `origin/staging`

Governance evidence was regenerated by the full rubric. No release/version change and no CDK/aws-cdk-lib upgrade are included.

Refs THE-2725.