### PR TITLE
fix(ci): signature-gate polish (THE-2802)

### DIFF
--- a/scripts/verify-release-branch-signatures.sh
+++ b/scripts/verify-release-branch-signatures.sh
@@ -45,10 +45,12 @@ github_commit_verification() {
   fi
 
   local api_stderr_file
+  local api_status=0
   api_stderr_file="$(mktemp)"
-  if gh api "repos/${repo}/commits/${sha}" \
+  gh api "repos/${repo}/commits/${sha}" \
     --jq '[.commit.verification.verified, .commit.verification.reason, (.commit.verification.signer.login // ""), (.commit.verification.key_id // "")] | @tsv' \
-    2>"${api_stderr_file}"; then
+    2>"${api_stderr_file}" || api_status=$?
+  if (( api_status == 0 )); then
     rm -f "${api_stderr_file}"
     return 0
   fi
@@ -56,7 +58,10 @@ github_commit_verification() {
   local api_stderr
   api_stderr="$(<"${api_stderr_file}")"
   rm -f "${api_stderr_file}"
-  if [[ "${api_stderr}" =~ HTTP[[:space:]]+4[0-9][0-9] ]]; then
+  if [[ "${RELEASE_SIGNATURE_VERBOSE}" == "true" && -n "${api_stderr}" ]]; then
+    printf '%s\n' "${api_stderr}" >&2
+  fi
+  if (( api_status == 4 )) || [[ "${api_stderr}" =~ HTTP[[:space:]]+4[0-9][0-9] ]]; then
     return 3
   fi
   return 1
@@ -106,7 +111,7 @@ verify_commit_signature_status() {
           fi
           if (( attempt < 3 )); then
             local retry_sleep_seconds=$((attempt * 5))
-            if (( release_signature_retry_sleep_seconds + retry_sleep_seconds > RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS )); then
+            if (( release_signature_retry_sleep_seconds + retry_sleep_seconds > 10#${RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS} )); then
               break
             fi
             release_signature_retry_sleep_seconds=$((release_signature_retry_sleep_seconds + retry_sleep_seconds))


### PR DESCRIPTION
## Summary

- interpret the retry sleep budget explicitly as base-10 so leading-zero values cannot fail open in Bash arithmetic
- preserve captured `gh api` diagnostics under `RELEASE_SIGNATURE_VERBOSE=true`
- treat `gh` exit code 4 (authentication not configured) as permanent and skip retries while preserving the existing definitive HTTP 4xx classification

## Validation

- `bash -n scripts/verify-release-branch-signatures.sh` — PASS
- `shellcheck scripts/verify-release-branch-signatures.sh` — SKIP (not installed; no repository shellcheck gate is configured)
- `bash scripts/verify-release-branch-signatures.sh --self-test` — PASS
- manual leading-zero budget shim (`0008`) — PASS: 2 `gh` calls, one 5-second retry, no arithmetic error
- manual verbose/auth shim — PASS: exit 4 made one `gh` call, made zero sleep calls, and surfaced captured stderr
- `bash scripts/verify-branch-release-supply-chain.sh` — `branch-release: PASS`
- `bash scripts/verify-release-workflows.sh` — `release-workflows: PASS`
- `NPM_CONFIG_ALLOW_REMOTE=all make test` — PASS (`version-alignment: PASS (3.0.0)`)
- `NPM_CONFIG_ALLOW_REMOTE=all make rubric` — PASS (`Status: PASS`, 29 pass / 0 fail / 0 blocked)
- `bash scripts/verify-release-branch-signatures.sh --range origin/staging..HEAD --label task-branch` — PASS (1 signed commit scanned)