### PR TITLE
test(ci): isolate exit-4 case from spent retry budget

### DIFF
--- a/scripts/verify-release-branch-signatures.sh
+++ b/scripts/verify-release-branch-signatures.sh
@@ -152,7 +152,7 @@ verify_commit_signature_status() {
         return 1
       fi
       local verification_stderr="${GITHUB_VERIFICATION_CACHE_STDERR[${sha}]-}"
-      if [[ -n "${verification_stderr}" && "${GITHUB_VERIFICATION_CACHE_STDERR_REPORTED[${sha}]-}" != "true" ]]; then
+      if [[ "${RELEASE_SIGNATURE_VERBOSE}" != "true" && -n "${verification_stderr}" && "${GITHUB_VERIFICATION_CACHE_STDERR_REPORTED[${sha}]-}" != "true" ]]; then
         printf '%s\n' "${verification_stderr}" >&2
         GITHUB_VERIFICATION_CACHE_STDERR_REPORTED["${sha}"]="true"
       fi
@@ -412,6 +412,8 @@ run_self_test() {
   auth_output="$(
     GITHUB_REPOSITORY="theory-cloud/AppTheory"
     RELEASE_SIGNATURE_VERBOSE=false
+    RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS=300
+    release_signature_retry_sleep_seconds=0
     gh() {
       printf '%s\n' "$*" >>"${auth_calls_file}"
       echo "self-test gh auth not configured" >&2


### PR DESCRIPTION
## Summary

- isolate the exit-4 no-retry self-test from retry sleep consumed by the preceding five-ref scan by resetting both the 300-second budget and its accumulator inside case (a)'s subshell
- suppress the cached terminal stderr echo in verbose mode because each failed GitHub API attempt already surfaces stderr

## Root cause

Case (a) inherited global retry-budget state from the real-ref scans. If the next five-second sleep no longer fit, a transiently classified exit 4 still produced one call and zero sleeps, so the regression assertion could pass for the wrong reason.

## Validation

- pre-fix scratch mutation (exit-4 classification removed, retry budget set to 4): false-green reproduced; case (a) reported PASS and the self-test exited 0
- post-fix same mutation and budget: case (a) correctly failed with `calls=3 sleeps=2`; self-test exited 1
- real GitHub CLI: `bash scripts/verify-release-branch-signatures.sh --self-test` — PASS in 82s
- permanent-failure verbose stub: exactly 3 stderr emissions (one per attempt), verifier failed closed as expected
- `bash -n scripts/verify-release-branch-signatures.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-release-workflows.sh` — PASS
- `NPM_CONFIG_ALLOW_REMOTE=all make test` — exit 0
- `NPM_CONFIG_ALLOW_REMOTE=all make rubric` — PASS (29 pass, 0 fail, 0 blocked)
