### PR TITLE
test(runtime): pin lower mcpfacade mutation survivors

### DIFF
--- a/THEORY_CLOUD.md
+++ b/THEORY_CLOUD.md
@@ -26,7 +26,8 @@ by the framework.
 
 - **One path to runtime behavior.** [AppTheory](https://github.com/theory-cloud/AppTheory) provides a single
   application model for AWS Lambda: routing, middleware, error handling, and event normalization. The same handler
-  code in Go, TypeScript, or Python produces the same HTTP response, verified by the contract fixture corpus. Go, TypeScript, and Python execute the SP09 MCP, SP12 OAuth, and SP13 objectstore fixtures as first-class contract tiers. <!-- apptheory-fixture-count: 264 -->
+  code in Go, TypeScript, or Python produces the same HTTP response, verified by the contract fixture corpus. <!-- apptheory-fixture-count: 264 -->
+  That corpus includes first-class SP09 MCP, SP12 OAuth, and SP13 objectstore tiers executed by all three runtimes.
 
 - **One path to client delivery.** [FaceTheory](https://github.com/theory-cloud/FaceTheory) provides a single model
   for SSR, SSG, and ISR on AWS Lambda + CloudFront, with adapter support for React, Vue, and Svelte.

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,8 +19,9 @@ edit_on_github: false
     One application model. Three runtimes. {{ site.tabletheory.framework_name }} keeps
     Go, TypeScript, and Python in lock-step on the shared Lambda contract — routing,
     middleware, error envelope, AppSync, WebSockets, and event workloads — verified on
-    every commit by the full fixture corpus. <!-- apptheory-fixture-count: 264 --> The runtimes also execute the
-    MCP fixtures for the Streamable HTTP surface and the OAuth fixtures for protected-resource flows used by Remote MCP deployments.
+    every commit by the full fixture corpus. <!-- apptheory-fixture-count: 264 -->
+    The corpus includes MCP fixtures for the Streamable HTTP surface and OAuth fixtures
+    for protected-resource flows used by Remote MCP deployments.
   </p>
   <div class="hero__actions">
     <a class="btn btn--primary" href="{{ '/getting-started/' | relative_url }}">

--- a/runtime/mcpfacade/facade_test.go
+++ b/runtime/mcpfacade/facade_test.go
@@ -300,6 +300,44 @@ func TestRequestHostModeAllowsOnlyNormalizedAllowlistMatches(t *testing.T) {
 	require.Equal(t, `{"error":"invalid_request_host"}`, string(wrongPort.Body))
 }
 
+func TestAllowedHostnameDefaultPortNormalizationIsSchemeAgnostic(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{"edge.example.com:80", "edge.example.com:443"} {
+		normalized, ok := normalizeAllowedHostname(raw)
+		require.True(t, ok)
+		require.Equal(t, "edge.example.com", normalized)
+	}
+}
+
+func TestWildcardStyleAllowlistEntriesRegisterButFailClosed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		allowedHost string
+		requestHost string
+	}{
+		{name: "bare wildcard", allowedHost: "*", requestHost: "tenant.example.com"},
+		{name: "wildcard prefix", allowedHost: "*.example.com", requestHost: "tenant.example.com"},
+		{name: "comma list", allowedHost: "a.example,b.example", requestHost: "a.example"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			app := apptheory.New(apptheory.WithTier(apptheory.TierP0))
+			config := validConfig(URLModeRequestHost)
+			config.AllowedHostnames = []string{test.allowedHost}
+			_, err := RegisterMCPFacade(app, config)
+			require.NoError(t, err)
+
+			response := serve(app, "GET", "/.well-known/oauth-protected-resource/acme/mcp", map[string][]string{
+				"host": {test.requestHost}, "x-forwarded-proto": {"https"},
+			})
+			require.Equal(t, 400, response.Status)
+			require.Equal(t, `{"error":"invalid_request_host"}`, string(response.Body))
+		})
+	}
+}
+
 func TestEveryFacadeMetadataResponseIsNoStoreAndVariesOnOriginHeaders(t *testing.T) {
 	t.Parallel()
 	for _, mode := range []URLMode{URLModePublicBaseURL, URLModeRequestHost} {
@@ -438,6 +476,17 @@ func TestInvalidDerivedInventoryFailsBeforeTargetRegistration(t *testing.T) {
 	for _, method := range []string{"POST", "GET", "DELETE"} {
 		require.Equal(t, 404, serve(app, method, "/acme/mcp", nil).Status)
 	}
+}
+
+func TestRouteInventoryValidationUsesTheScratchRouter(t *testing.T) {
+	t.Parallel()
+	handler := func(*apptheory.Context) (*apptheory.Response, error) { return apptheory.NoContent(), nil }
+	err := validateRouteRegistrations([]routeRegistration{{
+		method:  "GET",
+		pattern: "/{proxy+}/not-last",
+		handler: handler,
+	}})
+	require.ErrorContains(t, err, "invalid or duplicate route inventory entry")
 }
 
 func TestRouteInventoryDuplicatesAndRegisteredCollisionsReturnErrors(t *testing.T) {
@@ -597,6 +646,14 @@ func TestRegisterMCPFacadeValidatesConfigurationBeforeRegistration(t *testing.T)
 	}
 }
 
+func TestRequestHostAndPublicBaseMutualExclusionIsIndependentlyPinned(t *testing.T) {
+	t.Parallel()
+	config := validConfig(URLModeRequestHost)
+	config.PublicBaseURL = "https://front.example.com"
+	_, err := RegisterMCPFacade(apptheory.New(apptheory.WithTier(apptheory.TierP0)), config)
+	require.ErrorContains(t, err, "request-host mode cannot also configure a public base URL")
+}
+
 func TestPublicBaseURLPathConstraintIsExplicit(t *testing.T) {
 	t.Parallel()
 	config := validConfig(URLModePublicBaseURL)
@@ -642,6 +699,38 @@ func TestHelpersCanonicalizeURLsAndDefensivelyCloneInventory(t *testing.T) {
 	require.Equal(t, "POST", inventory.Routes[0].MCPMethods[0])
 	require.True(t, reflect.DeepEqual(indexFacadeTemplates(mcproutes.SupportedOAuthFacadeTemplates())[mcproutes.EndpointKindAgent].Kind, mcproutes.EndpointKindAgent))
 	require.Equal(t, mcproutes.EndpointKindPartnerAgent, indexDiscoveryTemplates(mcproutes.SupportedOAuthDiscoveryTemplates())[mcproutes.EndpointKindPartnerAgent].Kind)
+}
+
+func TestIPv6AllowedHostnameCanonicalizationKeepsBrackets(t *testing.T) {
+	t.Parallel()
+	host, ok := normalizeAllowedHostname("[::1]")
+	require.True(t, ok)
+	require.Equal(t, "[::1]", host)
+
+	host, ok = normalizeAllowedHostname("[::1]:8443")
+	require.True(t, ok)
+	require.Equal(t, "[::1]:8443", host)
+}
+
+func TestMetadataRequestFailuresPreserveTypeAndNilContextSemantics(t *testing.T) {
+	t.Parallel()
+	response, ok := metadataRequestFailure(fmt.Errorf("internal failure"))
+	require.False(t, ok)
+	require.Nil(t, response)
+
+	requestErr := &metadataRequestError{message: "request host is not allowlisted"}
+	require.Equal(t, "mcpfacade: request host is not allowlisted", requestErr.Error())
+	response, ok = metadataRequestFailure(requestErr)
+	require.True(t, ok)
+	require.Equal(t, 400, response.Status)
+	require.Equal(t, `{"error":"invalid_request_host"}`, string(response.Body))
+
+	config := normalizedConfig{urlMode: URLModeRequestHost}
+	_, err := config.absoluteURL(nil, "/acme/mcp")
+	require.EqualError(t, err, "mcpfacade: request context is required for request-host URL mode")
+	response, ok = metadataRequestFailure(err)
+	require.True(t, ok)
+	require.Equal(t, 400, response.Status)
 }
 
 func validConfig(mode URLMode) FacadeConfig {


### PR DESCRIPTION
## Intent

Pin the seven lower-ranked `runtime/mcpfacade` survivors from the accepted #933 adversarial review, then separate the machine-counted parity-corpus claims from the fixture-tier prose held from #932.

This is test-only plus the two requested prose edits. It changes no production behavior, exported/API surface, synth output, fixture data, or version state. Both commits are signed (SSH/ED25519) and carry `Refs Factory docs/061 change 4 follow-up.`

## Task A — seven survivor dispositions and kill proofs

1. **Allowlist/request default-port asymmetry — pinned deliberately.** `TestAllowedHostnameDefaultPortNormalizationIsSchemeAgnostic` fixes the existing configuration contract: both `:80` and `:443` normalize to the bare allowlist authority because allowlist entries do not carry a scheme. Hand mutation to strip only `:443` failed the focused test (`expected edge.example.com`, `actual edge.example.com:80`). Restored.
2. **Wildcard-style dead configuration — pinned fail closed, per the reviewer's call.** `TestWildcardStyleAllowlistEntriesRegisterButFailClosed` proves `*`, `*.example.com`, and `a.example,b.example` remain accepted as literal configured keys, never wildcard/list syntax, and valid concrete request hosts receive `400 invalid_request_host`. Hand mutation to reject `*` and `,` during configuration failed all three subtests at the expected-registration assertion. Restored. This intentionally makes no behavioral config-time rejection change.
3. **`metadataRequestFailure` type check — pinned.** `TestMetadataRequestFailuresPreserveTypeAndNilContextSemantics` requires an ordinary internal error to return `(nil, false)` while `metadataRequestError` maps to the 400 envelope. Hand mutation classifying every error as a request failure failed on `require.False`. Restored.
4. **Scratch-router validation nit — pinned.** `TestRouteInventoryValidationUsesTheScratchRouter` supplies the unique but router-invalid `/{proxy+}/not-last` pattern. Hand removal of both the scratch router and its probe failed with `expected error but got nil`. Restored.
5. **`metadataRequestError.Error` / nil-context cleanliness nit — pinned together.** The focused test asserts the exact `mcpfacade:` error string and proves nil request context remains a typed metadata request error that maps to 400. Dropping the prefix failed exact comparison; independently returning a plain `fmt.Errorf` for nil context failed the type-to-400 assertion. Both mutations were restored. Testing the defensive branch is preferable to removing it: it preserves fail-closed behavior for direct/internal helper use without changing production code.
6. **IPv6 bracket canonicalization nit — pinned.** `TestIPv6AllowedHostnameCanonicalizationKeepsBrackets` covers `[::1]` and `[::1]:8443`. Hand removal of the bracket branch failed with `expected [::1]`, `actual ::1`. Restored.
7. **Request-host/public-base mutual exclusion nit — unmasked and pinned.** `TestRequestHostAndPublicBaseMutualExclusionIsIndependentlyPinned` supplies a valid request-host allowlist so the named mutual-exclusion rule is the only error. Hand removal of that validation failed with `expected error but got nil`. Restored.

All hand mutations were applied to `runtime/mcpfacade/facade.go`, observed red with the named focused test, and restored before the commits. Final `go test ./runtime/mcpfacade -count=1` passes.

## Task B — fixture-corpus prose

### `docs/index.html`

Before:

> every commit by the full fixture corpus. The runtimes also execute the MCP fixtures for the Streamable HTTP surface and the OAuth fixtures for protected-resource flows used by Remote MCP deployments.

After:

> every commit by the full fixture corpus.
>
> The corpus includes MCP fixtures for the Streamable HTTP surface and OAuth fixtures for protected-resource flows used by Remote MCP deployments.

### `THEORY_CLOUD.md`

Before:

> code in Go, TypeScript, or Python produces the same HTTP response, verified by the contract fixture corpus. Go, TypeScript, and Python execute the SP09 MCP, SP12 OAuth, and SP13 objectstore fixtures as first-class contract tiers.

After:

> code in Go, TypeScript, or Python produces the same HTTP response, verified by the contract fixture corpus.
>
> That corpus includes first-class SP09 MCP, SP12 OAuth, and SP13 objectstore tiers executed by all three runtimes.

The `apptheory-fixture-count` marker stays directly on each parity claim.

## Fixture-count verification

`scripts/verify-fixture-count.sh` reports `PASS (actual=264, claims=1, markers=21)`. The marker was already correct and did not move: the checked-in corpus has 263 generic fixtures executed by each Go/TypeScript/Python runner plus one Go/CDK-TS MCP route-algebra expectations table, for 264 machine-readable JSON vectors total.

## Gate proofs

- `make test` — PASS; version alignment `3.1.1`
- `make lint` — PASS; Go `0 issues`, TypeScript PASS, Python PASS
- `make contract-tests` — PASS; 263 Go / 263 TypeScript / 263 Python
- `make rubric` — PASS; **29 pass / 0 fail / 0 blocked**
- `scripts/update-api-snapshots.sh` + `scripts/verify-api-snapshots.sh` — PASS; no snapshot diff
- `scripts/verify-api-docs.sh` — PASS; Go 1046, TS 711, Python 651, CDK 145 symbols
- `scripts/verify-cdk-synth.sh` — PASS; no synth/CDK diff
- `scripts/verify-fixture-count.sh` — PASS; actual 264, claims 1, markers 21
- `git diff --check` — PASS
- `origin/main` is an ancestor of the head; branch starts at current `origin/staging` `3377c6f4`

No version files or release manifests changed.
