### PR TITLE
fix(gov-infra): single-path dependency install behavior

### DIFF
--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -1548,14 +1548,7 @@ allowlist_has_id() {
 sha256_12() {
   local s="$1"
   local hash=""
-  if command -v sha256sum >/dev/null 2>&1; then
-    hash="$(printf '%s' "${s}" | sha256sum | awk '{print $1}')"
-  elif command -v shasum >/dev/null 2>&1; then
-    hash="$(printf '%s' "${s}" | shasum -a 256 | awk '{print $1}')"
-  else
-    echo "BLOCKED: sha256 tool missing (need sha256sum or shasum)" >&2
-    return 2
-  fi
+  hash="$(printf '%s' "${s}" | sha256_stdin)" || return $?
   printf '%s' "${hash:0:12}"
   return 0
 }

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -30,6 +30,9 @@ PLANNING_DIR="${GOV_INFRA}/planning"
 EVIDENCE_DIR="${GOV_INFRA}/evidence"
 REPORT_PATH="${EVIDENCE_DIR}/gov-rubric-report.json"
 
+# shellcheck source=scripts/lib/ts-runtime-deps.sh
+source "${REPO_ROOT}/scripts/lib/ts-runtime-deps.sh"
+
 # Always run checks from repo root so relative commands are stable.
 cd "${REPO_ROOT}"
 
@@ -344,15 +347,6 @@ is_unset_token() {
   return 1
 }
 
-require_cmd_or_blocked() {
-  local name="$1"
-  if ! command -v "$name" >/dev/null 2>&1; then
-    echo "BLOCKED: missing required tool: ${name}" >&2
-    return 2
-  fi
-  return 0
-}
-
 normalize_feature_flags() {
   if is_unset_token "$FEATURE_OSS_RELEASE"; then
     FEATURE_OSS_RELEASE="false"
@@ -501,53 +495,6 @@ ensure_cdk_dist_go_bindings_generated() {
   # Pacmak output can require a tidy pass to ensure the module graph is complete.
   (cd cdk/dist/go/apptheorycdk && go mod tidy >/dev/null)
 
-  return 0
-}
-
-file_sha256() {
-  local file_path="$1"
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${file_path}" | awk '{print $1}'
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "${file_path}" | awk '{print $1}'
-  else
-    echo "BLOCKED: sha256 tool missing (need sha256sum or shasum)" >&2
-    return 2
-  fi
-}
-
-ensure_ts_runtime_deps_installed() {
-  require_cmd_or_blocked node || return $?
-  require_cmd_or_blocked npm || return $?
-
-  if [[ ! -d "ts" ]]; then
-    echo "FAIL: expected TypeScript project missing: ts/" >&2
-    return 1
-  fi
-  if [[ ! -f "ts/package.json" ]]; then
-    echo "FAIL: expected TypeScript package missing: ts/package.json" >&2
-    return 1
-  fi
-  if [[ ! -f "ts/package-lock.json" ]]; then
-    echo "FAIL: expected TypeScript lockfile missing: ts/package-lock.json" >&2
-    return 1
-  fi
-
-  local lock_hash
-  lock_hash="$(file_sha256 "ts/package-lock.json")" || return $?
-
-  local stamp="ts/node_modules/.gov-ts-runtime-deps.sha256"
-  if [[ -d "ts/node_modules" && -f "${stamp}" ]] && grep -Fxq "${lock_hash}" "${stamp}" 2>/dev/null; then
-    return 0
-  fi
-
-  echo "Installing TypeScript runtime deps into ts/node_modules..." >&2
-  if ! (cd ts && npm ci --no-audit --no-fund >/dev/null); then
-    echo "BLOCKED: failed to install TypeScript runtime dependencies (check network/toolchain)" >&2
-    return 2
-  fi
-
-  printf '%s\n' "${lock_hash}" > "${stamp}"
   return 0
 }
 

--- a/scripts/lib/ts-runtime-deps.sh
+++ b/scripts/lib/ts-runtime-deps.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shared TypeScript runtime dependency installation contract.
+# Source this file from a script that has changed to the repository root.
+
+APPTHEORY_TS_RUNTIME_DEPS_STAMP="ts/node_modules/.gov-ts-runtime-deps.sha256"
+
+require_cmd_or_blocked() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "BLOCKED: missing required tool: ${name}" >&2
+    return 2
+  fi
+  return 0
+}
+
+file_sha256() {
+  local file_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file_path}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file_path}" | awk '{print $1}'
+  else
+    echo "BLOCKED: sha256 tool missing (need sha256sum or shasum)" >&2
+    return 2
+  fi
+}
+
+ensure_ts_runtime_deps_installed() {
+  require_cmd_or_blocked node || return $?
+  require_cmd_or_blocked npm || return $?
+
+  if [[ ! -d "ts" ]]; then
+    echo "FAIL: expected TypeScript project missing: ts/" >&2
+    return 1
+  fi
+  if [[ ! -f "ts/package.json" ]]; then
+    echo "FAIL: expected TypeScript package missing: ts/package.json" >&2
+    return 1
+  fi
+  if [[ ! -f "ts/package-lock.json" ]]; then
+    echo "FAIL: expected TypeScript lockfile missing: ts/package-lock.json" >&2
+    return 1
+  fi
+
+  local lock_hash
+  lock_hash="$(file_sha256 "ts/package-lock.json")" || return $?
+
+  local stamp="${APPTHEORY_TS_RUNTIME_DEPS_STAMP}"
+  if [[ -d "ts/node_modules" && -f "${stamp}" ]] && grep -Fxq "${lock_hash}" "${stamp}" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "Installing TypeScript runtime deps into ts/node_modules..." >&2
+  if ! (cd ts && npm ci --no-audit --no-fund >/dev/null); then
+    echo "BLOCKED: failed to install TypeScript runtime dependencies (check network/toolchain)" >&2
+    return 2
+  fi
+
+  printf '%s\n' "${lock_hash}" >"${stamp}"
+  return 0
+}

--- a/scripts/lib/ts-runtime-deps.sh
+++ b/scripts/lib/ts-runtime-deps.sh
@@ -13,16 +13,20 @@ require_cmd_or_blocked() {
   return 0
 }
 
-file_sha256() {
-  local file_path="$1"
+sha256_stdin() {
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${file_path}" | awk '{print $1}'
+    sha256sum | awk '{print $1}'
   elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "${file_path}" | awk '{print $1}'
+    shasum -a 256 | awk '{print $1}'
   else
     echo "BLOCKED: sha256 tool missing (need sha256sum or shasum)" >&2
     return 2
   fi
+}
+
+file_sha256() {
+  local file_path="$1"
+  sha256_stdin <"${file_path}"
 }
 
 ensure_ts_runtime_deps_installed() {

--- a/scripts/verify-testkit-examples.sh
+++ b/scripts/verify-testkit-examples.sh
@@ -2,7 +2,12 @@
 # Purpose: verify AppTheory testkit examples compile and pass.
 set -euo pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=scripts/lib/ts-runtime-deps.sh
+source "${SCRIPT_DIR}/lib/ts-runtime-deps.sh"
+
+cd "${REPO_ROOT}"
 
 if ! command -v go >/dev/null 2>&1; then
   echo "examples: BLOCKED (go not found)" >&2
@@ -21,24 +26,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-if command -v sha256sum >/dev/null 2>&1; then
-  lock_hash="$(sha256sum ts/package-lock.json | awk '{print $1}')"
-elif command -v shasum >/dev/null 2>&1; then
-  lock_hash="$(shasum -a 256 ts/package-lock.json | awk '{print $1}')"
-else
-  echo "examples: BLOCKED (sha256 tool not found)" >&2
-  exit 2
-fi
-
-stamp="ts/node_modules/.gov-ts-runtime-deps.sha256"
-if [[ ! -d ts/node_modules ]] || [[ ! -f "${stamp}" ]] || ! grep -Fxq "${lock_hash}" "${stamp}" 2>/dev/null; then
-  echo "Installing TypeScript runtime deps into ts/node_modules..." >&2
-  if ! (cd ts && npm ci --no-audit --no-fund >/dev/null); then
-    echo "examples: BLOCKED (failed to install TypeScript runtime dependencies)" >&2
-    exit 2
-  fi
-  printf '%s\n' "${lock_hash}" >"${stamp}"
-fi
+ensure_ts_runtime_deps_installed
 
 node examples/testkit/ts.mjs
 node examples/testkit/ts-streaming.mjs

--- a/scripts/verify-testkit-examples.sh
+++ b/scripts/verify-testkit-examples.sh
@@ -15,7 +15,7 @@ if ! command -v go >/dev/null 2>&1; then
 fi
 if ! command -v node >/dev/null 2>&1; then
   echo "examples: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "examples: BLOCKED (npm not found)" >&2
@@ -23,7 +23,7 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "examples: BLOCKED (python3 not found)" >&2
-  exit 1
+  exit 2
 fi
 
 ensure_ts_runtime_deps_installed


### PR DESCRIPTION
## Milestone

Gov-infra follow-up 4 — close K-A through K-D from the accepted #924 review ledger entry `mem-d5ffe748368ed389`.

## What changed

- Added `scripts/lib/ts-runtime-deps.sh` as the one sourced contract for the stamp path, SHA-256 tool selection, TypeScript project/lockfile validation, `npm ci --no-audit --no-fund`, cache behavior, and actionable install diagnostics.
- Both `scripts/verify-testkit-examples.sh` and `gov-infra/verifiers/gov-verify-rubric.sh` resolve it from `BASH_SOURCE`-derived absolute paths.
- All four missing-tool guards in the standalone examples script now use reserved BLOCKED exit 2.
- The verifier's SEC-3 short-hash path also reuses the shared SHA-256 selection primitive.

This closes K-A, K-B, K-C, and K-D. Rubric IDs/check IDs and the report schema are unchanged.

## Commits

- `b39f91b5fb23ef60554e3abefeb00b5a9b75de3c` — `fix(gov-infra): single-path TypeScript dependency installs`
- `7d71ad4babd6646007bd9523fa93541d2033f6d5` — `fix(gov-infra): reserve exit 2 for missing example tools`
- `1e3f1685cb795bd46d6e5ae5c57e38815ca4b2b1` — `refactor(gov-infra): single-path sha256 tool selection`

All three commits are signed (SSH/ED25519). Each carries:

```
Refs Factory docs/058 K-series.
```

## Reproduction proofs

All base/head cases used real files extracted with `git archive` / `git show` from assigned base `63885317607c2505207529036e83264b361a7f56` and final head `1e3f1685cb795bd46d6e5ae5c57e38815ca4b2b1`.

### Missing tools: standalone BLOCKED before work

Only the script's own single-line message was emitted:

```text
head-npm-absent     exit=2 output=examples: BLOCKED (npm not found)
head-go-absent      exit=2 output=examples: BLOCKED (go not found)
head-node-absent    exit=2 output=examples: BLOCKED (node not found)
head-python3-absent exit=2 output=examples: BLOCKED (python3 not found)
```

K-B base/head delta:

```text
base-node-absent    exit=1 ... -> head exit=2
base-python3-absent exit=1 ... -> head exit=2
```

Go and npm remained exit 2, preserving #924's J-A/J-B regression contract.

### Missing lockfile

```text
base exit=1 output=sha256sum: ts/package-lock.json: No such file or directory
head exit=1 output=FAIL: expected TypeScript lockfile missing: ts/package-lock.json
```

### Failing npm ci shim

```text
base exit=2 ... examples: BLOCKED (failed to install TypeScript runtime dependencies)
head exit=2 ... BLOCKED: failed to install TypeScript runtime dependencies (check network/toolchain)
```

The shim emitted `npm-shim: forced exit 42` in both cases; head restores the actionable hint without changing reserved exit-2 classification.

### Single-path and stamp contract

Scoped grep across the helper and both consumers:

```text
stamp-path-definitions=1
npm-ci-sites=1
sha256-selection-blocks=1
```

Independent real-helper writers produced byte-identical stamp content:

```text
stamp-writers cmp=IDENTICAL
content=5beaf6c92dc3b485bc74d2107fa0a977125be140b2c64eee8198197d4598f8ea
expected-lock-hash=5beaf6c92dc3b485bc74d2107fa0a977125be140b2c64eee8198197d4598f8ea
```

Back-to-back cache handoff in scratch, both orders:

```text
cache rubric->standalone npm-ci-count=1
cache standalone->rubric npm-ci-count=1 rubric-second=PASS
```

The second consumer did not invoke npm. On the provisioned checkout, standalone installed once and passed immediately before `make rubric`; rubric evidence then showed:

```text
cache-evidence install-lines=0
QUA-1=HIT
QUA-2=HIT
CON-3=HIT
```

Mutation in two independent scratch trees pointed the consumers at `.rubric-stamp` and `.standalone-stamp`:

```text
mutation rubric->standalone npm-ci-count=2 stamps=present/present
mutation standalone->rubric npm-ci-count=2 stamps=present/present
```

Both orders miss twice when the paths diverge, proving the shared definition is load-bearing.

## Validation

Final head:

- `make test` — PASS; `version-alignment: PASS (3.1.1)`
- `make build` — PASS all five: ts-dist-drift, ts-pack, python-build, cdk-ts-pack, cdk-python-build
- `bash scripts/verify-testkit-examples.sh` — `examples: PASS`
- `make rubric` — PASS, report `29/0/0`, `git_head=1e3f1685...`
- `bash gov-infra/verifiers/test-gov-rubric-timestamp.sh` — PASS in both shapes:
  - Git checkout: assertion PASS, skips 0, raw fatal lines 0
  - non-Git archive: assertion SKIP, skips 1, raw fatal lines 0
- `bash -n` on all three touched shell files — PASS
- `git diff --check 63885317...HEAD` — PASS
- base/head rubric check inventory — byte-identical
- version files/manifests — untouched at 3.1.1
- `origin/main` is an ancestor of head; `origin/staging` remains the assigned base `63885317...`

## Contract and risk

Internal governance/script behavior only. No runtime fixture, API snapshot, dependency version, toolchain version, release manifest, report schema, rubric ID, check ID, AWS, deploy, account, or secrets changes.

Residual risk is limited to sourced-shell global namespace coupling. The helper uses the existing function names and one AppTheory-prefixed stamp variable, and both entrypoints passed standalone and full-rubric validation.

Review note (from the #925 adversarial review): one previously unclaimed behavior change is part of this PR — a missing `ts/package.json` now exits 1 with a one-line FAIL instead of the base's exit 2 with npm spew. This aligns with the reserved exit-2 (missing-tool BLOCKED) contract; it is called out here for completeness.

