### PR TITLE
test(cdk): pin stack-level install-parameter logical-ID collisions

### DIFF
--- a/cdk/test/constructs.test.cjs
+++ b/cdk/test/constructs.test.cjs
@@ -7255,14 +7255,51 @@ test("AppTheoryInstallParameters leaves invalid literal values to CloudFormation
   assert.equal(template.Parameters.DnsHost.AllowedPattern, "^[a-z0-9][a-z0-9.-]{2,252}\\.theorycloud\\.app$");
 });
 
-test("AppTheoryInstallParameters parameter ID collisions fail closed", () => {
+test("AppTheoryInstallParameters rejects a second instance in the same stack", () => {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, "TestStack", { synthesizer: new cdk.BootstraplessSynthesizer() });
-  const parameters = new apptheory.AppTheoryInstallParameters(stack, "InstallParameters");
+
+  new apptheory.AppTheoryInstallParameters(stack, "InstallParametersOne");
+  new apptheory.AppTheoryInstallParameters(stack, "InstallParametersTwo");
 
   assert.throws(
-    () => new cdk.CfnParameter(parameters, "TargetAccountId"),
-    /There is already a Construct with name 'TargetAccountId'/,
+    () => assertions.Template.fromStack(stack).toJSON(),
+    {
+      name: "SectionAlreadyContains",
+      message: "section 'Parameters' already contains 'TargetAccountId'",
+    },
+  );
+});
+
+test("AppTheoryInstallParameters rejects a stack-level parameter logical-ID collision", () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack", { synthesizer: new cdk.BootstraplessSynthesizer() });
+
+  new apptheory.AppTheoryInstallParameters(stack, "InstallParameters");
+  new cdk.CfnParameter(stack, "TargetAccountId");
+
+  assert.throws(
+    () => assertions.Template.fromStack(stack).toJSON(),
+    {
+      name: "SectionAlreadyContains",
+      message: "section 'Parameters' already contains 'TargetAccountId'",
+    },
+  );
+});
+
+test("AppTheoryInstallParameters rejects a stack-level rule logical-ID collision", () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack", { synthesizer: new cdk.BootstraplessSynthesizer() });
+
+  new apptheory.AppTheoryInstallParameters(stack, "InstallParameters");
+  new cdk.CfnRule(stack, "TargetAccountMatchesCaller");
+
+  assert.throws(
+    () => assertions.Template.fromStack(stack).toJSON(),
+    {
+      name: "SectionAlreadyContains",
+      message: "section 'Rules' already contains 'TargetAccountMatchesCaller'",
+    },
   );
 });
 


### PR DESCRIPTION
## What changed

- replaced the constructs-library duplicate-child collision assertion with three stack-level CloudFormation logical-ID collision tests
- covered duplicate `AppTheoryInstallParameters` instances, a colliding stack-level `CfnParameter`, and a colliding stack-level `CfnRule`

## Why

A7 review finding R1-F1 showed the prior test never exercised the fail-closed behavior introduced by `overrideLogicalId`. The new tests pin the actual `SectionAlreadyContains` errors emitted during stack synthesis.

## Impact

Test-only follow-up. No construct source, generated artifacts, API surface, or documentation changed.

## Validation

- `make test`
- `make lint`
- `cd cdk && npm test` — 195/195
- `make rubric` — 29/0/0 with default `TMPDIR`
- `scripts/verify-cdk-synth.sh`
- `scripts/verify-cdk-go.sh`
- `scripts/verify-api-docs.sh`
- `git diff --check`
- M3 mutation proof: neutralizing `parameter.overrideLogicalId(id)` made the direct Node suite red (6 failures, including both new parameter-collision tests); compiled JS restored byte-pristine afterward
