### PR TITLE
test(ci): signature-gate regression coverage + terminal-failure diagnostics (THE-2818)

### DIFF
--- a/scripts/verify-release-branch-signatures.sh
+++ b/scripts/verify-release-branch-signatures.sh
@@ -21,6 +21,8 @@ declare -A GITHUB_VERIFICATION_CACHE_VERIFIED=()
 declare -A GITHUB_VERIFICATION_CACHE_REASON=()
 declare -A GITHUB_VERIFICATION_CACHE_SIGNER=()
 declare -A GITHUB_VERIFICATION_CACHE_KEY=()
+declare -A GITHUB_VERIFICATION_CACHE_STDERR=()
+declare -A GITHUB_VERIFICATION_CACHE_STDERR_REPORTED=()
 
 github_repo_name() {
   if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
@@ -58,6 +60,9 @@ github_commit_verification() {
   local api_stderr
   api_stderr="$(<"${api_stderr_file}")"
   rm -f "${api_stderr_file}"
+  if [[ -n "${GITHUB_VERIFICATION_STDERR_FILE:-}" ]]; then
+    printf '%s' "${api_stderr}" >"${GITHUB_VERIFICATION_STDERR_FILE}"
+  fi
   if [[ "${RELEASE_SIGNATURE_VERBOSE}" == "true" && -n "${api_stderr}" ]]; then
     printf '%s\n' "${api_stderr}" >&2
   fi
@@ -90,6 +95,9 @@ verify_commit_signature_status() {
       local cache_state="${GITHUB_VERIFICATION_CACHE_STATE[${sha}]-}"
       if [[ -z "${cache_state}" ]]; then
         local verification=""
+        local verification_stderr_file
+        verification_stderr_file="$(mktemp)"
+        local GITHUB_VERIFICATION_STDERR_FILE="${verification_stderr_file}"
         local attempt
         for attempt in 1 2 3; do
           local verification_status
@@ -111,6 +119,7 @@ verify_commit_signature_status() {
           fi
           if (( attempt < 3 )); then
             local retry_sleep_seconds=$((attempt * 5))
+            # 10# is safe only because the ^[0-9]+$ guard above guarantees non-empty digits.
             if (( release_signature_retry_sleep_seconds + retry_sleep_seconds > 10#${RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS} )); then
               break
             fi
@@ -118,8 +127,14 @@ verify_commit_signature_status() {
             sleep "${retry_sleep_seconds}"
           fi
         done
+        local verification_stderr=""
+        if [[ -s "${verification_stderr_file}" ]]; then
+          verification_stderr="$(<"${verification_stderr_file}")"
+        fi
+        rm -f "${verification_stderr_file}"
         if [[ -z "${cache_state}" ]]; then
           GITHUB_VERIFICATION_CACHE_STATE["${sha}"]="unavailable"
+          GITHUB_VERIFICATION_CACHE_STDERR["${sha}"]="${verification_stderr}"
           cache_state="unavailable"
         fi
       fi
@@ -135,6 +150,11 @@ verify_commit_signature_status() {
         fi
         echo "release-signatures: FAIL ${label} ${sha} local_status=${status} github_verified=${verified:-unknown} reason=${reason:-unknown} subject=${subject}" >&2
         return 1
+      fi
+      local verification_stderr="${GITHUB_VERIFICATION_CACHE_STDERR[${sha}]-}"
+      if [[ -n "${verification_stderr}" && "${GITHUB_VERIFICATION_CACHE_STDERR_REPORTED[${sha}]-}" != "true" ]]; then
+        printf '%s\n' "${verification_stderr}" >&2
+        GITHUB_VERIFICATION_CACHE_STDERR_REPORTED["${sha}"]="true"
       fi
       echo "release-signatures: FAIL ${label} ${sha} local_status=${status}; GitHub verification evidence unavailable subject=${subject}" >&2
       return 1
@@ -382,6 +402,129 @@ run_self_test() {
   else
     echo "release-signatures self-test: PASS cross-range GitHub verification dedupe"
     echo "${dedupe_output}"
+  fi
+
+  local auth_calls_file auth_sleeps_file
+  auth_calls_file="$(mktemp)"
+  auth_sleeps_file="$(mktemp)"
+  local auth_output
+  local auth_status=0
+  auth_output="$(
+    GITHUB_REPOSITORY="theory-cloud/AppTheory"
+    RELEASE_SIGNATURE_VERBOSE=false
+    gh() {
+      printf '%s\n' "$*" >>"${auth_calls_file}"
+      echo "self-test gh auth not configured" >&2
+      return 4
+    }
+    sleep() {
+      printf '%s\n' "$1" >>"${auth_sleeps_file}"
+    }
+    {
+      verify_commit_signature_status \
+        "1123456789abcdef0123456789abcdef01234567" \
+        "N" \
+        "" \
+        "" \
+        "self-test simulated gh auth failure" \
+        "self-test:gh-auth-permanent" || true
+      verify_commit_signature_status \
+        "1123456789abcdef0123456789abcdef01234567" \
+        "N" \
+        "" \
+        "" \
+        "self-test simulated cached gh auth failure" \
+        "self-test:gh-auth-permanent-cached"
+    } 2>&1
+  )" || auth_status=$?
+  local auth_calls auth_sleeps auth_stderr_count
+  auth_calls="$(wc -l <"${auth_calls_file}")"
+  auth_sleeps="$(wc -l <"${auth_sleeps_file}")"
+  auth_stderr_count="$(grep -cF "self-test gh auth not configured" <<<"${auth_output}" || true)"
+  rm -f "${auth_calls_file}" "${auth_sleeps_file}"
+  if [[ "${auth_status}" -eq 0 ]]; then
+    echo "release-signatures self-test: FAIL (gh exit 4 unexpectedly passed verification)" >&2
+    echo "${auth_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${auth_calls}" -ne 1 || "${auth_sleeps}" -ne 0 ]]; then
+    echo "release-signatures self-test: FAIL (gh exit 4 was retried: calls=${auth_calls} sleeps=${auth_sleeps})" >&2
+    echo "${auth_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${auth_stderr_count}" -ne 1 ]]; then
+    echo "release-signatures self-test: FAIL (terminal gh exit 4 stderr surfaced ${auth_stderr_count} times, expected 1)" >&2
+    echo "${auth_output}" >&2
+    failures=$((failures + 1))
+  else
+    echo "release-signatures self-test: PASS gh exit 4 is permanent without retries"
+    echo "${auth_output}"
+  fi
+
+  local budget_calls_file budget_sleeps_file
+  budget_calls_file="$(mktemp)"
+  budget_sleeps_file="$(mktemp)"
+  local budget_output
+  local budget_status=0
+  budget_output="$(
+    RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS=0008
+    release_signature_retry_sleep_seconds=0
+    github_commit_verification() {
+      printf '%s\n' "$1" >>"${budget_calls_file}"
+      return 1
+    }
+    sleep() {
+      printf '%s\n' "$1" >>"${budget_sleeps_file}"
+    }
+    verify_commit_signature_status \
+      "2123456789abcdef0123456789abcdef01234567" \
+      "N" \
+      "" \
+      "" \
+      "self-test simulated padded retry budget" \
+      "self-test:padded-retry-budget" 2>&1
+  )" || budget_status=$?
+  local budget_calls budget_sleeps
+  budget_calls="$(wc -l <"${budget_calls_file}")"
+  budget_sleeps="$(tr '\n' ' ' <"${budget_sleeps_file}")"
+  rm -f "${budget_calls_file}" "${budget_sleeps_file}"
+  if [[ "${budget_status}" -eq 0 ]]; then
+    echo "release-signatures self-test: FAIL (padded retry budget unexpectedly passed verification)" >&2
+    echo "${budget_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${budget_output}" == *"value too great for base"* ]]; then
+    echo "release-signatures self-test: FAIL (padded retry budget triggered octal arithmetic)" >&2
+    echo "${budget_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${budget_calls}" -ne 2 || "${budget_sleeps}" != "5 " ]]; then
+    echo "release-signatures self-test: FAIL (padded retry budget was not enforced: calls=${budget_calls} sleeps=${budget_sleeps:-none})" >&2
+    echo "${budget_output}" >&2
+    failures=$((failures + 1))
+  else
+    echo "release-signatures self-test: PASS padded retry budget is decimal and enforced"
+    echo "${budget_output}"
+  fi
+
+  local verbose_output
+  local verbose_status=0
+  verbose_output="$(
+    GITHUB_REPOSITORY="theory-cloud/AppTheory"
+    RELEASE_SIGNATURE_VERBOSE=true
+    gh() {
+      echo "self-test verbose gh stderr" >&2
+      return 1
+    }
+    github_commit_verification "3123456789abcdef0123456789abcdef01234567" 2>&1
+  )" || verbose_status=$?
+  if [[ "${verbose_status}" -ne 1 ]]; then
+    echo "release-signatures self-test: FAIL (verbose gh failure returned ${verbose_status}, expected 1)" >&2
+    echo "${verbose_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${verbose_output}" != *"self-test verbose gh stderr"* ]]; then
+    echo "release-signatures self-test: FAIL (verbose gh stderr was not surfaced)" >&2
+    echo "${verbose_output}" >&2
+    failures=$((failures + 1))
+  else
+    echo "release-signatures self-test: PASS verbose gh stderr is surfaced"
+    echo "${verbose_output}"
   fi
 
   if (( failures > 0 )); then


### PR DESCRIPTION
## Summary

- add self-test regressions for gh exit 4 permanent classification, decimal handling of a padded retry budget, and verbose gh stderr surfacing
- retain the terminal gh failure diagnostic per SHA and emit it exactly once when GitHub verification evidence is unavailable
- document that the `10#` conversion is safe because the numeric guard guarantees non-empty digits

## Validation

- `bash scripts/verify-release-branch-signatures.sh --self-test` — PASS, including all three new cases
- scratch mutation proof, exit-4 classification removed — RED (`calls=3 sleeps=2`)
- scratch mutation proof, decimal `10#` removed — RED (`value too great for base`)
- scratch mutation proof, verbose stderr emission removed — RED (`verbose gh stderr was not surfaced`)
- `bash -n scripts/verify-release-branch-signatures.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-release-workflows.sh` — PASS
- `NPM_CONFIG_ALLOW_REMOTE=all make test` — exit 0; version alignment PASS (3.0.0)
- `NPM_CONFIG_ALLOW_REMOTE=all make rubric` — PASS (29 pass / 0 fail / 0 blocked)

No `gov-infra/evidence/` delta was produced.

THE-2818
