### PR TITLE
fix(gov-infra): close K-series verifier findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ contract-one:
 	@if [ -z "$(ID)" ]; then echo "contract-one: FAIL (set ID=<fixture-id>)" >&2; exit 1; fi
 	@./scripts/verify-fixture-schema.sh
 	@go run ./contract-tests/runners/go --id "$(ID)"
+# GNU make collapses every failed recipe to exit 2; rubric classifiers invoke
+# verifier scripts directly, so their FAIL (1) and BLOCKED (2) codes remain distinct.
 	@bash -c 'source scripts/lib/ts-runtime-deps.sh && ensure_ts_runtime_deps_installed'
 	@node contract-tests/runners/ts/run.cjs --id "$(ID)"
 	@python3 contract-tests/runners/py/run.py --id "$(ID)"

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -30,8 +30,9 @@ PLANNING_DIR="${GOV_INFRA}/planning"
 EVIDENCE_DIR="${GOV_INFRA}/evidence"
 REPORT_PATH="${EVIDENCE_DIR}/gov-rubric-report.json"
 
-# shellcheck source=scripts/lib/ts-runtime-deps.sh
+# shellcheck source=scripts/lib/blocked.sh
 source "${REPO_ROOT}/scripts/lib/blocked.sh"
+# shellcheck source=scripts/lib/ts-runtime-deps.sh
 source "${REPO_ROOT}/scripts/lib/ts-runtime-deps.sh"
 
 # Always run checks from repo root so relative commands are stable.

--- a/scripts/verify-cdk-synth.sh
+++ b/scripts/verify-cdk-synth.sh
@@ -55,6 +55,10 @@ if [[ ! -d "cdk/node_modules" ]]; then
     exit 2
   fi
 fi
+if [[ ! -f "cdk/node_modules/constructs/package.json" ]]; then
+  echo "cdk-synth: FAIL (CDK dependencies incomplete: missing constructs module; run 'cd cdk && npm ci' or remove stale cdk/node_modules/)" >&2
+  exit 1
+fi
 
 failed=0
 for entry in "${examples[@]}"; do

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -19,11 +19,6 @@ if ! command -v npm >/dev/null 2>&1; then
   echo "contract-tests: BLOCKED (npm not found)" >&2
   exit 2
 fi
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "contract-tests: BLOCKED (python3 not found)" >&2
-  exit 2
-fi
-
 go run ./contract-tests/runners/go
 
 ensure_ts_runtime_deps_installed

--- a/scripts/verify-testkit-examples.sh
+++ b/scripts/verify-testkit-examples.sh
@@ -9,22 +9,10 @@ source "${SCRIPT_DIR}/lib/ts-runtime-deps.sh"
 
 cd "${REPO_ROOT}"
 
-if ! command -v go >/dev/null 2>&1; then
-  echo "BLOCKED: examples require go (not found)" >&2
-  exit 2
-fi
-if ! command -v node >/dev/null 2>&1; then
-  echo "BLOCKED: examples require node (not found)" >&2
-  exit 2
-fi
-if ! command -v npm >/dev/null 2>&1; then
-  echo "BLOCKED: examples require npm (not found)" >&2
-  exit 2
-fi
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "BLOCKED: examples require python3 (not found)" >&2
-  exit 2
-fi
+require_cmd_or_blocked go || exit $?
+require_cmd_or_blocked node || exit $?
+require_cmd_or_blocked npm || exit $?
+require_cmd_or_blocked python3 || exit $?
 
 ensure_ts_runtime_deps_installed
 


### PR DESCRIPTION
## Milestone
Gov-infra follow-up 6 closes K-K through K-N and documents K-O from the #927 adversarial review (`mem-db81975cbb1cc8e5`).

## Tasks
- [x] K-K — correct the stale shellcheck source directive
- [x] K-L — remove the shadowed Python guard
- [x] K-M — converge missing-tool wording on the shared primitive
- [x] K-N — diagnose incomplete CDK dependencies actionably
- [x] K-O — document GNU make exit-code collapse (comment only)

## Commits
- `4c6e3e02` — `fix(gov-infra): correct shellcheck source bindings`
- `03aad7fd` — `fix(gov-infra): remove shadowed Python guard`
- `59397ef0` — `fix(gov-infra): reuse missing-tool diagnostic`
- `acf6d8cc` — `fix(gov-infra): diagnose incomplete CDK dependencies`
- `56d23e38` — `docs(gov-infra): note make exit-code collapse`

Each commit carries `Refs Factory docs/058 K-series.` as its final trailer and is signed (SSH/ED25519).

## Contract and scope impact
Internal verifier hygiene only. The diff is limited to `scripts/`, `gov-infra/`, and `Makefile`. There are no rubric ID/check-ID changes, report schema changes, runtime contract changes, dependency/toolchain changes, version/manifest changes, fixture/API snapshot changes, or CDK snapshot changes.

## Reproduction proofs

### K-K — shellcheck source bindings

```text
33  # shellcheck source=scripts/lib/blocked.sh
34  source "${REPO_ROOT}/scripts/lib/blocked.sh"
35  # shellcheck source=scripts/lib/ts-runtime-deps.sh
36  source "${REPO_ROOT}/scripts/lib/ts-runtime-deps.sh"

grep_rc=1 shellcheck_invocation_sites=0
```

The zero-site grep searched command invocations across `Makefile`, `scripts`, `gov-infra`, and `.github`; the remaining `shellcheck` text is annotation-only.

### K-L — shadowed Python guard

Before removal, a PATH mirror hiding `python3` stopped in the earlier fixture-schema gate:

```text
== K-L before removal: PATH hides python3 ==
fixture-schema: BLOCKED (python3 not found)
exit=2
```

After removing the caller guard, the same shim produced the same classifier and diagnostic:

```text
== K-L after removal: PATH hides python3 ==
fixture-schema: BLOCKED (python3 not found)
exit=2
caller_python3_guard_count=0
```

### K-M — one missing-tool wording, unchanged exits

```text
== unchanged exit matrix (before -> after) ==
go       2    go       2
node     2    node     2
npm      2    npm      2
python3  2    python3  2

== after messages ==
go       2  BLOCKED: missing required tool: go
node     2  BLOCKED: missing required tool: node
npm      2  BLOCKED: missing required tool: npm
python3  2  BLOCKED: missing required tool: python3

legacy_wording_count=0 shared_wording_definitions=1
```

`verify-testkit-examples.sh` now has four `require_cmd_or_blocked` call sites and the only diagnostic definition is in `scripts/lib/blocked.sh`.

### K-N — incomplete, absent, and healthy CDK dependency trees

The pre-change gutted-tree reproduction was exit 1 but looked like API drift:

```text
lib/hello-world-stack.ts(150,11): error TS2353: Object literal may only specify known properties, and 'runtime' does not exist in type 'AppTheoryFunctionProps'.
```

The gutted tree now fails before synth with actionable guidance and remains a verification failure:

```text
== gutted cdk/node_modules ==
cdk-synth: FAIL (CDK dependencies incomplete: missing constructs module; run 'cd cdk && npm ci' or remove stale cdk/node_modules/)
exit=1 installs=0 snapshots=11 byte_identical=yes
```

Absent-directory behavior remains K-J's self-installing path:

```text
cdk-synth: installing CDK dependencies
cdk-synth: PASS
exit=0 install_banner_count=1 snapshots=11 byte_identical=yes
```

Healthy-directory behavior remains warm and passing:

```text
cdk-synth: PASS
exit=0 install_banner_count=0 snapshots=11 byte_identical=yes
```

### K-O — known GNU make collapse

The `contract-one` recipe now has a two-line comment documenting that GNU make returns process exit 2 for any failed recipe, while rubric classifiers invoke verifier scripts directly and therefore retain FAIL=1/BLOCKED=2. `make -n contract-one ID=p0.binding.query_conversion_error` parsed the recipe unchanged.

## Snapshot proof

The 11 tracked `examples/cdk/*/snapshots/*.sha256` files were hashed before reproduction and compared after the pre-change gutted run, post-change gutted run, absent-directory run, healthy-directory run, `make test`, `make build`, the timestamp regression, and both final warm rubrics:

```text
snapshots=11 byte_identical=yes
```

## Validation

`make test`:

```text
version-alignment: PASS (3.1.1)
exit=0
```

`make build` (all five gates):

```text
ts-dist-drift: PASS
ts-pack: PASS (theory-cloud-apptheory-3.1.1.tgz)
python-build: PASS (3.1.1)
cdk-ts-pack: PASS (theory-cloud-apptheory-cdk-3.1.1.tgz)
cdk-python-build: PASS (3.1.1)
exit=0
```

Final warm `make rubric`, using the same real-tree TypeScript install counter as the #927 review:

```text
warm_precondition_stamp_match=yes
Status: PASS
Pass: 29
Fail: 0
Blocked: 0
rubric: PASS
make_rubric_exit=0 tee_exit=0 warm_real_ts_installs=0
report_status=PASS pass=29 fail=0 blocked=0
```

Timestamp/provenance regression covers the intended in-repo worktree and the enclosing/non-git shapes:

```text
gov-rubric provenance regression: PASS
in_repo_git_head_assertion=PASS
in_repo_git_head_assertion_skips=0
enclosing_non_root_git_head=omitted
non_git_git_head=omitted
non_git_guard_status=2
all_probe_raw_fatal_lines=0
```

Shell and diff validation:

```text
bash-n: PASS gov-infra/verifiers/gov-verify-rubric.sh
bash-n: PASS scripts/verify-cdk-synth.sh
bash-n: PASS scripts/verify-contract-tests.sh
bash-n: PASS scripts/verify-testkit-examples.sh
git-diff-check: PASS
restricted_surfaces_unchanged=yes
```

## Risks
- The K-N marker detects the reviewed gutted/incomplete dependency shape through the direct `constructs` package. It is not a checksum of every installed dependency; other corruption still fails closed in the existing install/synth paths.
- K-O records GNU make's process-exit collapse only. No rubric classifier invokes these checks through make, so the verifier contract remains unchanged.

## CI

```text
All checks were successful
0 cancelled, 0 failing, 21 successful, 1 skipped, and 0 pending checks
```

The skipped prerelease-readiness job is expected for a PR targeting `staging`.
