### PR TITLE
fix(ci): validate synced v3 cdk-go artifacts

### DIFF
--- a/scripts/verify-cdk-go-major-version.sh
+++ b/scripts/verify-cdk-go-major-version.sh
@@ -133,31 +133,60 @@ summary_file="${tmp_dir}/summary.json"
     --baseline-root "${baseline_root}"
 )
 
-python3 - "${summary_file}" "${payload_file}" <<'PY'
+python3 - \
+  "${summary_file}" \
+  "${payload_file}" \
+  "${baseline_root}" \
+  "${fixture_root}" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 payload = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+baseline_root = Path(sys.argv[3])
+generated_root = Path(sys.argv[4])
 additions = set(summary.get("additions", []))
 deletions = set(summary.get("deletions", []))
 
-required_additions = {
+required_generated = {
     "cdk-go/apptheorycdk/jsii/jsii.go",
     "cdk-go/apptheorycdk/jsii/theory-cloud-apptheory-cdk-3.0.0-rc.tgz",
 }
-if summary.get("additionCount", 0) <= 0:
-    raise SystemExit("cdk-go-major-version: FAIL (synthetic GitHub artifact-sync plan is empty)")
-if not required_additions.issubset(additions):
-    raise SystemExit(
-        "cdk-go-major-version: FAIL (artifact-sync plan is missing v3 generated additions: "
-        f"{sorted(required_additions - additions)})"
-    )
-if not any(path.startswith("cdk-go/apptheorycdk/jsii/") and path.endswith(".tgz") for path in deletions):
-    raise SystemExit(
-        "cdk-go-major-version: FAIL (artifact-sync plan is missing the superseded jsii archive deletion)"
-    )
+target_archive = "cdk-go/apptheorycdk/jsii/theory-cloud-apptheory-cdk-3.0.0-rc.tgz"
+post_sync = baseline_root.joinpath(target_archive).is_file()
+
+if post_sync:
+    stale_generated = []
+    for relative in sorted(required_generated):
+        baseline_path = baseline_root / relative
+        generated_path = generated_root / relative
+        if (
+            not baseline_path.is_file()
+            or not generated_path.is_file()
+            or baseline_path.read_bytes() != generated_path.read_bytes()
+        ):
+            stale_generated.append(relative)
+    if stale_generated:
+        raise SystemExit(
+            "cdk-go-major-version: FAIL (post-sync baseline has stale or modified v3 generated artifacts: "
+            f"{stale_generated})"
+        )
+else:
+    if summary.get("additionCount", 0) <= 0:
+        raise SystemExit("cdk-go-major-version: FAIL (synthetic GitHub artifact-sync plan is empty)")
+    if not required_generated.issubset(additions):
+        raise SystemExit(
+            "cdk-go-major-version: FAIL (artifact-sync plan is missing v3 generated additions: "
+            f"{sorted(required_generated - additions)})"
+        )
+    if not any(
+        path.startswith("cdk-go/apptheorycdk/jsii/") and path.endswith(".tgz")
+        for path in deletions
+    ):
+        raise SystemExit(
+            "cdk-go-major-version: FAIL (artifact-sync plan is missing the superseded jsii archive deletion)"
+        )
 legacy_module_files = {"cdk-go/go.mod", "cdk-go/go.sum"}
 if legacy_module_files.intersection(additions | deletions):
     raise SystemExit("cdk-go-major-version: FAIL (v3 artifact sync touched legacy parent module files)")
@@ -170,6 +199,7 @@ if len(file_changes.get("deletions", [])) != summary["deletionCount"]:
 
 print(
     "cdk-go-major-version: PASS "
-    f"(additions={summary['additionCount']}, deletions={summary['deletionCount']})"
+    f"(state={'post-sync' if post_sync else 'pre-sync'}, "
+    f"additions={summary['additionCount']}, deletions={summary['deletionCount']})"
 )
 PY


### PR DESCRIPTION
## Summary

- detect whether the synthetic CDK Go baseline already contains the target v3 jsii archive
- preserve the existing pre-sync artifact-plan additions/deletion assertions
- require byte-identical regenerated `jsii.go` and `3.0.0-rc` archive content on post-sync release heads
- keep generated-layout, legacy-module, handwritten-test, canonical-import, and payload/summary count guards intact

## Root cause

`verify-cdk-go-major-version.sh` treated the required v3 files as valid only when the artifact-sync renderer reported them as additions. That is correct on `staging`, but impossible on the deterministic post-sync release head: those files are already tracked with the generated bytes, so the renderer correctly omits them from the delta.

The renderer remains unchanged because its baseline-to-worktree delta is accurate. The verifier now interprets that delta according to the baseline state and fails closed when post-sync content is stale or modified.

## Validation

- `bash scripts/verify-cdk-go-major-version.sh` on unmodified `b67aa713` before the fix — **exit 1**, reproduced the missing-additions failure
- patched verifier on `b67aa713` — **exit 0**, `PASS (state=post-sync, additions=1, deletions=0)`
- `bash scripts/verify-cdk-go-major-version.sh` on this `origin/staging`-based branch — **exit 0**, `PASS (state=pre-sync, additions=45, deletions=1)`
- patched verifier on `b67aa713` after appending bytes to the synced v3 tgz — **exit 1**, rejected the stale/modified post-sync artifact
- `bash -n scripts/verify-cdk-go-major-version.sh` — **exit 0**
- `bash scripts/verify-release-workflows.sh` — **exit 0**
- `bash scripts/verify-branch-release-supply-chain.sh` — **exit 0**
- `bash scripts/verify-ci-rubric-enforced.sh` — **exit 0**
- `make lint` — **exit 0**
- `make test` — **exit 0**
- `make rubric` — **exit 0**
