### PR TITLE
test(ci): pin 5xx-stays-transient classification boundary

### DIFF
--- a/scripts/verify-release-branch-signatures.sh
+++ b/scripts/verify-release-branch-signatures.sh
@@ -509,6 +509,54 @@ run_self_test() {
     echo "${http_4xx_output}"
   fi
 
+  local http_5xx_calls_file http_5xx_sleeps_file
+  http_5xx_calls_file="$(mktemp)"
+  http_5xx_sleeps_file="$(mktemp)"
+  local http_5xx_output
+  local http_5xx_status=0
+  http_5xx_output="$(
+    GITHUB_REPOSITORY="theory-cloud/AppTheory"
+    RELEASE_SIGNATURE_VERBOSE=false
+    RELEASE_SIGNATURE_RETRY_SLEEP_BUDGET_SECONDS=300
+    release_signature_retry_sleep_seconds=0
+    gh() {
+      printf '%s\n' "$*" >>"${http_5xx_calls_file}"
+      echo "gh: Service Unavailable (HTTP 503)" >&2
+      return 1
+    }
+    sleep() {
+      printf '%s\n' "$1" >>"${http_5xx_sleeps_file}"
+    }
+    verify_commit_signature_status \
+      "6123456789abcdef0123456789abcdef01234567" \
+      "N" \
+      "" \
+      "" \
+      "self-test simulated gh HTTP 503 failure" \
+      "self-test:gh-http-5xx-transient" 2>&1
+  )" || http_5xx_status=$?
+  local http_5xx_calls http_5xx_sleeps http_5xx_stderr_count
+  http_5xx_calls="$(wc -l <"${http_5xx_calls_file}")"
+  http_5xx_sleeps="$(tr '\n' ' ' <"${http_5xx_sleeps_file}")"
+  http_5xx_stderr_count="$(grep -cF "gh: Service Unavailable (HTTP 503)" <<<"${http_5xx_output}" || true)"
+  rm -f "${http_5xx_calls_file}" "${http_5xx_sleeps_file}"
+  if [[ "${http_5xx_status}" -eq 0 ]]; then
+    echo "release-signatures self-test: FAIL (gh HTTP 503 unexpectedly passed verification)" >&2
+    echo "${http_5xx_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${http_5xx_calls}" -ne 3 || "${http_5xx_sleeps}" != "5 10 " ]]; then
+    echo "release-signatures self-test: FAIL (gh HTTP 503 did not exhaust retries: calls=${http_5xx_calls} sleeps=${http_5xx_sleeps:-none})" >&2
+    echo "${http_5xx_output}" >&2
+    failures=$((failures + 1))
+  elif [[ "${http_5xx_stderr_count}" -ne 1 || "${http_5xx_output}" != *"GitHub verification evidence unavailable"* ]]; then
+    echo "release-signatures self-test: FAIL (gh HTTP 503 did not fail closed through unavailable evidence)" >&2
+    echo "${http_5xx_output}" >&2
+    failures=$((failures + 1))
+  else
+    echo "release-signatures self-test: PASS gh HTTP 503 is transient with bounded retries"
+    echo "${http_5xx_output}"
+  fi
+
   local budget_calls_file budget_sleeps_file
   budget_calls_file="$(mktemp)"
   budget_sleeps_file="$(mktemp)"


### PR DESCRIPTION
## Summary

- add one HTTP 503 self-test fixture through the production GitHub API failure classifier
- assert transient handling exhausts all three attempts with the shipped `5 10` sleep schedule
- assert the terminal result fails closed through the evidence-unavailable path
- isolate the fixture's retry budget and accumulator so prior cases cannot spend its budget

## Validation

### Revert proofs

- broadened `HTTP[[:space:]]+4[0-9][0-9]` to `HTTP[[:space:]]+[45][0-9][0-9]` in a scratch copy: RED only in the new fixture with `gh HTTP 503 did not exhaust retries: calls=1 sleeps=none`
- unmutated scratch copy: GREEN

### Mutation cross-talk

- exit-4 classification removed: RED only in the exit-4 fixture
- HTTP 4xx classification removed: RED only in the HTTP 401 fixture
- decimal `10#` removed: RED only in the padded-budget fixture
- retry-budget guard deleted: RED only in the padded-budget fixture
- verbose per-attempt echo removed: RED only in the verbose-stderr fixture
- terminal cached echo removed: RED in exit-4, HTTP 401, HTTP 503, and quiet-stderr fixtures, the four consumers of that path

### Gates

- `bash -n scripts/verify-release-branch-signatures.sh`: PASS
- `bash scripts/verify-release-branch-signatures.sh --self-test`: PASS using real `gh`
- `bash scripts/verify-branch-release-supply-chain.sh`: PASS
- `bash scripts/verify-release-workflows.sh`: PASS
- `NPM_CONFIG_ALLOW_REMOTE=all make test`: PASS (exit 0)
- `NPM_CONFIG_ALLOW_REMOTE=all make rubric`: PASS (29 pass / 0 fail / 0 blocked)
