### PR TITLE
fix(ci): prove canonical-layout baseline in cdk-go major-version gate

### DIFF
--- a/scripts/verify-cdk-go-major-version.sh
+++ b/scripts/verify-cdk-go-major-version.sh
@@ -70,6 +70,22 @@ cp "${fixture_root}/cdk/.jsii" "${baseline_root}/cdk/.jsii"
 cp -a "${fixture_root}/cdk/lib" "${baseline_root}/cdk/lib"
 cp -a "${fixture_root}/cdk-go/." "${baseline_root}/cdk-go/"
 
+# When the checked-in bindings are already in the canonical next-major layout
+# (for example on a release-please branch after generated artifact sync), the
+# Release Please-authored baseline no longer matches the checkout. Reconstruct
+# the legacy baseline so the sync plan still has the module moves to prove.
+if [[ -f "${baseline_root}/cdk-go/apptheorycdk/go.mod" && ! -f "${baseline_root}/cdk-go/go.mod" ]]; then
+  sed \
+    -e 's|^module github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v[0-9]\+$|module github.com/theory-cloud/apptheory/cdk-go|' \
+    "${baseline_root}/cdk-go/apptheorycdk/go.mod" >"${baseline_root}/cdk-go/go.mod"
+  if [[ -f "${baseline_root}/cdk-go/apptheorycdk/go.sum" ]]; then
+    cp "${baseline_root}/cdk-go/apptheorycdk/go.sum" "${baseline_root}/cdk-go/go.sum"
+  fi
+  rm -f \
+    "${baseline_root}/cdk-go/apptheorycdk/go.mod" \
+    "${baseline_root}/cdk-go/apptheorycdk/go.sum"
+fi
+
 (cd "${fixture_root}" && bash scripts/update-cdk-generated.sh >/dev/null)
 
 if [[ -e "${fixture_root}/cdk-go/go.mod" || -e "${fixture_root}/cdk-go/go.sum" ]]; then


### PR DESCRIPTION
## Intent

The manual CI dispatch on `release-please--branches--premain` (run 30158586985) fails `CDK Go binding drift` / `CDK floor matrix` at the `cdk-go-major-version` step, even though the branch is in the correct post-artifact-sync state (canonical v2 layout; `update-cdk-generated` and `version-alignment` pass).

Root cause: `scripts/verify-cdk-go-major-version.sh` snapshots the checked-in `cdk-go` as the Release Please-authored baseline. That holds on staging (legacy layout) but not on a release-please branch after generated artifact sync, where the canonical v2 module is already checked in — the sync plan then has no module moves left and the gate fails closed on a healthy branch.

## Change

When the checked-in layout is already canonical, reconstruct the legacy baseline (legacy `cdk-go/go.mod` rewritten from the nested module, nested module files removed from the baseline) so the plan still proves the required additions (`cdk-go/apptheorycdk/go.mod`, `go.sum`) and deletions (`cdk-go/go.mod`, `go.sum`). Legacy-layout behavior is unchanged.

## Verification

- Staging legacy layout: `cdk-go-major-version: PASS (additions=89, deletions=3)` — identical to pre-fix behavior
- `origin/release-please--branches--premain` (canonical) in a scratch worktree with the patched script: `PASS (additions=3, deletions=2)` — previously FAIL
- `make test` — PASS (unit tests + version alignment 1.17.1)
- `bash -n` syntax check clean

## Propagation

Once this lands on staging and promotes to premain, release-please recuts the premain RC branch with the fixed gate and a re-dispatch of CI there should go green. Note the v2.0.0-rc publish is still mid-flight per `scripts/diagnose-release-state.sh` (draft release at `c54164f0`, missing tags/assets) and needs the serialized publisher rerun independently.