### PR TITLE
test(cdk): cover final OAuth URL validator guards

### DIFF
--- a/cdk/test/mcp-server-redesign.test.cjs
+++ b/cdk/test/mcp-server-redesign.test.cjs
@@ -471,6 +471,36 @@ for (const item of [
     error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
   },
   {
+    name: "issuer URL with empty userinfo",
+    authorizationServerIssuer: "https://@auth.example.com",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "issuer URL with percent-encoded authority",
+    authorizationServerIssuer: "https://%61uth.example.com",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "issuer URL with an out-of-range port",
+    authorizationServerIssuer: "https://host:99999",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "issuer URL with a space in the authority",
+    authorizationServerIssuer: "https://exa mple.com",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
+    name: "issuer URL with an empty host and explicit port",
+    authorizationServerIssuer: "https://:8080",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
     name: "issuer URL with query",
     authorizationServerIssuer: "https://auth.example.com?tenant=example",
     jwksUri: "https://auth.example.com/jwks.json",


### PR DESCRIPTION
## N3 disposition

Closes the final parked LOW finding from the docs/061 change-5 review chain with test-only coverage in the existing deprecated OAuth URL negative-case array:

- pins empty userinfo rejection for `https://@auth.example.com`;
- pins percent-encoded authority rejection for `https://%61uth.example.com`;
- pins the `!parsed` rejection path for `https://host:99999`, `https://exa mple.com`, and `https://:8080`.

This reaches the review's terminating boundary: every non-equivalent disjunct of `validateLiteralOAuthURL` is mutation-covered. The remaining `!parsed.hostname` mutant is equivalent because WHATWG HTTPS URLs require a host. The validator follow-up is complete.

Scope is exactly one test file; there are no construct, runtime, docs, fixture, snapshot, or generated-artifact changes.

## Kill proofs

Run from a scratch copy against the real jsii build, using compile-safe reference-preserving mutations:

- empty-userinfo helper neutered with an always-false conjunct: **230 pass / 1 fail**, exactly `issuer URL with empty userinfo`;
- percent-authority guard neutered while retaining the reference: **230 pass / 1 fail**, exactly `issuer URL with percent-encoded authority`;
- `!parsed` neutered with an always-false conjunct plus the compile-safe placeholder URL in the catch path: **228 pass / 3 fail**, exactly the out-of-range port, space-in-authority, and empty-host/explicit-port cases.

The restored baseline passes **231/231** (226 existing + 5 new cases).

## Gates

- `make rubric` — **PASS (29/0/0)**
- `make test` — **PASS**; version alignment **3.1.1**
- `make lint` — **PASS**
- `make contract-tests` — **PASS (263/263/263)**, unchanged
- `cd cdk && npm test` — **PASS (231/231; 226 baseline + 5 new)**
- `./scripts/verify-cdk-synth.sh` — **PASS (11 stacks)**
- `./scripts/verify-cdk-go.sh` — **PASS**
- `./scripts/verify-api-snapshots.sh` — **PASS**
- `./scripts/verify-api-docs.sh` — **PASS** (Go 1046 / TS 711 / Python 651 / CDK 150)
- `bash ./scripts/verify-docs-standard.sh` — **PASS**

The single commit is signed (SSH/ED25519). `origin/main` is an ancestor of this staging PR head.
