### PR TITLE
fix(deps): bump docs json gem to 2.21.1

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.19.5)
+    json (2.21.1)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
## Intent

Address the three open dependabot alerts:

- **#75 (Ruby `json` >=2.9.0 <2.19.9, heap buffer overflow when streaming to an IO)**: fixed here by a conservative `bundle lock --update json` — `json` 2.19.5 → 2.21.1 in `docs/Gemfile.lock`, within Jekyll's `json ~> 2.6` constraint. Alert auto-closes once this merges to the default branch.
- **#81 / #86 (`brace-expansion` <=5.0.7 in `examples/cdk/lambda-role` and `examples/cdk/sqs-queue` lockfiles)**: not fixable yet — the vulnerable copy is bundled inside the published `aws-cdk-lib` tarball, and the latest `aws-cdk-lib@2.262.1` still bundles 5.0.7 (fix requires >=5.0.8). Both alerts dismissed as tolerable risk, pointing at the existing reviewed, fail-closed exception (expires 2026-08-05) in `scripts/check-visible-aws-cdk-finding.mjs` and `docs/dependency-automation.md`. No code change needed.

No contract/snapshot/version-manifest impact (docs-only lockfile change).

## Verification

- `make test` — PASS (unit tests + version alignment 1.17.1)
- `bundle install` against the updated lockfile resolves and loads `json` 2.21.1
- `git merge-base --is-ancestor origin/main HEAD` — OK (branch cut from current `staging`, which contains `main`)