### PR TITLE
test(cdk): cover MCP redesign guard gaps

### DIFF
--- a/cdk/test/mcp-server-redesign.test.cjs
+++ b/cdk/test/mcp-server-redesign.test.cjs
@@ -70,8 +70,8 @@ function inventoryFromFixture() {
 function literalSingletonRouteFamilies(document) {
   const singletons = [];
   for (const fence of document.matchAll(/```[^\n]*\n([\s\S]*?)```/g)) {
-    if (!/\brouteFamily\s*:/.test(fence[1])) continue;
-    for (const patterns of fence[1].matchAll(/\bpatterns\s*:\s*\[([\s\S]*?)\]/g)) {
+    if (!/\b(?:routeFamily|route_family)\s*[:=]/.test(fence[1])) continue;
+    for (const patterns of fence[1].matchAll(/\bpatterns\s*[:=]\s*\[([\s\S]*?)\]/g)) {
       if (/^\s*["'][^"']+["']\s*,?\s*$/.test(patterns[1])) {
         singletons.push(patterns[0]);
       }
@@ -462,6 +462,52 @@ test("AppTheoryMcpServer rejects invalid deprecated issuer and JWKS pairs", () =
     );
   }
 });
+
+for (const item of [
+  {
+    name: "issuer URL with userinfo",
+    authorizationServerIssuer: "https://user:password@auth.example.com",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "issuer URL with query",
+    authorizationServerIssuer: "https://auth.example.com?tenant=example",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "issuer URL with fragment",
+    authorizationServerIssuer: "https://auth.example.com#issuer",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "JWKS URL with userinfo",
+    authorizationServerIssuer: "https://auth.example.com",
+    jwksUri: "https://user:password@auth.example.com/jwks.json",
+    error: /jwksUri must be an absolute HTTPS URL with no userinfo or fragment/,
+  },
+  {
+    name: "JWKS URL with fragment",
+    authorizationServerIssuer: "https://auth.example.com",
+    jwksUri: "https://auth.example.com/jwks.json#keys",
+    error: /jwksUri must be an absolute HTTPS URL with no userinfo or fragment/,
+  },
+]) {
+  test(`AppTheoryMcpServer rejects deprecated ${item.name}`, () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "LegacyAuthURLValidation");
+    assert.throws(
+      () => new apptheory.AppTheoryMcpServer(stack, "McpServer", {
+        handler: handler(stack),
+        authorizationServerIssuer: item.authorizationServerIssuer,
+        jwksUri: item.jwksUri,
+      }),
+      item.error,
+    );
+  });
+}
 
 test("AppTheoryMcpServer validates every explicit opt-out", () => {
   const cases = [


### PR DESCRIPTION
## Summary

- **N1 — complete:** widened the R2 fenced-example detector to recognize both `routeFamily`/`:` and `route_family`/`=`, while keeping the guide TypeScript-only.
- **N2 — complete:** added synthesis-negative coverage for deprecated issuer URLs containing userinfo, query, or fragment and deprecated JWKS URLs containing userinfo or fragment. The deprecated props remain validated-then-discarded; runtime behavior and deprecation state are unchanged.
- Test-only change: no construct code, docs prose, runtime code, contract fixtures, or API snapshots changed.

## Kill proofs

- **N1:** temporarily added a Python fence containing `route_family=AppTheoryMcpRouteFamily(patterns=["/mcp"])` to `docs/features/mcp-server-construct.md`. The targeted guard failed with `actual: [ 'patterns=["/mcp"]' ]`; the temporary fence was then removed.
- **N2 userinfo group:** temporarily removed the `parsed.username`, `parsed.password`, and `literalURLAuthorityHasUserinfo` clauses. Both issuer-userinfo and JWKS-userinfo tests failed with missing expected exceptions; the mutation was reverted.
- **N2 query group:** temporarily removed the issuer query clause. The issuer-query test failed with a missing expected exception; the mutation was reverted.
- **N2 fragment group:** temporarily removed the fragment clause. Both issuer-fragment and JWKS-fragment tests failed with missing expected exceptions; the mutation was reverted.

## Gates

- `make rubric` — PASS (29 pass / 0 fail / 0 blocked)
- `make test` — PASS; version alignment PASS (`3.1.1`, released-major)
- `make lint` — PASS (Go / TypeScript / Python)
- `make contract-tests` — PASS (`263/263/263`, unchanged)
- `cd cdk && npm test` — PASS (`226/226`: 221 baseline + 5 new)
- `./scripts/verify-cdk-synth.sh` — PASS (11 stacks)
- `./scripts/verify-cdk-go.sh` — PASS (released-major)
- `./scripts/verify-api-snapshots.sh` — PASS
- `./scripts/verify-api-docs.sh` — PASS (Go 1046 / TS 711 / Python 651 / CDK 150)
- `bash ./scripts/verify-docs-standard.sh` — PASS

Commit is signed (SSH/ED25519).

Refs Factory docs/061 change 5.
