### PR TITLE
test(cdk): cover missing OAuth URL authority

### DIFF
--- a/cdk/test/mcp-server-redesign.test.cjs
+++ b/cdk/test/mcp-server-redesign.test.cjs
@@ -483,6 +483,12 @@ for (const item of [
     error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
   },
   {
+    name: "issuer URL with a single-slash authority",
+    authorizationServerIssuer: "https:/auth.example.com",
+    jwksUri: "https://auth.example.com/jwks.json",
+    error: /authorizationServerIssuer must be an absolute HTTPS URL with no query or fragment/,
+  },
+  {
     name: "issuer URL with an out-of-range port",
     authorizationServerIssuer: "https://host:99999",
     jwksUri: "https://auth.example.com/jwks.json",


### PR DESCRIPTION
## Boundary correction (supersedes #939's claim)

#939's merged body stated that after N3 "every non-equivalent disjunct of `validateLiteralOAuthURL` is mutation-covered" with only the `!parsed.hostname` mutant remaining as equivalent. Adversarial review of this PR (14 clause mutants enumerated against the real jsii build; 2,239,488-combination differential fuzz cross-validated against 23,086 real-build synthesis outcomes, 0 mismatches) proved that claim false on three counts: the `authority !== undefined` conjunct was non-equivalent and uncovered (120,120 divergences — the defect N4 closes here); there were **five** proven-equivalent mutants, not one (`!parsed.hostname`, `parsed.protocol !== "https:"`, `parsed.username !== ""`, `parsed.password !== ""`, and the userinfo helper's `?? false`); and the follow-up was not complete.

With this PR merged, the accurate boundary is: all 14 clause mutants are accounted for — 7 killed, and the only survivors are the 5 proven-equivalent mutants plus 2 deliberately unfiled observations (`!allowQuery` asymmetry, `value.trim()` whitespace tolerance, both out of scope by design).

## N4 disposition

Closes the final LOW test-coverage finding from the docs/061 change-5 review chain.

- Adds one deprecated issuer-URL rejection case for `https:/auth.example.com`.
- Pins the `authority !== undefined` half of `literalURLHasRFC3986Authority` without changing production code.
- Leaves the optional `!allowQuery` asymmetry and `value.trim()` observations explicitly out of scope.
- Scope is test-only: one file, six added lines, no fixtures, snapshots, generated artifacts, docs, or runtime movement.

## Kill proof

1. `origin/staging` baseline: CDK tests passed **231/231**.
2. Head with the new case: CDK tests passed **232/232**.
3. Temporarily replaced the predicate with the reference-preserving mutant:
   ```ts
   return authority === undefined ? true : !authority.includes("%");
   ```
4. Against that mutant, CDK tests reported **231 pass / 1 fail**. The sole failure was `AppTheoryMcpServer rejects deprecated issuer URL with a single-slash authority` (`Missing expected exception`); all other tests passed.
5. Restored the production predicate and rebuilt; the final tree passes **232/232** and contains only the test-file change.

## Gates

| Gate | Result |
| --- | --- |
| `make rubric` | PASS — 29 pass / 0 fail / 0 blocked |
| `make test` | PASS — version alignment 3.1.1 (`released-major`) |
| `make lint` | PASS — Go, TypeScript, Python |
| `make contract-tests` | PASS — 263/263/263, unchanged |
| `cd cdk && npm test` | PASS — 232/232 (231 baseline + 1) |
| `./scripts/verify-cdk-synth.sh` | PASS — 11 stacks |
| `./scripts/verify-cdk-go.sh` | PASS — released-major |
| `./scripts/verify-api-snapshots.sh` | PASS |
| `./scripts/verify-api-docs.sh` | PASS — Go 1046 / TS 711 / Python 651 / CDK 150 |
| `bash ./scripts/verify-docs-standard.sh` | PASS |

## Commit hygiene

- One commit, signed (SSH/ED25519).
- `origin/main` and `origin/staging` are ancestors of the PR head.
- Factory provenance trailer included.

