### PR TITLE
fix(gov-infra): make verifier status claims honest

### DIFF
--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -681,6 +681,10 @@ gov_cmd_integration() {
   require_cmd_or_blocked npm || return $?
   require_cmd_or_blocked python3 || return $?
   ensure_ts_runtime_deps_installed || return $?
+  if ! command -v go >/dev/null 2>&1; then
+    echo "examples: BLOCKED (go not found)" >&2
+    return 2
+  fi
   scripts/verify-testkit-examples.sh
 }
 

--- a/gov-infra/verifiers/test-gov-rubric-timestamp.sh
+++ b/gov-infra/verifiers/test-gov-rubric-timestamp.sh
@@ -56,7 +56,39 @@ initialize_report_provenance
 first_timestamp="${REPORT_TIMESTAMP}"
 first_git_head="${REPORT_GIT_HEAD}"
 assert_timestamp_shape "${first_timestamp}"
-assert_eq "$(git -C "${ORIGINAL_REPO_ROOT}" rev-parse HEAD)" "${first_git_head}" "in-repo git_head"
+
+in_repo_probe_head="${tmpdir}/in-repo-git-head.txt"
+in_repo_probe_status=0
+if in_repo_probe_output="$({
+  intended_root_status=0
+  require_intended_git_worktree_or_blocked || intended_root_status=$?
+  if [[ "${intended_root_status}" -ne 0 ]]; then
+    exit "${intended_root_status}"
+  fi
+  git -C "${ORIGINAL_REPO_ROOT}" rev-parse --verify HEAD >"${in_repo_probe_head}"
+} 2>&1)"; then
+  in_repo_probe_status=0
+else
+  in_repo_probe_status=$?
+fi
+in_repo_probe_raw_fatal_lines="$(printf '%s\n' "${in_repo_probe_output}" | grep -Ec 'fatal:' || true)"
+assert_eq "0" "${in_repo_probe_raw_fatal_lines}" "in-repo git_head probe leaked raw Git diagnostics"
+
+case "${in_repo_probe_status}" in
+  0)
+    expected_git_head="$(cat "${in_repo_probe_head}")"
+    assert_eq "${expected_git_head}" "${first_git_head}" "in-repo git_head"
+    in_repo_git_head_assertion="PASS"
+    in_repo_git_head_assertion_skips=0
+    ;;
+  2)
+    in_repo_git_head_assertion="SKIP"
+    in_repo_git_head_assertion_skips=1
+    ;;
+  *)
+    fail "in-repo git_head probe failed with exit ${in_repo_probe_status}"
+    ;;
+esac
 
 # A report timestamp is run provenance. It must be regenerated rather than
 # inherited from the environment or a previous report.
@@ -97,6 +129,9 @@ assert_eq "2" "${guard_status}" "non-git intended-worktree guard status"
 grep -Fq 'BLOCKED: repository root is not the intended Git worktree root' "${non_git_evidence}" \
   || fail "non-git intended-worktree guard did not explain the BLOCKED result"
 assert_grep_absent 'fatal:' "${non_git_evidence}" "non-git intended-worktree guard leaked raw Git diagnostics"
+non_git_guard_raw_fatal_lines="$(grep -Ec 'fatal:' "${non_git_evidence}" || true)"
+non_git_raw_fatal_lines="$((in_repo_probe_raw_fatal_lines + non_git_guard_raw_fatal_lines))"
+assert_eq "0" "${non_git_raw_fatal_lines}" "non-git captured output contained raw Git diagnostics"
 REPO_ROOT="${ORIGINAL_REPO_ROOT}"
 
 grep -Fq 'REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"' "${SCRIPT_DIR}/gov-verify-rubric.sh" \
@@ -112,7 +147,9 @@ echo "gov-rubric provenance regression: PASS"
 echo "first_timestamp=${first_timestamp}"
 echo "second_timestamp=${second_timestamp}"
 echo "git_head=${first_git_head}"
+echo "in_repo_git_head_assertion=${in_repo_git_head_assertion}"
+echo "in_repo_git_head_assertion_skips=${in_repo_git_head_assertion_skips}"
 echo "enclosing_non_root_git_head=omitted"
 echo "non_git_git_head=omitted"
 echo "non_git_guard_status=${guard_status}"
-echo "non_git_raw_fatal_lines=0"
+echo "non_git_raw_fatal_lines=${non_git_raw_fatal_lines}"


### PR DESCRIPTION
## Summary

- I-A/I-B: capture the timestamp regression's in-repo Git probe, measure and assert raw `fatal:` diagnostics, and report non-Git execution as an explicit counted `SKIP` instead of a vacuous pass.
- I-C: make QUA-2 return the rubric-reserved exit code 2 when `go` is absent while preserving `examples: BLOCKED (go not found)`.
- Preserve all 29 rubric checks and their IDs. The N5 enclosing-repository fixture and assertions are byte-equivalent to `staging`.

## Reachability

In a non-Git tree, `make rubric` still stops at `scripts/verify-rubric.sh:11` before the timestamp regression call at line 16. The I-A/I-B leak was therefore reachable through direct/sourced execution paths, not through `make rubric`; the direct test still must report its own observations honestly.

## Demonstrations

### Non-Git direct run

```text
exit=0
gov-rubric provenance regression: PASS
first_timestamp=2026-08-21T00:01:11Z
second_timestamp=2026-08-21T00:01:12Z
git_head=
in_repo_git_head_assertion=SKIP
in_repo_git_head_assertion_skips=1
enclosing_non_root_git_head=omitted
non_git_git_head=omitted
non_git_guard_status=2
non_git_raw_fatal_lines=0
--- stderr ---
stderr_raw_fatal_lines=0
```

### N5 mutation, `init.defaultBranch` unset

The scratch mutant removed only the `REPORT_GIT_TOPLEVEL == REPO_ROOT` arm. The test's `git init -q -b main` fixture and N5 assertions were unchanged.

```text
init.defaultBranch=<unset>
mutation=removed REPORT_GIT_TOPLEVEL == REPO_ROOT arm
exit=1
--- stderr ---
FAIL: enclosing non-root worktree git_head omission: expected '', got '5f71201bf4cb4ddbd2a2c0c7fc8e50942284fab0'
```

### QUA-2 with `go` removed from `PATH`

Before (`staging`):

```text
go_lookup=<absent>
verifier_exit=1
QUA-2 status=FAIL
QUA-2 message=Command failed with exit code 1
QUA-2 evidence:
examples: BLOCKED (go not found)
```

After:

```text
go_lookup=<absent>
verifier_exit=1
QUA-2 status=BLOCKED
QUA-2 message=Command reported BLOCKED (exit code 2)
QUA-2 evidence:
examples: BLOCKED (go not found)
```

The full verifier continues to exit 1 when any check is BLOCKED; the QUA-2 check itself now returns reserved exit 2 and is classified BLOCKED.

## Validation

Final head: `4d003e5ce06df36d57d0cd7436b016c04ede14f3`

- Baseline `make rubric` on `staging` `ffb71b400ebb15aecc7c4227eca6f8e54ffd6a1e`: PASS, 29/0/0.
- `make test`: PASS; version alignment 3.1.1.
- `make build`: PASS, all five gates (`ts-dist-drift`, `ts-pack`, `python-build`, `cdk-ts-pack`, `cdk-python-build`).
- `make rubric`: PASS, 29/0/0.
- `git diff --check staging...HEAD`: PASS.
- `origin/main` is an ancestor of the PR head.
- Both commits are signed (SSH/ED25519) with key `SHA256:q7HPwpHpeTN3JDe9vzuMxby+Nc1n4trLrVNWUL7pzE8`.

## Scope

Only these files changed:

- `gov-infra/verifiers/test-gov-rubric-timestamp.sh`
- `gov-infra/verifiers/gov-verify-rubric.sh`

No check-ID, dependency, toolchain, release, sibling-repository, AWS, deploy, account, or secrets changes.
