### PR TITLE
fix(docs): stamp Go install snippet from the latest release at Pages build time

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,15 @@
 # docs/index.html falls back to the pinned versions in docs/_data/runtimes.yml,
 # so local preview shows real versions. The override is git-ignored.
 #
+# The Go install string is the one runtime snippet the placeholders cannot
+# express: Go semantic import versioning bakes the module major into the path
+# (/v3, /v4, ...), which is a function of the release, not a constant. The
+# derive step below rewrites the override's Go install from the deploy tag, so
+# the live docs can never advertise a Go module version/tag that has not been
+# published (for example the staged /v4 path paired with a v3 tag, or an
+# in-flight RC tag). docs/_data/runtimes.yml pins the same derived shape for
+# the latest published release as the checked-in local-preview fallback.
+#
 # The generator runs from the checkout: it is present on `staging` and on
 # every release tag cut after this workflow lands. Dispatching with a tag
 # older than that fails fast in the generator step — deploy such tags by
@@ -193,6 +202,43 @@ jobs:
             --config docs/_config.yml \
             --output docs/_config_versions.yml
 
+      - name: Derive Go install from deploy tag
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Go semantic import versioning bakes the module major into the
+          # import path (/v3, /v4, ...), so the Go install cannot be a
+          # constant the generator stamps. Derive it from the resolved deploy
+          # tag: the module path carries the tag's major and the pinned
+          # version IS the tag. The resolve step only ever produces a
+          # published stable release (gh release view excludes drafts and
+          # prereleases; the tag input path refuses them explicitly), so the
+          # stamped Go install can never advertise an unpublished version.
+          go_major="${TAG#v}"
+          go_major="${go_major%%.*}"
+          if [[ ! "${go_major}" =~ ^[0-9]+$ ]]; then
+            echo "could not derive Go module major from tag '${TAG}'" >&2
+            exit 1
+          fi
+          ruby -ryaml -e '
+            path = ARGV[0]
+            tag = ARGV[1]
+            go_major = ARGV[2]
+            override = YAML.safe_load(File.read(path)) or {}
+            runtimes = override.dig("tabletheory", "runtimes")
+            abort "error: #{path} has no tabletheory.runtimes array" unless runtimes.is_a?(Array)
+            go = runtimes.find { |rt| rt.is_a?(Hash) && rt["id"] == "go" }
+            abort "error: #{path} has no go runtime entry" if go.nil?
+            install = go["install"]
+            unless install.is_a?(String) && install.include?("@#{tag}")
+              abort "error: go install in #{path} does not reference the deploy tag #{tag}: #{install.inspect}"
+            end
+            go["install"] = "go get github.com/theory-cloud/apptheory/v#{go_major}@#{tag}"
+            File.write(path, YAML.dump(override, line_width: -1))
+            puts "go install stamped to #{go["install"]}"
+          ' docs/_config_versions.yml "${TAG}" "${go_major}"
+
       - name: Jekyll build
         working-directory: docs
         env:
@@ -209,8 +255,18 @@ jobs:
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
+          go_major="${TAG#v}"
+          go_major="${go_major%%.*}"
           if ! grep -qF "theory-cloud-apptheory-${TAG#v}.tgz" _site/index.html; then
             echo "homepage does not show the stamped TypeScript install URL for tag ${TAG}" >&2
+            exit 1
+          fi
+          if ! grep -qF "go get github.com/theory-cloud/apptheory/v${go_major}@${TAG}" _site/index.html; then
+            echo "homepage does not show the stamped Go install URL for tag ${TAG}" >&2
+            exit 1
+          fi
+          if ! grep -qF "go get github.com/theory-cloud/apptheory/v${go_major}@${TAG}" _site/runtimes/go/index.html; then
+            echo "Go runtime page does not show the stamped Go install URL for tag ${TAG}" >&2
             exit 1
           fi
           if grep -qF 'vX.Y.Z' _site/index.html; then

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,30 @@ for `CHANGELOG.md`:
 Every minor release line that changes runtime behavior, deployment constructs, generated artifacts, dependency floors,
 or deprecation posture must add or update a section here before the release is promoted.
 
+## v4.x line
+
+### Go module import paths
+
+AppTheory v4 moves the Go runtime and the generated CDK Go bindings onto the next semantic import version. Replace the
+`/v3` suffix on every AppTheory runtime import with the canonical `github.com/theory-cloud/apptheory/v4` path, pin the
+v4 module tag, and run `go mod tidy`:
+
+```bash
+go get github.com/theory-cloud/apptheory/v4@v4.0.0-rc
+```
+
+Update the generated CDK Go bindings in the same release transaction: replace
+`github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v3` with `github.com/theory-cloud/apptheory/cdk-go/apptheorycdk/v4`,
+pin the matching v4 module tag, and run `go mod tidy` in the CDK application's module. Runtime and CDK module tags
+continue to target the same immutable release commit; do not mix major lines or substitute registry-published
+artifacts.
+
+The v4.0.0-rc tag is the first v4 release; pin the exact v4 release or RC tag you are moving to. v4.0.0-rc carries no
+Go API behavior change beyond the import-path migration: the api-snapshot diff between v3.3.0 and the v4 line is
+header-path-only, and the contract-test fixtures are byte-untouched. Do not retain both AppTheory major paths in one
+application: packages from `/v3` and `/v4` have distinct Go type identities even where their APIs are otherwise
+unchanged.
+
 ## v3.x line
 
 ### Toolchain and CDK dependency floors

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,11 +31,35 @@ pin the matching v4 module tag, and run `go mod tidy` in the CDK application's m
 continue to target the same immutable release commit; do not mix major lines or substitute registry-published
 artifacts.
 
-The v4.0.0-rc tag is the first v4 release; pin the exact v4 release or RC tag you are moving to. v4.0.0-rc carries no
-Go API behavior change beyond the import-path migration: the api-snapshot diff between v3.3.0 and the v4 line is
-header-path-only, and the contract-test fixtures are byte-untouched. Do not retain both AppTheory major paths in one
-application: packages from `/v3` and `/v4` have distinct Go type identities even where their APIs are otherwise
-unchanged.
+The v4.0.0-rc tag is the first v4 release; pin the exact v4 release or RC tag you are moving to. Within the /v3→/v4
+module migration itself, the Go API surface is unchanged beyond import paths: the api-snapshot diff between v3.3.0 and
+the v4 line is header-path-only. Do not retain both AppTheory major paths in one application: packages from `/v3` and
+`/v4` have distinct Go type identities even where their APIs are otherwise unchanged.
+
+### Breaking runtime behavior changes
+
+The v4 line is a major release for more than its import paths: the v3.3.0→v4 range also ships Go-runtime-observable
+breaking wire changes from the [#956](https://github.com/theory-cloud/AppTheory/pull/956) and
+[#957](https://github.com/theory-cloud/AppTheory/pull/957) trains:
+
+- Streaming responses on the HTTP API v2 and buffered Function URL adapters are no longer silently dropped. A
+  terminating stream is drained into the buffered body within a bounded budget (4 MiB / 5 s), and a stream that does
+  not terminate in time or exceeds the byte budget fails closed with the documented HTTP 500 JSON error instead of
+  reaching clients as a 200 with an empty body and immediate EOF.
+- A streamed-body drain byte overrun maps to HTTP 413 payload too large with the `app.too_large` error shape, matching
+  the buffered-body size semantics, instead of the generic 500 fail-closed shape. The 500 shape is retained only for
+  non-size drain failures such as non-termination and stream errors.
+- A response carrying both a non-empty buffered body and a streaming body is rejected and fails closed, because
+  different adapters previously picked different representations and produced divergent wire bytes for the same
+  response.
+- MCP method-not-allowed responses now carry the RFC 9110 `Allow` header: `Allow: POST` on the stateless shape,
+  `Allow: DELETE, GET, POST` on the session-ful transport.
+- Panicking event callbacks on the SQS, Kinesis, and SNS adapters are recovered into the established event-workload
+  failure shape instead of crashing the invocation; a panicking SQS/Kinesis record no longer aborts the whole batch.
+
+These are wire-contract changes, not source-level API changes: after the import-path migration, Go code that compiles
+on v3 compiles on v4, but the wire behavior an application observes can differ. See `CHANGELOG.md` and the v4 release
+notes for the complete commit-level detail in this range.
 
 ## v3.x line
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -133,6 +133,10 @@ tabletheory:
   runtimes:
     - id: go
       label: Go
+      # The module major is derived from the deploy tag at Pages build time
+      # (pages.yml) because Go semantic import versioning bakes it into the
+      # path (/v3, /v4, ...). This /v4 path is a placeholder default only —
+      # the generated docs/_config_versions.yml carries the real /v<major>.
       install: "go get github.com/theory-cloud/apptheory/v4@vX.Y.Z"
       docs_path: runtimes/go
     - id: ts

--- a/docs/_data/runtimes.yml
+++ b/docs/_data/runtimes.yml
@@ -2,12 +2,24 @@
 # Landing-page runtime tabs — Go / TypeScript / Python snippets.
 # Each block is rendered inside the .runtime-block UI on the home
 # page. `lang` matches the Rouge highlighter id.
+#
+# This file is the checked-in LOCAL-PREVIEW FALLBACK for the landing
+# page's install strings. The release-tagged config override (pages.yml
+# -> scripts/generate-docs-version-override.rb -> docs/_config_versions.yml)
+# replaces site.tabletheory.runtimes at build time, and docs/index.html
+# falls back to the pinned installs below when the override is absent.
+# The pins must therefore describe the LATEST ACTUALLY PUBLISHED release —
+# never an unpublished or in-flight tag — so local previews never instruct
+# fetching a nonexistent version. Go pins additionally carry the module
+# major that matches the release (Go semantic import versioning: a v3.x.y
+# release lives on the /v3 path); pages.yml derives the live Go install
+# from the deploy tag at build time.
 # =============================================================
 
 - id: go
   label: Go
   icon: go-mark
-  install: "go get github.com/theory-cloud/apptheory/v4@v4.0.0-rc"
+  install: "go get github.com/theory-cloud/apptheory/v3@v3.3.0"
   lang: go
   snippet: |
     package main

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -11,11 +11,23 @@ The Go runtime is the most complete implementation of the AppTheory contract and
 
 The Go toolchain resolves modules from the immutable git tag — no registry is involved beyond Go's standard proxy.
 
+{%- assign go_rt = site.tabletheory.runtimes | where: "id", "go" | first -%}
+{%- if go_rt.install == nil or go_rt.install contains "X.Y.Z" -%}
+  {%- assign go_fallback = site.data.runtimes | where: "id", "go" | first -%}
+  {%- assign go_install_cmd = go_fallback.install -%}
+{%- else -%}
+  {%- assign go_install_cmd = go_rt.install -%}
+{%- endif -%}
+
 ```bash
-go get github.com/theory-cloud/apptheory/v4@v4.0.0-rc
+{{ go_install_cmd }}
 ```
 
-Pin a specific release tag from the [releases page](https://github.com/theory-cloud/AppTheory/releases). AppTheory does not publish to the npm or PyPI registries; the Go module is the only language artifact that ships through Go's normal toolchain path.
+The command is stamped from the latest published release at Pages build time (pages.yml resolves it with
+`gh release view`), so the module path and version always match a release that actually exists. Pin a specific release
+tag from the [releases page](https://github.com/theory-cloud/AppTheory/releases) when you need a different line.
+AppTheory does not publish to the npm or PyPI registries; the Go module is the only language artifact that ships through
+Go's normal toolchain path.
 
 Module layout (see `api-snapshots/go.txt` for the exact exported surface):
 

--- a/scripts/verify-version-alignment.sh
+++ b/scripts/verify-version-alignment.sh
@@ -280,12 +280,17 @@ allowed_suffixes = ("/v4", "/cdk-go")
 # Release-pinned documentation (docs/_config_versions.yml) documents the
 # released v3.3.0 version, whose /v3 module path is historically accurate
 # and remains fetchable; the release PR advances it to /v4 with the v4.0.0
-# bump. cmd/apptheory-init/main_test.go pins a v3.0.0-rc scaffold to prove
+# bump. docs/_data/runtimes.yml is that mechanism's checked-in local-preview
+# fallback: it pins the latest published release (today v3.3.0 on the /v3
+# module path) so local previews never advertise an unpublished tag, and
+# pages.yml derives the live Go install from the deploy tag at build time.
+# cmd/apptheory-init/main_test.go pins a v3.0.0-rc scaffold to prove
 # the version->module-major derivation still maps v3-era pins to /v3.
 # Everything else must reference the staged /v4 import path.
 skip_files = {
     Path("cmd/apptheory-init/main_test.go"),
     Path("docs/_config_versions.yml"),
+    Path("docs/_data/runtimes.yml"),
 }
 skip_parts = {
     ".git",


### PR DESCRIPTION
## Intent

Two user-facing docs defects on the v4 line, fixed as atomic commits:

1. **fix(docs)** — `docs/runtimes/go.md` and `docs/_data/runtimes.yml` hardcoded
   `go get github.com/theory-cloud/apptheory/v4@v4.0.0-rc`, which does not resolve until
   the v4.0.0-rc release is actually cut (release-please #959). The Go install is now
   derived from the deploy tag at Pages build time (pages.yml resolves it with
   `gh release view`, same source of truth as the existing `docs/_config_versions.yml`
   stamping), so the live docs can never advertise a Go module version/tag that has not
   been published. The checked-in local-preview fallback pins the latest published
   release (v3.3.0 on the /v3 module path). `verify-version-alignment.sh` allowlists
   `docs/_data/runtimes.yml` as release-pinned documentation (same rationale as
   `docs/_config_versions.yml`).
2. **docs(UPGRADING)** — adds the v3→v4 Go module import-path migration section
   (`apptheory/v3` → `/v4`, `cdk-go/apptheorycdk/v3` → `/v4`) and the `go get` commands.
   The no-API-change claim is scoped to the /v3→/v4 module migration itself: the
   api-snapshot diff is header-path-only there. A follow-up commit records the breaking
   Go-runtime wire changes in the v3.3.0→v4 range from #956/#957 (streaming fail-closed
   semantics, 500→413 drain overrun, dual-body divergence fail-closed, the 405 `Allow`
   header, and event-callback panic isolation) and points readers to CHANGELOG.md and the
   v4 release notes, as the UPGRADING.md charter requires.

## Commands run

- `./scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.3.0)`
  (go module state `staged-next-major`)
- `./scripts/verify-version-alignment.sh --self-test` → `version-alignment-self-test: PASS`
- `bash scripts/verify-docs-standard.sh` → `docs-standard: PASS`
- Rework validation: both gates above re-run after the follow-up commit → still PASS
- Pages build mechanism simulated locally (generator → derive step → Jekyll config merge →
  index.html/go.md fallback logic): production and local-preview both render
  `go get github.com/theory-cloud/apptheory/v3@v3.3.0`; future v4.0.0 tag renders
  `/v4@v4.0.0`; no `vX.Y.Z` leakage, no unpublished tag advertised
- Readiness gate simulated: `git log --format=%s origin/premain..HEAD` contains the
  `fix(docs):` commit → `prerelease-ready: OK`
- `make test` (go test ./... + version alignment)

## Updates

- Version files: none (VERSION stays 3.3.0; staged-next-major)
- API snapshots: none
- Contract-test fixtures: none

Signed (SSH/ED25519) — all commits.
