### PR TITLE
fix(gov-infra): complete K-series verifier follow-through

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ contract-one:
 	@if [ -z "$(ID)" ]; then echo "contract-one: FAIL (set ID=<fixture-id>)" >&2; exit 1; fi
 	@./scripts/verify-fixture-schema.sh
 	@go run ./contract-tests/runners/go --id "$(ID)"
-	@(cd ts && npm ci >/dev/null)
+	@bash -c 'source scripts/lib/ts-runtime-deps.sh && ensure_ts_runtime_deps_installed'
 	@node contract-tests/runners/ts/run.cjs --id "$(ID)"
 	@python3 contract-tests/runners/py/run.py --id "$(ID)"
 

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -31,6 +31,7 @@ EVIDENCE_DIR="${GOV_INFRA}/evidence"
 REPORT_PATH="${EVIDENCE_DIR}/gov-rubric-report.json"
 
 # shellcheck source=scripts/lib/ts-runtime-deps.sh
+source "${REPO_ROOT}/scripts/lib/blocked.sh"
 source "${REPO_ROOT}/scripts/lib/ts-runtime-deps.sh"
 
 # Always run checks from repo root so relative commands are stable.

--- a/scripts/lib/blocked.sh
+++ b/scripts/lib/blocked.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Shared BLOCKED contract for missing command-line tools.
+
+require_cmd_or_blocked() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "BLOCKED: missing required tool: ${name}" >&2
+    return 2
+  fi
+  return 0
+}

--- a/scripts/lib/ts-runtime-deps.sh
+++ b/scripts/lib/ts-runtime-deps.sh
@@ -2,16 +2,9 @@
 # Shared TypeScript runtime dependency installation contract.
 # Source this file from a script that has changed to the repository root.
 
-APPTHEORY_TS_RUNTIME_DEPS_STAMP="ts/node_modules/.gov-ts-runtime-deps.sha256"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/blocked.sh"
 
-require_cmd_or_blocked() {
-  local name="$1"
-  if ! command -v "${name}" >/dev/null 2>&1; then
-    echo "BLOCKED: missing required tool: ${name}" >&2
-    return 2
-  fi
-  return 0
-}
+APPTHEORY_TS_RUNTIME_DEPS_STAMP="ts/node_modules/.gov-ts-runtime-deps.sha256"
 
 sha256_stdin() {
   if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/verify-cdk-audit.sh
+++ b/scripts/verify-cdk-audit.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v npm >/dev/null 2>&1; then
   echo "cdk-audit: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "cdk" ]]; then
   echo "cdk-audit: FAIL (missing cdk/)" >&2

--- a/scripts/verify-cdk-constructs.sh
+++ b/scripts/verify-cdk-constructs.sh
@@ -6,11 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v node >/dev/null 2>&1; then
   echo "cdk-constructs: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "cdk-constructs: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "cdk" ]]; then
   echo "cdk-constructs: FAIL (missing cdk/)" >&2

--- a/scripts/verify-cdk-deprecation-warnings.sh
+++ b/scripts/verify-cdk-deprecation-warnings.sh
@@ -8,11 +8,11 @@ gate_name="cdk-deprecation-warnings"
 
 if ! command -v node >/dev/null 2>&1; then
   echo "${gate_name}: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "${gate_name}: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "cdk" ]]; then
   echo "${gate_name}: FAIL (missing cdk/)" >&2

--- a/scripts/verify-cdk-go-major-version.sh
+++ b/scripts/verify-cdk-go-major-version.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 for cmd in go npm npx python3 rsync; do
   if ! command -v "${cmd}" >/dev/null 2>&1; then
     echo "cdk-go-major-version: BLOCKED (${cmd} not found)" >&2
-    exit 1
+    exit 2
   fi
 done
 

--- a/scripts/verify-cdk-go.sh
+++ b/scripts/verify-cdk-go.sh
@@ -6,11 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v go >/dev/null 2>&1; then
   echo "cdk-go: BLOCKED (go not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "cdk-go: BLOCKED (python3 not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "cdk-go/apptheorycdk" ]]; then
   echo "cdk-go: FAIL (missing cdk-go/apptheorycdk)" >&2

--- a/scripts/verify-cdk-synth.sh
+++ b/scripts/verify-cdk-synth.sh
@@ -40,6 +40,21 @@ if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1
   echo "cdk-synth: BLOCKED (sha256sum/shasum not found)" >&2
   exit 2
 fi
+if [[ ! -d "cdk" ]]; then
+  echo "cdk-synth: FAIL (missing cdk/)" >&2
+  exit 1
+fi
+if [[ ! -f "cdk/package-lock.json" ]]; then
+  echo "cdk-synth: FAIL (missing cdk/package-lock.json)" >&2
+  exit 1
+fi
+if [[ ! -d "cdk/node_modules" ]]; then
+  echo "cdk-synth: installing CDK dependencies" >&2
+  if ! (cd cdk && npm ci --no-audit --no-fund >/dev/null); then
+    echo "cdk-synth: BLOCKED (failed to install CDK dependencies; check network/toolchain)" >&2
+    exit 2
+  fi
+fi
 
 failed=0
 for entry in "${examples[@]}"; do

--- a/scripts/verify-cdk-synth.sh
+++ b/scripts/verify-cdk-synth.sh
@@ -30,15 +30,15 @@ examples=(
 
 if ! command -v node >/dev/null 2>&1; then
   echo "cdk-synth: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "cdk-synth: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
   echo "cdk-synth: BLOCKED (sha256sum/shasum not found)" >&2
-  exit 1
+  exit 2
 fi
 
 failed=0

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -9,11 +9,11 @@ source "scripts/lib/ts-runtime-deps.sh"
 
 if ! command -v go >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (go not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v node >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (npm not found)" >&2
@@ -21,7 +21,7 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (python3 not found)" >&2
-  exit 1
+  exit 2
 fi
 
 go run ./contract-tests/runners/go

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+source "scripts/lib/ts-runtime-deps.sh"
 
 ./scripts/verify-fixture-schema.sh
 
@@ -25,7 +26,7 @@ fi
 
 go run ./contract-tests/runners/go
 
-(cd ts && npm ci >/dev/null)
+ensure_ts_runtime_deps_installed
 
 node contract-tests/runners/ts/run.cjs
 python3 contract-tests/runners/py/run.py

--- a/scripts/verify-fixture-schema.sh
+++ b/scripts/verify-fixture-schema.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "fixture-schema: BLOCKED (python3 not found)" >&2
-  exit 1
+  exit 2
 fi
 
 schema_path="contract-tests/fixtures/fixture.schema.json"

--- a/scripts/verify-go-lint.sh
+++ b/scripts/verify-go-lint.sh
@@ -23,8 +23,8 @@ ensure_golangci_lint_pinned() {
   fi
 
   if ! command -v go >/dev/null 2>&1; then
-    echo "go-lint: FAIL (missing go; needed to install pinned golangci-lint ${v})" >&2
-    exit 1
+    echo "go-lint: BLOCKED (missing go; needed to install pinned golangci-lint ${v})" >&2
+    exit 2
   fi
 
   echo "go-lint: installing pinned golangci-lint ${v} into ${GOV_TOOLS_BIN}" >&2

--- a/scripts/verify-go-module-tags.sh
+++ b/scripts/verify-go-module-tags.sh
@@ -122,12 +122,12 @@ verify_module_set() {
   local temporary
 
   if ! command -v go >/dev/null 2>&1; then
-    echo "go-module-probe: FAIL (go not found)" >&2
-    return 1
+    echo "go-module-probe: BLOCKED (go not found)" >&2
+    return 2
   fi
   if ! command -v python3 >/dev/null 2>&1; then
-    echo "go-module-probe: FAIL (python3 not found)" >&2
-    return 1
+    echo "go-module-probe: BLOCKED (python3 not found)" >&2
+    return 2
   fi
 
   go_release_validate_source_contract "${tag}" "${source_ref}" || return 1

--- a/scripts/verify-python-lint.sh
+++ b/scripts/verify-python-lint.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python-lint: BLOCKED (python3 not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "py" ]]; then
   echo "python-lint: FAIL (missing py/)" >&2

--- a/scripts/verify-python-tests.sh
+++ b/scripts/verify-python-tests.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python-tests: BLOCKED (python3 not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "py" ]]; then
   echo "python-tests: FAIL (missing py/)" >&2

--- a/scripts/verify-scaffold-examples.sh
+++ b/scripts/verify-scaffold-examples.sh
@@ -27,7 +27,7 @@ fi
 for cmd in go node npm python3; do
   if ! command -v "${cmd}" >/dev/null 2>&1; then
     echo "scaffold: BLOCKED (${cmd} not found)" >&2
-    exit 1
+    exit 2
   fi
 done
 

--- a/scripts/verify-ssr-only-provided-assets-synth.sh
+++ b/scripts/verify-ssr-only-provided-assets-synth.sh
@@ -11,7 +11,7 @@ need_cmd() {
   local cmd="$1"
   if ! command -v "${cmd}" >/dev/null 2>&1; then
     echo "ssr-only-provided-assets-synth: BLOCKED (${cmd} not found)" >&2
-    exit 1
+    exit 2
   fi
 }
 

--- a/scripts/verify-testkit-examples.sh
+++ b/scripts/verify-testkit-examples.sh
@@ -10,19 +10,19 @@ source "${SCRIPT_DIR}/lib/ts-runtime-deps.sh"
 cd "${REPO_ROOT}"
 
 if ! command -v go >/dev/null 2>&1; then
-  echo "examples: BLOCKED (go not found)" >&2
+  echo "BLOCKED: examples require go (not found)" >&2
   exit 2
 fi
 if ! command -v node >/dev/null 2>&1; then
-  echo "examples: BLOCKED (node not found)" >&2
+  echo "BLOCKED: examples require node (not found)" >&2
   exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
-  echo "examples: BLOCKED (npm not found)" >&2
+  echo "BLOCKED: examples require npm (not found)" >&2
   exit 2
 fi
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "examples: BLOCKED (python3 not found)" >&2
+  echo "BLOCKED: examples require python3 (not found)" >&2
   exit 2
 fi
 

--- a/scripts/verify-ts-dist-drift.sh
+++ b/scripts/verify-ts-dist-drift.sh
@@ -7,11 +7,11 @@ source "scripts/lib/ts-runtime-deps.sh"
 
 if ! command -v node >/dev/null 2>&1; then
   echo "ts-dist-drift: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "ts-dist-drift: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "ts" ]]; then
   echo "ts-dist-drift: FAIL (missing ts/)" >&2

--- a/scripts/verify-ts-dist-drift.sh
+++ b/scripts/verify-ts-dist-drift.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+source "scripts/lib/ts-runtime-deps.sh"
 
 if ! command -v node >/dev/null 2>&1; then
   echo "ts-dist-drift: BLOCKED (node not found)" >&2
@@ -119,9 +120,7 @@ elif [[ -n "${1:-}" ]]; then
   exit 1
 fi
 
-if [[ ! -d "ts/node_modules" ]]; then
-  (cd ts && npm ci >/dev/null)
-fi
+ensure_ts_runtime_deps_installed
 
 (cd ts && npm run build >/dev/null)
 

--- a/scripts/verify-ts-lint.sh
+++ b/scripts/verify-ts-lint.sh
@@ -6,11 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v node >/dev/null 2>&1; then
   echo "ts-lint: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "ts-lint: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "ts" ]]; then
   echo "ts-lint: FAIL (missing ts/)" >&2

--- a/scripts/verify-ts-pack.sh
+++ b/scripts/verify-ts-pack.sh
@@ -6,11 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v node >/dev/null 2>&1; then
   echo "ts-pack: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "ts-pack: BLOCKED (npm not found)" >&2
-  exit 1
+  exit 2
 fi
 if [[ ! -d "ts" ]]; then
   echo "ts-pack: FAIL (missing ts/)" >&2

--- a/scripts/verify-ts-tests.sh
+++ b/scripts/verify-ts-tests.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v node >/dev/null 2>&1; then
   echo "ts-tests: BLOCKED (node not found)" >&2
-  exit 1
+  exit 2
 fi
 if ! command -v npm >/dev/null 2>&1; then
   echo "ts-tests: BLOCKED (npm not found)" >&2


### PR DESCRIPTION
## Milestone
Gov-infra follow-up 5 — K-series verifier follow-through.

- Base: 4f1d074cfcfd6979c8e47481c377b3bdbd8b1058 (fresh staging, including #925/#926)
- Head: c8a866e953d52689b8925ff98e38d71366412ad1
- Branch: steward/gov-infra-followup-5
- Target/state: staging / draft

## Tasks
- [x] K-E: one stamped path for executable real-ts-tree installs
- [x] K-F: reserved exit 2 for missing verification tools
- [x] K-G: generic blocked-command library
- [x] K-H: one example BLOCKED message grammar
- [x] K-J: self-contained CDK synth verifier

Closes K-E..K-H from the #925 review (mem-693432d473b53b08) and K-J from the #926 delta review (mem-20a451b4f3d89d14). K-I is accepted as documented/fail-closed and intentionally untouched.

## Contract and scope
Internal verification behavior only. No rubric/check IDs, report schema, fixtures, API snapshots, versions, manifests, dependency versions, or toolchain versions changed. Scope is Makefile, scripts/, and one gov-infra verifier source line. All commits are signed (SSH/ED25519).

## Proofs

### K-E — cold/warm/cache/drift
The shim separately counts npm ci calls whose CWD is the registered checkout real ts/ tree; unrelated scratch/CDK/example installs are reported only for transparency.

~~~text
cold_rubric_rc=0
cold_real_ts_install_count=1
cold_all_repo_and_scratch_npm_ci_count=52
cold_stamp=5c63916a8b0fc46551c754f487fb0516716dbbaad187aa795e60c3ccf638343b
lock_hash=5c63916a8b0fc46551c754f487fb0516716dbbaad187aa795e60c3ccf638343b
Status: PASS / Pass: 29 / Fail: 0 / Blocked: 0

warm_rubric_rc=0
warm_real_ts_additional_install_count=0
warm_all_repo_and_scratch_additional_npm_ci_count=51
warm_stamp=5c63916a8b0fc46551c754f487fb0516716dbbaad187aa795e60c3ccf638343b
Status: PASS / Pass: 29 / Fail: 0 / Blocked: 0

final_drift_mutation_rc=1
final_drift_mutation_install_count=0
ts-dist-drift: FAIL (ts/dist has uncommitted generated drift after npm run build)

final_contract_cold_install_count=1 result=contract-tests: PASS
final_contract_warm_additional_install_count=0 result=contract-tests: PASS

executable_real_ts_bare_sites_outside_helper=0
documented_nonconsumer_examples=1
helper_real_ts_install_sites=1
~~~

The one planning-doc example is not executable. The helper is the only real-ts install site.

### K-F — base/head exit matrix
Real base/head files ran against PATH mirrors hiding one tool at a time:

~~~text
rows=39
non_exit2_head_rows=0
base_exit1_to_head2=37
base_exit2_preserved=2
~~~

Preserved exit-2 rows (already correct at base): `verify-contract-tests.sh | npm`, `verify-ts-tests.sh | npm`.

| Script | Tools: base→head |
|---|---|
| verify-cdk-audit.sh | npm 1→2 |
| verify-cdk-constructs.sh | node/npm 1→2 |
| verify-cdk-deprecation-warnings.sh | node/npm 1→2 |
| verify-cdk-go-major-version.sh | go/npm/npx/python3/rsync 1→2 |
| verify-cdk-go.sh | go/python3 1→2 |
| verify-cdk-synth.sh | node/npm/sha256-tool pair 1→2 |
| verify-contract-tests.sh | go/node/python3 1→2; npm 2→2 |
| verify-fixture-schema.sh | python3 1→2 |
| verify-go-lint.sh | go 1→2; FAIL text→BLOCKED |
| verify-go-module-tags.sh | go/python3 1→2; FAIL text→BLOCKED |
| verify-python-lint.sh | python3 1→2 |
| verify-python-tests.sh | python3 1→2 |
| verify-scaffold-examples.sh | go/node/npm/python3 1→2 |
| verify-ssr-only-provided-assets-synth.sh | node/npm 1→2 |
| verify-ts-dist-drift.sh | node/npm 1→2 |
| verify-ts-lint.sh | node/npm 1→2 |
| verify-ts-pack.sh | node/npm 1→2 |
| verify-ts-tests.sh | node 1→2; npm 2→2 |

Direct extraction of the contract python guard (fixture already validated) proves its otherwise shadowed transition:

~~~text
base rc=1 contract-tests: BLOCKED (python3 not found)
head rc=2 contract-tests: BLOCKED (python3 not found)
~~~

AWS/account deployment smoke scripts are intentionally untouched. Genuine verification failures remain exit 1.

### K-G — library altitude
~~~text
scripts/lib/blocked.sh:4:require_cmd_or_blocked() {
generic_definition_in_ts_helper=0
blocked-source=PASS
ts-runtime-source=PASS
function_body_cmp=PASS
~~~

The literal ts-runtime-deps.sh name remains, as required, for TS-specific stamp/hash/install logic and its real TS consumers. No generic definition remains there; the general gov verifier sources blocked.sh explicitly. Removing every ts-runtime-deps.sh consumer reference would contradict K-E and the requirement to keep TS logic there.

### K-H — message grammar
~~~text
legacy_grammar_count=0
colon_grammar_count=4
reachable_legacy_grammar_count=0
reachable_colon_grammar_count=7
go=2→2 node=2→2 npm=2→2 python3=2→2
~~~

### K-J — standalone synth
With cdk/node_modules removed:

~~~text
standalone_cold_rc=0
install_message_count=1
stdout_last=cdk-synth: PASS
stderr_last=cdk-synth: installing CDK dependencies
snapshot_bytes_after_standalone=UNCHANGED files=11

verify-builds: PASS (SOURCE_DATE_EPOCH=1787296675)
snapshot_bytes_after_builds=UNCHANGED files=11
~~~

Final committed-head rubrics and the successful CI deterministic-build job also exercise the full chain.

### #925 regressions
Byte-exact consumer-prefix drivers, shared real tree, both orders:

~~~text
rubric-examples_install_count=1
rubric-examples_stamp_valid=yes
examples-rubric_install_count=1
examples-rubric_stamp_valid=yes
verify-testkit-examples: go=2 node=2 npm=2 python3=2
~~~

K-H intentionally changes only those four messages.

## Validation
~~~text
make test: PASS
version-alignment: PASS (3.1.1)

make build: PASS
ts-dist-drift: PASS
ts-pack: PASS
python-build: PASS
cdk-ts-pack: PASS
cdk-python-build: PASS

make rubric (cold): PASS 29/0/0 exit 0
make rubric (warm): PASS 29/0/0 exit 0

bash gov-infra/verifiers/test-gov-rubric-timestamp.sh
gov-rubric provenance regression: PASS
in_repo_git_head_assertion=PASS
in_repo_git_head_assertion_skips=0
non_git_git_head=omitted
non_git_guard_status=2
all_probe_raw_fatal_lines=0

bash -n: PASS (22 touched shell files)
git diff --check: PASS
origin/main ancestor: PASS
working tree: clean
~~~

## Commits and signatures
~~~text
cb3d9f6f fix(gov-infra): preserve TypeScript dependency cache
cea67657 fix(gov-infra): reserve exit 2 for missing tools
4fcdc477 refactor(gov-infra): separate blocked command helper
e251f915 fix(gov-infra): unify example BLOCKED messages
c8a866e9 fix(gov-infra): make CDK synth gate self-contained
~~~

All five pass git verify-commit with status G, signer aron23@gmail.com, ED25519 key SHA256:q7HPwpHpeTN3JDe9vzuMxby+Nc1n4trLrVNWUL7pzE8. Each ends with Refs Factory docs/058 K-series.

## Risks
- K-I remains intentionally CWD-relative, documented, and fail-closed.
- CDK synth caches cdk/node_modules by directory presence; this closes clean-tree ordering without inventing a second CDK stamp contract.
- Full-rubric npm-ci totals include unrelated deterministic scratch/example/CDK installs; K-E covers the one real ts/ tree.

## Cross-repo
None. No sibling checkout, parent repo, framework, AWS environment, deployment, account, secret, registry, or release state changed.

## CI
Final head: 21 checks pass; prerelease readiness is the one expected skip for a staging-target PR. Rubric (full gate set) and Verify deterministic builds both pass.

