### PR TITLE
fix(gov-infra): align blocked-tool rubric paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/.bundle/
 
 # GovTheory generated artifacts
 gov-infra/.tools/
+gov-infra/evidence/gov-rubric-report.json
 gov-infra/evidence/*-output.log
 gov-infra/evidence/DOC-5-parity.log
 gov-infra/evidence/go-coverage.out

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -655,6 +655,7 @@ ensure_py_runtime_deps_installed() {
 gov_cmd_unit() {
   require_cmd_or_blocked go || return $?
   require_cmd_or_blocked node || return $?
+  require_cmd_or_blocked npm || return $?
   require_cmd_or_blocked python3 || return $?
 
   # QUA-1 is the unit-test gate. The direct, uninstrumented contract suite runs
@@ -705,6 +706,7 @@ gov_cmd_lint() {
 gov_cmd_contract() {
   require_cmd_or_blocked go || return $?
   require_cmd_or_blocked node || return $?
+  require_cmd_or_blocked npm || return $?
   require_cmd_or_blocked python3 || return $?
   ensure_ts_runtime_deps_installed || return $?
   scripts/verify-contract-tests.sh

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -680,11 +680,6 @@ gov_cmd_integration() {
   require_cmd_or_blocked node || return $?
   require_cmd_or_blocked npm || return $?
   require_cmd_or_blocked python3 || return $?
-  ensure_ts_runtime_deps_installed || return $?
-  if ! command -v go >/dev/null 2>&1; then
-    echo "examples: BLOCKED (go not found)" >&2
-    return 2
-  fi
   scripts/verify-testkit-examples.sh
 }
 

--- a/gov-infra/verifiers/test-gov-rubric-timestamp.sh
+++ b/gov-infra/verifiers/test-gov-rubric-timestamp.sh
@@ -130,8 +130,8 @@ grep -Fq 'BLOCKED: repository root is not the intended Git worktree root' "${non
   || fail "non-git intended-worktree guard did not explain the BLOCKED result"
 assert_grep_absent 'fatal:' "${non_git_evidence}" "non-git intended-worktree guard leaked raw Git diagnostics"
 non_git_guard_raw_fatal_lines="$(grep -Ec 'fatal:' "${non_git_evidence}" || true)"
-non_git_raw_fatal_lines="$((in_repo_probe_raw_fatal_lines + non_git_guard_raw_fatal_lines))"
-assert_eq "0" "${non_git_raw_fatal_lines}" "non-git captured output contained raw Git diagnostics"
+all_probe_raw_fatal_lines="$((in_repo_probe_raw_fatal_lines + non_git_guard_raw_fatal_lines))"
+assert_eq "0" "${all_probe_raw_fatal_lines}" "captured probe output contained raw Git diagnostics"
 REPO_ROOT="${ORIGINAL_REPO_ROOT}"
 
 grep -Fq 'REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"' "${SCRIPT_DIR}/gov-verify-rubric.sh" \
@@ -152,4 +152,4 @@ echo "in_repo_git_head_assertion_skips=${in_repo_git_head_assertion_skips}"
 echo "enclosing_non_root_git_head=omitted"
 echo "non_git_git_head=omitted"
 echo "non_git_guard_status=${guard_status}"
-echo "non_git_raw_fatal_lines=${non_git_raw_fatal_lines}"
+echo "all_probe_raw_fatal_lines=${all_probe_raw_fatal_lines}"

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -16,7 +16,7 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (python3 not found)" >&2

--- a/scripts/verify-testkit-examples.sh
+++ b/scripts/verify-testkit-examples.sh
@@ -4,17 +4,40 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+if ! command -v go >/dev/null 2>&1; then
+  echo "examples: BLOCKED (go not found)" >&2
+  exit 2
+fi
 if ! command -v node >/dev/null 2>&1; then
   echo "examples: BLOCKED (node not found)" >&2
   exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "examples: BLOCKED (npm not found)" >&2
+  exit 2
 fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "examples: BLOCKED (python3 not found)" >&2
   exit 1
 fi
-if ! command -v go >/dev/null 2>&1; then
-  echo "examples: BLOCKED (go not found)" >&2
-  exit 1
+
+if command -v sha256sum >/dev/null 2>&1; then
+  lock_hash="$(sha256sum ts/package-lock.json | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  lock_hash="$(shasum -a 256 ts/package-lock.json | awk '{print $1}')"
+else
+  echo "examples: BLOCKED (sha256 tool not found)" >&2
+  exit 2
+fi
+
+stamp="ts/node_modules/.gov-ts-runtime-deps.sha256"
+if [[ ! -d ts/node_modules ]] || [[ ! -f "${stamp}" ]] || ! grep -Fxq "${lock_hash}" "${stamp}" 2>/dev/null; then
+  echo "Installing TypeScript runtime deps into ts/node_modules..." >&2
+  if ! (cd ts && npm ci --no-audit --no-fund >/dev/null); then
+    echo "examples: BLOCKED (failed to install TypeScript runtime dependencies)" >&2
+    exit 2
+  fi
+  printf '%s\n' "${lock_hash}" >"${stamp}"
 fi
 
 node examples/testkit/ts.mjs

--- a/scripts/verify-ts-tests.sh
+++ b/scripts/verify-ts-tests.sh
@@ -10,7 +10,7 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "ts-tests: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "ts" ]]; then
   echo "ts-tests: FAIL (missing ts/)" >&2


### PR DESCRIPTION
## Milestone
gov-infra follow-up 3 — close J-A through J-E from the #922 ACCEPT review.

## Tasks
- [x] J-A/J-B — single-path and order the missing-Go example guard
- [x] J-C — reserve exit 2 for missing npm in contract and unit checks
- [x] J-D — accurately name the aggregate raw-fatal counter
- [x] J-E — ignore the generated rubric report

## Implementation
- The only missing-Go example guard now lives in `scripts/verify-testkit-examples.sh`, exits 2, and preserves `examples: BLOCKED (go not found)` verbatim.
- QUA-2 dependency preparation moved behind that canonical script guard, so a Go-absent run blocks before `npm ci`; no verifier-side duplicate remains.
- CON-3 and QUA-1 pre-check npm, and their sibling scripts reserve exit 2 for a missing npm binary.
- The aggregate timestamp-test metric is now `all_probe_raw_fatal_lines`; the separate in-repo and non-git guard assertions remain intact.
- `gov-infra/evidence/gov-rubric-report.json` is explicitly ignored.

## Contract impact
Internal governance verifier behavior only. No rubric IDs, check IDs, report schema, runtime contract fixtures, API snapshots, or exported APIs changed. Healthy-tree inventory remains 29/0/0 with zero carve-outs.

## Head-vs-base reproduction

All base measurements use exact merge commit `2b93e743c02a8211aa0471ded79b098b6a3ccb05`; head is `2f06c06e076c87e63d377694f1015fb8fd0ea2b9`. Both were run from non-worktree `git archive` extractions.

### J-A/J-B — Go removed from PATH

```text
base verifier_exit=1
base QUA-2 status=BLOCKED
base QUA-2 message=Command reported BLOCKED (exit code 2)
base preserved_message=True
base first_evidence_line=Installing TypeScript runtime deps into ts/node_modules...

head verifier_exit=1
head QUA-2 status=BLOCKED
head QUA-2 message=Command reported BLOCKED (exit code 2)
head preserved_message=True
head first_evidence_line=examples: BLOCKED (go not found)
```

The rubric classification and required message are unchanged. Head removes the pre-block `npm ci` and reaches the single script-owned guard first. With Go present, `bash scripts/verify-testkit-examples.sh` passed.

### J-C — npm removed from PATH

Direct sibling-script behavior moves in the required direction:

```text
base verify-contract-tests.sh exit=1 message=contract-tests: BLOCKED (npm not found)
base verify-ts-tests.sh exit=1 message=ts-tests: BLOCKED (npm not found)

head verify-contract-tests.sh exit=2 message=contract-tests: BLOCKED (npm not found)
head verify-ts-tests.sh exit=2 message=ts-tests: BLOCKED (npm not found)
```

Head full-verifier behavior:

```text
head verifier_exit=1
head CON-3 status=BLOCKED message=Command reported BLOCKED (exit code 2)
head QUA-1 status=BLOCKED message=Command reported BLOCKED (exit code 2)
```

Important exact-base correction: the requested “base verifier FAIL” premise is not reproducible at `2b93e743`. The base verifier's `ensure_ts_runtime_deps_installed` already calls `require_cmd_or_blocked npm` before either sibling script, so exact-base full-verifier results are also BLOCKED/exit 2:

```text
base verifier_exit=1
base CON-3 status=BLOCKED message=Command reported BLOCKED (exit code 2)
base QUA-1 status=BLOCKED message=Command reported BLOCKED (exit code 2)
```

This change still closes the real gap: direct scripts now honor reserved exit 2, and explicit verifier pre-checks make the dependency contract visible at each command boundary. A present-but-failing npm shim exiting 42 proves real failures are not laundered:

```text
verifier_exit=1
CON-3 status=FAIL message=Command failed with exit code 42
QUA-1 status=FAIL message=Command failed with exit code 42
```

## Validation

Final head:

- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS, 29/0/0, zero carve-outs, exit 0.
- `bash gov-infra/verifiers/test-gov-rubric-timestamp.sh` — PASS in Git: `in_repo_git_head_assertion=PASS`, skips 0, `all_probe_raw_fatal_lines=0`.
- Non-Git archive timestamp shape — PASS: `in_repo_git_head_assertion=SKIP`, skips 1, `all_probe_raw_fatal_lines=0`.
- `make test` — PASS; `version-alignment: PASS (3.1.1)`.
- `make build` — PASS: ts-dist-drift, ts-pack, python-build, cdk-ts-pack, and cdk-python-build.
- `make rubric` — PASS, 29/0/0.
- `bash -n` — PASS for every touched shell script.
- `git diff --check 2b93e743...HEAD` — PASS.
- `git check-ignore -v gov-infra/evidence/gov-rubric-report.json` — matched `.gitignore:36`.
- `git status --short --branch` after the final rubric run — clean.
- `origin/main` is an ancestor of the PR head.

## Commits
- `784c4c03` — `fix(gov-infra): single-path the example Go guard`
- `9774c5e6` — `fix(gov-infra): reserve exit 2 for missing npm`
- `b85d06a2` — `test(gov-infra): name the aggregate probe counter`
- `2f06c06e` — `chore(gov-infra): ignore generated rubric evidence`

All four commits are signed (SSH/ED25519) and carry `Refs Factory docs/058 J-series.`.

## Cross-repo notes
None. AppTheory-only scope.
