### PR TITLE
fix(ci): dedupe release signature verification

### DIFF
--- a/scripts/verify-release-branch-signatures.sh
+++ b/scripts/verify-release-branch-signatures.sh
@@ -8,6 +8,12 @@ SIGNED_HISTORY_BASE="${SIGNED_HISTORY_BASE:-c723c42c71d9220f49702db965d4deffff61
 HISTORICAL_UNSIGNED_FIXTURE="${HISTORICAL_UNSIGNED_FIXTURE:-ae2468e0c27b02138ad25f3035afff17e253b8a1}"
 RELEASE_SIGNATURE_VERBOSE="${RELEASE_SIGNATURE_VERBOSE:-false}"
 
+declare -A GITHUB_VERIFICATION_CACHE_STATE=()
+declare -A GITHUB_VERIFICATION_CACHE_VERIFIED=()
+declare -A GITHUB_VERIFICATION_CACHE_REASON=()
+declare -A GITHUB_VERIFICATION_CACHE_SIGNER=()
+declare -A GITHUB_VERIFICATION_CACHE_KEY=()
+
 github_repo_name() {
   if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
     printf '%s\n' "${GITHUB_REPOSITORY}"
@@ -55,10 +61,37 @@ verify_commit_signature_status() {
       return 1
       ;;
     *)
-      local verification
-      if verification="$(github_commit_verification "${sha}")"; then
-        local verified reason gh_signer gh_key
-        IFS=$'\t' read -r verified reason gh_signer gh_key <<<"${verification}"
+      local cache_state="${GITHUB_VERIFICATION_CACHE_STATE[${sha}]-}"
+      if [[ -z "${cache_state}" ]]; then
+        local verification=""
+        local attempt
+        for attempt in 1 2 3; do
+          if verification="$(github_commit_verification "${sha}")"; then
+            local verified reason gh_signer gh_key
+            IFS=$'\t' read -r verified reason gh_signer gh_key <<<"${verification}"
+            GITHUB_VERIFICATION_CACHE_STATE["${sha}"]="available"
+            GITHUB_VERIFICATION_CACHE_VERIFIED["${sha}"]="${verified}"
+            GITHUB_VERIFICATION_CACHE_REASON["${sha}"]="${reason}"
+            GITHUB_VERIFICATION_CACHE_SIGNER["${sha}"]="${gh_signer}"
+            GITHUB_VERIFICATION_CACHE_KEY["${sha}"]="${gh_key}"
+            cache_state="available"
+            break
+          fi
+          if (( attempt < 3 )); then
+            sleep "$((attempt * 5))"
+          fi
+        done
+        if [[ -z "${cache_state}" ]]; then
+          GITHUB_VERIFICATION_CACHE_STATE["${sha}"]="unavailable"
+          cache_state="unavailable"
+        fi
+      fi
+
+      if [[ "${cache_state}" == "available" ]]; then
+        local verified="${GITHUB_VERIFICATION_CACHE_VERIFIED[${sha}]}"
+        local reason="${GITHUB_VERIFICATION_CACHE_REASON[${sha}]}"
+        local gh_signer="${GITHUB_VERIFICATION_CACHE_SIGNER[${sha}]}"
+        local gh_key="${GITHUB_VERIFICATION_CACHE_KEY[${sha}]}"
         if [[ "${verified}" == "true" && "${reason}" == "valid" ]]; then
           echo "release-signatures: PASS ${label} ${sha} github-verified reason=${reason} signer=${gh_signer:-unknown} key=${gh_key:-unknown} local_status=${status} subject=${subject}"
           return 0
@@ -273,6 +306,44 @@ run_self_test() {
   else
     echo "release-signatures self-test: PASS GitHub verified-valid fallback for local_status=N"
     echo "${github_fallback_output}"
+  fi
+
+  local dedupe_count_file
+  dedupe_count_file="$(mktemp)"
+  local dedupe_output
+  local dedupe_status=0
+  dedupe_output="$(
+    github_commit_verification() {
+      printf '%s\n' "$1" >>"${dedupe_count_file}"
+      printf 'true\tvalid\tgithub-self-test\tself-test-key\n'
+    }
+    git() {
+      if [[ "$1" == "rev-parse" ]]; then
+        return 0
+      fi
+      if [[ "$1" == "log" ]]; then
+        printf '0123456789abcdef0123456789abcdef01234567\x1fN\x1f\x1f\x1fself-test simulated duplicate commit\n'
+        return 0
+      fi
+      command git "$@"
+    }
+    scan_range "self-test:dedupe-range-one" "dedupe-base-one..dedupe-head-one"
+    scan_range "self-test:dedupe-range-two" "dedupe-base-two..dedupe-head-two"
+  )" || dedupe_status=$?
+  local dedupe_calls
+  dedupe_calls="$(wc -l <"${dedupe_count_file}")"
+  rm -f "${dedupe_count_file}"
+  if [[ "${dedupe_status}" -ne 0 ]]; then
+    echo "release-signatures self-test: FAIL (cross-range GitHub verification dedupe scan failed)" >&2
+    echo "${dedupe_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${dedupe_calls}" -ne 1 ]]; then
+    echo "release-signatures self-test: FAIL (cross-range GitHub verification dedupe called helper ${dedupe_calls} times, expected 1)" >&2
+    echo "${dedupe_output}" >&2
+    failures=$((failures + 1))
+  else
+    echo "release-signatures self-test: PASS cross-range GitHub verification dedupe"
+    echo "${dedupe_output}"
   fi
 
   if (( failures > 0 )); then

--- a/scripts/verify-release-branch-signatures.sh
+++ b/scripts/verify-release-branch-signatures.sh
@@ -7,6 +7,14 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 SIGNED_HISTORY_BASE="${SIGNED_HISTORY_BASE:-c723c42c71d9220f49702db965d4deffff6183f1}"
 HISTORICAL_UNSIGNED_FIXTURE="${HISTORICAL_UNSIGNED_FIXTURE:-ae2468e0c27b02138ad25f3035afff17e253b8a1}"
 RELEASE_SIGNATURE_VERBOSE="${RELEASE_SIGNATURE_VERBOSE:-false}"
+RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS="${RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS:-300}"
+
+if [[ ! "${RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS}" =~ ^[0-9]+$ ]]; then
+  echo "release-signatures: FAIL RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS must be a non-negative integer" >&2
+  exit 1
+fi
+
+release_signature_retry_sleep_seconds=0
 
 declare -A GITHUB_VERIFICATION_CACHE_STATE=()
 declare -A GITHUB_VERIFICATION_CACHE_VERIFIED=()
@@ -29,16 +37,29 @@ github_commit_verification() {
   local repo
   repo="$(github_repo_name)"
   if [[ -z "${repo}" ]] || ! command -v gh >/dev/null 2>&1; then
-    return 1
+    return 2
   fi
 
   if [[ -n "${GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
     export GH_TOKEN="${GITHUB_TOKEN}"
   fi
 
-  gh api "repos/${repo}/commits/${sha}" \
+  local api_stderr_file
+  api_stderr_file="$(mktemp)"
+  if gh api "repos/${repo}/commits/${sha}" \
     --jq '[.commit.verification.verified, .commit.verification.reason, (.commit.verification.signer.login // ""), (.commit.verification.key_id // "")] | @tsv' \
-    2>/dev/null || return 1
+    2>"${api_stderr_file}"; then
+    rm -f "${api_stderr_file}"
+    return 0
+  fi
+
+  local api_stderr
+  api_stderr="$(<"${api_stderr_file}")"
+  rm -f "${api_stderr_file}"
+  if [[ "${api_stderr}" =~ HTTP[[:space:]]+4[0-9][0-9] ]]; then
+    return 3
+  fi
+  return 1
 }
 
 verify_commit_signature_status() {
@@ -66,6 +87,7 @@ verify_commit_signature_status() {
         local verification=""
         local attempt
         for attempt in 1 2 3; do
+          local verification_status
           if verification="$(github_commit_verification "${sha}")"; then
             local verified reason gh_signer gh_key
             IFS=$'\t' read -r verified reason gh_signer gh_key <<<"${verification}"
@@ -76,9 +98,19 @@ verify_commit_signature_status() {
             GITHUB_VERIFICATION_CACHE_KEY["${sha}"]="${gh_key}"
             cache_state="available"
             break
+          else
+            verification_status=$?
+          fi
+          if (( verification_status == 2 || verification_status == 3 )); then
+            break
           fi
           if (( attempt < 3 )); then
-            sleep "$((attempt * 5))"
+            local retry_sleep_seconds=$((attempt * 5))
+            if (( release_signature_retry_sleep_seconds + retry_sleep_seconds > RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS )); then
+              break
+            fi
+            release_signature_retry_sleep_seconds=$((release_signature_retry_sleep_seconds + retry_sleep_seconds))
+            sleep "${retry_sleep_seconds}"
           fi
         done
         if [[ -z "${cache_state}" ]]; then
@@ -279,16 +311,17 @@ run_self_test() {
   local github_fallback_output
   local github_fallback_status=0
   github_fallback_output="$(
+    local github_fallback_sha="0123456789abcdef0123456789abcdef01234567"
     github_commit_verification() {
       local requested_sha="$1"
-      if [[ "${requested_sha}" == "${SIGNED_HISTORY_BASE}" ]]; then
+      if [[ "${requested_sha}" == "${github_fallback_sha}" ]]; then
         printf 'true\tvalid\tgithub-self-test\tself-test-key\n'
         return 0
       fi
       return 1
     }
     verify_commit_signature_status \
-      "${SIGNED_HISTORY_BASE}" \
+      "${github_fallback_sha}" \
       "N" \
       "" \
       "" \


### PR DESCRIPTION
## Summary

Fixes THE-2801. `scripts/verify-release-branch-signatures.sh` called `gh api repos/{repo}/commits/{sha}` once per locally-unverifiable commit **per scanned range** — no dedupe, no retry — burning ~1,500–2,000 API calls per job against the Actions `GITHUB_TOKEN` cap of 1,000/hr. Deterministic quota exhaustion failed the premain push run 30721305130 closed on `450c706a` ("GitHub verification evidence unavailable"), and would keep failing the premain→main release PR #867 the same way.

## Changes (one file)

- Cross-range memoization: each unique SHA is verified against the GitHub API at most once per invocation; verdicts are reused across ranges while per-range PASS/FAIL accounting is unchanged.
- Bounded retry (5s, 10s) on transient `gh api` failure before concluding evidence-unavailable; exhausted retries still fail closed. Definitive verdicts (`verified=false` / `reason!=valid`) are not retried.
- Fail-closed semantics, range computation, `SIGNED_HISTORY_BASE`, fixture behavior, and log-line wording unchanged.
- `--self-test` extended: stubbed counter proves a duplicate SHA across two ranges triggers exactly one API call.

## Validation

- `bash scripts/verify-release-branch-signatures.sh --self-test` — PASS (Factory re-run on head c310a589; all five real refs scanned green, 346 commits on release-please--branches--premain)
- Codex functional check: overlapping ranges produced exactly one API call for the shared SHA
- `make test` — PASS (codex-reported)
- shellcheck unavailable in delegate environment (not run)

Factory verification: single signed commit (G), diff scoped to the one script, based on fresh origin/staging.

Ref: https://linear.app/theorycloud/issue/THE-2801