### PR TITLE
fix(gov-infra): close K-Q through K-T follow-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ rubric:
 contract-tests:
 	@./scripts/verify-contract-tests.sh
 
+# GNU make collapses every failed recipe to exit 2; rubric classifiers invoke
+# verifier scripts directly, so their FAIL (1) and BLOCKED (2) codes remain distinct.
 contract-one:
 	@if [ -z "$(ID)" ]; then echo "contract-one: FAIL (set ID=<fixture-id>)" >&2; exit 1; fi
 	@./scripts/verify-fixture-schema.sh
 	@go run ./contract-tests/runners/go --id "$(ID)"
-# GNU make collapses every failed recipe to exit 2; rubric classifiers invoke
-# verifier scripts directly, so their FAIL (1) and BLOCKED (2) codes remain distinct.
 	@bash -c 'source scripts/lib/ts-runtime-deps.sh && ensure_ts_runtime_deps_installed'
 	@node contract-tests/runners/ts/run.cjs --id "$(ID)"
 	@python3 contract-tests/runners/py/run.py --id "$(ID)"

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -34,6 +34,7 @@ REPORT_PATH="${EVIDENCE_DIR}/gov-rubric-report.json"
 source "${REPO_ROOT}/scripts/lib/blocked.sh"
 # shellcheck source=scripts/lib/ts-runtime-deps.sh
 source "${REPO_ROOT}/scripts/lib/ts-runtime-deps.sh"
+source "${REPO_ROOT}/scripts/lib/cdk-runtime-deps.sh"
 
 # Always run checks from repo root so relative commands are stable.
 cd "${REPO_ROOT}"
@@ -485,7 +486,7 @@ ensure_cdk_dist_go_bindings_generated() {
     return 1
   fi
 
-  (cd cdk && npm ci >/dev/null)
+  ensure_cdk_runtime_deps_installed || return $?
   (cd cdk && npm run build >/dev/null)
   (cd cdk && npx jsii-pacmak -t go --code-only -o dist/go --force-subdirectory false --force >/dev/null)
 

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -30,9 +30,9 @@ PLANNING_DIR="${GOV_INFRA}/planning"
 EVIDENCE_DIR="${GOV_INFRA}/evidence"
 REPORT_PATH="${EVIDENCE_DIR}/gov-rubric-report.json"
 
-# shellcheck source=scripts/lib/blocked.sh
+# shellcheck source=../../scripts/lib/blocked.sh
 source "${REPO_ROOT}/scripts/lib/blocked.sh"
-# shellcheck source=scripts/lib/ts-runtime-deps.sh
+# shellcheck source=../../scripts/lib/ts-runtime-deps.sh
 source "${REPO_ROOT}/scripts/lib/ts-runtime-deps.sh"
 source "${REPO_ROOT}/scripts/lib/cdk-runtime-deps.sh"
 

--- a/scripts/lib/cdk-runtime-deps.sh
+++ b/scripts/lib/cdk-runtime-deps.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Shared CDK runtime dependency installation contract.
+# Source this file from a script that has changed to the repository root.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/runtime-deps.sh"
+
+APPTHEORY_CDK_RUNTIME_DEPS_STAMP="cdk/node_modules/.gov-cdk-runtime-deps.sha256"
+
+cdk_runtime_deps_complete() {
+  [[ -f "cdk/node_modules/constructs/package.json" ]] &&
+    [[ -f "cdk/node_modules/aws-cdk-lib/package.json" ]]
+}
+
+ensure_cdk_runtime_deps_installed() {
+  require_cmd_or_blocked node || return $?
+  require_cmd_or_blocked npm || return $?
+
+  if [[ ! -d "cdk" ]]; then
+    echo "FAIL: expected CDK project missing: cdk/" >&2
+    return 1
+  fi
+  if [[ ! -f "cdk/package.json" ]]; then
+    echo "FAIL: expected CDK package missing: cdk/package.json" >&2
+    return 1
+  fi
+  if [[ ! -f "cdk/package-lock.json" ]]; then
+    echo "FAIL: expected CDK lockfile missing: cdk/package-lock.json" >&2
+    return 1
+  fi
+
+  local lock_hash
+  lock_hash="$(file_sha256 "cdk/package-lock.json")" || return $?
+
+  local stamp="${APPTHEORY_CDK_RUNTIME_DEPS_STAMP}"
+  if [[ -d "cdk/node_modules" && -f "${stamp}" ]] &&
+    grep -Fxq "${lock_hash}" "${stamp}" 2>/dev/null &&
+    cdk_runtime_deps_complete
+  then
+    return 0
+  fi
+
+  echo "Installing CDK runtime deps into cdk/node_modules..." >&2
+  if ! (cd cdk && npm ci --no-audit --no-fund >/dev/null); then
+    echo "BLOCKED: failed to install CDK runtime dependencies (check network/toolchain)" >&2
+    return 2
+  fi
+  if ! cdk_runtime_deps_complete; then
+    echo "FAIL: CDK dependencies incomplete after npm ci" >&2
+    return 1
+  fi
+
+  printf '%s\n' "${lock_hash}" >"${stamp}"
+  return 0
+}

--- a/scripts/lib/runtime-deps.sh
+++ b/scripts/lib/runtime-deps.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Shared runtime dependency installation primitives.
+# Source this file from a script that has changed to the repository root.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/blocked.sh"
+
+sha256_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    echo "BLOCKED: sha256 tool missing (need sha256sum or shasum)" >&2
+    return 2
+  fi
+}
+
+file_sha256() {
+  local file_path="$1"
+  sha256_stdin <"${file_path}"
+}

--- a/scripts/lib/ts-runtime-deps.sh
+++ b/scripts/lib/ts-runtime-deps.sh
@@ -2,25 +2,9 @@
 # Shared TypeScript runtime dependency installation contract.
 # Source this file from a script that has changed to the repository root.
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/blocked.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/runtime-deps.sh"
 
 APPTHEORY_TS_RUNTIME_DEPS_STAMP="ts/node_modules/.gov-ts-runtime-deps.sha256"
-
-sha256_stdin() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum | awk '{print $1}'
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 | awk '{print $1}'
-  else
-    echo "BLOCKED: sha256 tool missing (need sha256sum or shasum)" >&2
-    return 2
-  fi
-}
-
-file_sha256() {
-  local file_path="$1"
-  sha256_stdin <"${file_path}"
-}
 
 ensure_ts_runtime_deps_installed() {
   require_cmd_or_blocked node || return $?

--- a/scripts/update-cdk-generated.sh
+++ b/scripts/update-cdk-generated.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+source "scripts/lib/cdk-runtime-deps.sh"
 
 if ! command -v npm >/dev/null 2>&1; then
   echo "update-cdk-generated: FAIL (npm not found)" >&2
@@ -49,7 +50,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-(cd cdk && npm ci >/dev/null)
+ensure_cdk_runtime_deps_installed || exit $?
 (cd cdk && npm run build >/dev/null)
 (cd cdk && npx jsii-pacmak -t go --code-only -o "${tmp_dir}" --force-subdirectory false --force >/dev/null)
 

--- a/scripts/verify-cdk-constructs.sh
+++ b/scripts/verify-cdk-constructs.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+source "scripts/lib/cdk-runtime-deps.sh"
 
 if ! command -v node >/dev/null 2>&1; then
   echo "cdk-constructs: BLOCKED (node not found)" >&2
@@ -17,7 +18,7 @@ if [[ ! -d "cdk" ]]; then
   exit 1
 fi
 
-(cd cdk && npm ci >/dev/null)
+ensure_cdk_runtime_deps_installed || exit $?
 
 tmp_log="$(mktemp)"
 cleanup() { rm -f "${tmp_log}"; }
@@ -30,4 +31,3 @@ if ! (cd cdk && npm test >/dev/null 2>"${tmp_log}"); then
 fi
 
 echo "cdk-constructs: PASS"
-

--- a/scripts/verify-cdk-deprecation-warnings.sh
+++ b/scripts/verify-cdk-deprecation-warnings.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+source "scripts/lib/cdk-runtime-deps.sh"
 
 gate_name="cdk-deprecation-warnings"
 
@@ -19,10 +20,7 @@ if [[ ! -d "cdk" ]]; then
   exit 1
 fi
 
-if ! (cd cdk && npm ci >/dev/null); then
-  echo "${gate_name}: FAIL (cd cdk && npm ci failed)" >&2
-  exit 1
-fi
+ensure_cdk_runtime_deps_installed || exit $?
 
 tmp_log="$(mktemp)"
 cleanup() { rm -f "${tmp_log}"; }

--- a/scripts/verify-cdk-go-major-version.sh
+++ b/scripts/verify-cdk-go-major-version.sh
@@ -21,7 +21,7 @@ trap cleanup EXIT
 
 fixture_root="${tmp_dir}/fixture"
 baseline_root="${tmp_dir}/baseline"
-mkdir -p "${fixture_root}/scripts" "${baseline_root}/cdk" "${baseline_root}/cdk-go"
+mkdir -p "${fixture_root}/scripts/lib" "${baseline_root}/cdk" "${baseline_root}/cdk-go"
 
 rsync -a \
   --exclude node_modules \
@@ -35,6 +35,11 @@ cp \
   scripts/update-cdk-generated.sh \
   scripts/verify-cdk-go.sh \
   "${fixture_root}/scripts/"
+cp \
+  scripts/lib/blocked.sh \
+  scripts/lib/runtime-deps.sh \
+  scripts/lib/cdk-runtime-deps.sh \
+  "${fixture_root}/scripts/lib/"
 
 python3 - "${fixture_root}" "${synthetic_version}" <<'PY'
 import json

--- a/scripts/verify-cdk-synth.sh
+++ b/scripts/verify-cdk-synth.sh
@@ -55,8 +55,14 @@ if [[ ! -d "cdk/node_modules" ]]; then
     exit 2
   fi
 fi
-if [[ ! -f "cdk/node_modules/constructs/package.json" ]]; then
-  echo "cdk-synth: FAIL (CDK dependencies incomplete: missing constructs module; run 'cd cdk && npm ci' or remove stale cdk/node_modules/)" >&2
+missing_cdk_deps=()
+for module in constructs aws-cdk-lib; do
+  if [[ ! -f "cdk/node_modules/${module}/package.json" ]]; then
+    missing_cdk_deps+=("${module}")
+  fi
+done
+if [[ "${#missing_cdk_deps[@]}" -ne 0 ]]; then
+  echo "cdk-synth: FAIL (CDK dependencies incomplete: missing ${missing_cdk_deps[*]} module(s); run 'cd cdk && npm ci' or remove stale cdk/node_modules/)" >&2
   exit 1
 fi
 

--- a/scripts/verify-cdk-synth.sh
+++ b/scripts/verify-cdk-synth.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+source "scripts/lib/cdk-runtime-deps.sh"
 
 epoch="${SOURCE_DATE_EPOCH:-}"
 if [[ -z "${epoch}" ]]; then
@@ -48,23 +49,19 @@ if [[ ! -f "cdk/package-lock.json" ]]; then
   echo "cdk-synth: FAIL (missing cdk/package-lock.json)" >&2
   exit 1
 fi
-if [[ ! -d "cdk/node_modules" ]]; then
-  echo "cdk-synth: installing CDK dependencies" >&2
-  if ! (cd cdk && npm ci --no-audit --no-fund >/dev/null); then
-    echo "cdk-synth: BLOCKED (failed to install CDK dependencies; check network/toolchain)" >&2
-    exit 2
-  fi
-fi
 missing_cdk_deps=()
-for module in constructs aws-cdk-lib; do
-  if [[ ! -f "cdk/node_modules/${module}/package.json" ]]; then
-    missing_cdk_deps+=("${module}")
-  fi
-done
+if [[ -d "cdk/node_modules" ]]; then
+  for module in constructs aws-cdk-lib; do
+    if [[ ! -f "cdk/node_modules/${module}/package.json" ]]; then
+      missing_cdk_deps+=("${module}")
+    fi
+  done
+fi
 if [[ "${#missing_cdk_deps[@]}" -ne 0 ]]; then
   echo "cdk-synth: FAIL (CDK dependencies incomplete: missing ${missing_cdk_deps[*]} module(s); run 'cd cdk && npm ci' or remove stale cdk/node_modules/)" >&2
   exit 1
 fi
+ensure_cdk_runtime_deps_installed || exit $?
 
 failed=0
 for entry in "${examples[@]}"; do

--- a/scripts/verify-testkit-examples.sh
+++ b/scripts/verify-testkit-examples.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-# shellcheck source=scripts/lib/ts-runtime-deps.sh
+# shellcheck source=lib/ts-runtime-deps.sh
 source "${SCRIPT_DIR}/lib/ts-runtime-deps.sh"
 
 cd "${REPO_ROOT}"


### PR DESCRIPTION
## Milestone
Gov-infra follow-up 7 closes K-Q..K-T from the #928 adversarial review (`mem-e787f51a62be2646`).

## Changes
- K-Q: recognize both missing `constructs` and missing `aws-cdk-lib` as actionable incomplete CDK dependency shapes while leaving unknown corruption fail-closed.
- K-R: route real-tree CDK dependency installation through one lockfile-hash-stamped helper.
- K-S: normalize all five ShellCheck source directives to script-directory-relative paths.
- K-T: move the GNU make exit-collapse comment above `contract-one` without changing its recipe.

## Commits
- `fbea60448b6586a24f9adbd5491e93efa2a8685e` — K-Q
- `b8a3c101a78c70a143107971d0ef7767a487910b` — K-R
- `d0d9beb92b7bae2b60369a8965a36f1a196d7627` — K-S
- `be4eb1c805ed026dcb3c0aa5336ec0e04f4c74d5` — K-T

All four commits are signed (SSH/ED25519) and carry `Refs Factory docs/058 K-series.` on its own final line.

## Reproduction proofs

### K-Q — incomplete dependency shapes

Final-tip recognized shapes:

```text
constructs rc=1 real_cdk_installs=0 message=cdk-synth: FAIL (CDK dependencies incomplete: missing constructs module(s); run 'cd cdk && npm ci' or remove stale cdk/node_modules/)
aws-cdk-lib rc=1 real_cdk_installs=0 message=cdk-synth: FAIL (CDK dependencies incomplete: missing aws-cdk-lib module(s); run 'cd cdk && npm ci' or remove stale cdk/node_modules/)
snapshots_after_recognized=unchanged (11/11)
```

Final-tip unknown corruption (`cdk/lib/function.js` withheld) stays fail-closed with its real error and never emits PASS or the recognized-shape message:

```text
unknown_shape_rc=1 real_cdk_installs=0 incomplete_lines=0 pass_lines=0
cdk-synth: FAIL (synth failed for examples/cdk/kinesis-cloudwatch-logs)
Error: Stripping types is currently unsupported for files under node_modules, for ".../@theory-cloud/apptheory-cdk/lib/function.ts"
snapshots_after_unknown=unchanged (11/11)
```

Absent/healthy regressions:

```text
absent-dir-2 rc=0 cdk_installs=1 incomplete_lines=0 pass_lines=1
cdk-synth: PASS
healthy-2 rc=0 cdk_installs=0 incomplete_lines=0 pass_lines=1
cdk-synth: PASS
```

### K-R — stamped CDK runtime dependencies

Cold tree (`cdk/node_modules` absent):

```text
Status: PASS
Pass: 29
Fail: 0
Blocked: 0
cold_real_cdk_installs=1
cold_real_ts_installs=0
stamp_exists=yes
stamp_valid=yes
lock_hash=4d9c01d77d2215e3b3ea678b0389494ffab0e303a0c5645f6f03e7c6e0419f30
stamp=4d9c01d77d2215e3b3ea678b0389494ffab0e303a0c5645f6f03e7c6e0419f30
```

Warm final-tip rubric:

```text
Status: PASS
Pass: 29
Fail: 0
Blocked: 0
warm_real_cdk_installs=0
warm_real_ts_installs=0
```

Warm source drift never consults npm and remains visible:

```text
drift_rc=1 real_cdk_installs=0 drift_lines=1
cdk-go-drift: FAIL (cdk-go bindings are stale; run ./scripts/update-cdk-generated.sh and commit the diff)
```

K-J standalone cold regression and bare-site check:

```text
kj_standalone_rc=0 kj_real_cdk_installs=1 kj_pass_lines=1
stamp_valid=yes
bare_install_sites_outside_helper=0
```

The grep excludes the single executable `cd cdk && npm ci --no-audit --no-fund` inside `scripts/lib/cdk-runtime-deps.sh`; no executable bare install into the real `cdk/` tree remains elsewhere.

### K-S — ShellCheck source resolution

Mechanically resolved relative to each script directory (ShellCheck is not installed and the repo has zero `--source-path`/`source-path=` sites):

```text
scripts/publish-go-module-tags.sh:6 source=go-module-release-contract.sh resolved_file=True
scripts/verify-go-module-tags.sh:6 source=go-module-release-contract.sh resolved_file=True
scripts/verify-testkit-examples.sh:7 source=lib/ts-runtime-deps.sh resolved_file=True
gov-infra/verifiers/gov-verify-rubric.sh:33 source=../../scripts/lib/blocked.sh resolved_file=True
gov-infra/verifiers/gov-verify-rubric.sh:35 source=../../scripts/lib/ts-runtime-deps.sh resolved_file=True
directive_count=5 resolved_file_count=5
```

### K-T — comment placement

```text
make_n_contract_one_expansion=byte-identical
comment_occurrences_before=2 after=2
makefile_bytes_excluding_moved_comment_identical=true
```

### Snapshot invariant

```text
snapshots=byte-identical files=11
snapshot_diff_paths=0
```

The 11 tracked `examples/cdk/*/snapshots/*.sha256` files matched the fresh-staging baseline after every destructive probe; the final manifest after the cold/warm/full validation sequence also matched all 11 byte-for-byte.

## Validation

```text
make test: PASS
version-alignment: PASS (3.1.1)

make build: PASS
- ts-dist-drift: PASS
- ts-pack: PASS (3.1.1)
- python-build: PASS (3.1.1)
- cdk-ts-pack: PASS (3.1.1)
- cdk-python-build: PASS (3.1.1)

make rubric (warm): PASS, 29/0/0, exit 0
real-tree installs: ts=0, cdk=0

gov-rubric provenance regression: PASS
in_repo_git_head_assertion=PASS
in_repo_git_head_assertion_skips=0
enclosing_non_root_git_head=omitted
non_git_git_head=omitted
non_git_guard_status=2
all_probe_raw_fatal_lines=0

bash -n: PASS on all 10 touched shell files
git diff --check: PASS
origin/main ancestor of PR head: PASS
```

The first fresh-staging baseline rubric attempt encountered a transient GitHub release-asset HTTP 504 while downloading TableTheory for the scaffold smoke. An unchanged immediate retry passed 29/0/0; all milestone cold/warm/final rubrics also passed 29/0/0.

## Contract and release impact
- Internal governance/build behavior only; no runtime contract fixture or public API change.
- No rubric IDs/check IDs changed.
- Report schema untouched.
- `VERSION`, package manifests/lockfiles, and both Release Please manifests untouched.
- Healthy rubric cardinality remains 29/0/0.

## Risks
- The CDK stamp is intentionally keyed only to `cdk/package-lock.json`, with required package markers checked on the fast path. Source changes are not part of dependency identity and remain visible to downstream drift gates, as the zero-install mutation proof shows.
- Synthetic major-version fixtures still install their own isolated temporary CDK tree; the zero-install claim applies specifically to the repository's real `cdk/` tree.
- Observable behavior change on corrupted `cdk/node_modules`: previously `verify-cdk-constructs.sh` silently repaired the tree via its unconditional `npm ci` (PASS); it now routes through the stamp helper and fails closed with the actionable incomplete-dependencies message (exit 1). This matches the K-E ts-helper precedent on staging and is the intended fail-closed posture.

## Blockers
None.

