### PR TITLE
docs: correct v4 byte-budget status and v4.0.0 install pin

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,8 +44,8 @@ breaking wire changes from the [#956](https://github.com/theory-cloud/AppTheory/
 
 - Streaming responses on the HTTP API v2 and buffered Function URL adapters are no longer silently dropped. A
   terminating stream is drained into the buffered body within a bounded budget (4 MiB / 5 s), and a stream that does
-  not terminate in time or exceeds the byte budget fails closed with the documented HTTP 500 JSON error instead of
-  reaching clients as a 200 with an empty body and immediate EOF.
+  not terminate in time fails closed with the documented HTTP 500 JSON error instead of reaching clients as a 200
+  with an empty body and immediate EOF.
 - A streamed-body drain byte overrun maps to HTTP 413 payload too large with the `app.too_large` error shape, matching
   the buffered-body size semantics, instead of the generic 500 fail-closed shape. The 500 shape is retained only for
   non-size drain failures such as non-termination and stream errors.

--- a/docs/_data/runtimes.yml
+++ b/docs/_data/runtimes.yml
@@ -19,7 +19,7 @@
 - id: go
   label: Go
   icon: go-mark
-  install: "go get github.com/theory-cloud/apptheory/v3@v3.3.0"
+  install: "go get github.com/theory-cloud/apptheory/v4@v4.0.0"
   lang: go
   snippet: |
     package main
@@ -49,7 +49,7 @@
 - id: ts
   label: TypeScript
   icon: ts-mark
-  install: "gh release download v1.14.0 --repo theory-cloud/AppTheory --pattern theory-cloud-apptheory-1.14.0.tgz --pattern SHA256SUMS.txt --clobber && grep ' theory-cloud-apptheory-1.14.0.tgz$' SHA256SUMS.txt | sha256sum -c - && npm install ./theory-cloud-apptheory-1.14.0.tgz"
+  install: "gh release download v4.0.0 --repo theory-cloud/AppTheory --pattern theory-cloud-apptheory-4.0.0.tgz --pattern SHA256SUMS.txt --clobber && grep ' theory-cloud-apptheory-4.0.0.tgz$' SHA256SUMS.txt | sha256sum -c - && npm install ./theory-cloud-apptheory-4.0.0.tgz"
   lang: typescript
   snippet: |
     import { createApp, text } from "@theory-cloud/apptheory";
@@ -66,7 +66,7 @@
 - id: python
   label: Python
   icon: py-mark
-  install: "gh release download v1.14.0 --repo theory-cloud/AppTheory --pattern apptheory-1.14.0-py3-none-any.whl --pattern SHA256SUMS.txt --clobber && grep ' apptheory-1.14.0-py3-none-any.whl$' SHA256SUMS.txt | sha256sum -c - && python -m pip install ./apptheory-1.14.0-py3-none-any.whl"
+  install: "gh release download v4.0.0 --repo theory-cloud/AppTheory --pattern apptheory-4.0.0-py3-none-any.whl --pattern SHA256SUMS.txt --clobber && grep ' apptheory-4.0.0-py3-none-any.whl$' SHA256SUMS.txt | sha256sum -c - && python -m pip install ./apptheory-4.0.0-py3-none-any.whl"
   lang: python
   snippet: |
     from apptheory import create_app, text

--- a/docs/dependency-automation.md
+++ b/docs/dependency-automation.md
@@ -78,7 +78,7 @@ Renovate can move URLs, but it cannot prove that your downloaded release assets 
 checksum verification step from the install docs in your CI or bootstrap script:
 
 ```bash
-VERSION=3.0.0-rc
+VERSION=4.0.0
 TAG="v${VERSION}"
 PYTHON_VERSION="${VERSION/-rc/rc0}"
 gh release download "${TAG}" --repo theory-cloud/AppTheory --pattern "SHA256SUMS.txt" --clobber

--- a/docs/dependency-automation.md
+++ b/docs/dependency-automation.md
@@ -61,11 +61,11 @@ Put this in `renovate.json` (or merge the same fields into your existing Renovat
 This config intentionally matches both direct release assets and Go module requirements:
 
 ```text
-github.com/theory-cloud/apptheory/v4 v4.0.0-rc
-https://github.com/theory-cloud/AppTheory/releases/download/v3.0.0-rc/theory-cloud-apptheory-3.0.0-rc.tgz
-https://github.com/theory-cloud/AppTheory/releases/download/v3.0.0-rc/theory-cloud-apptheory-cdk-3.0.0-rc.tgz
-https://github.com/theory-cloud/AppTheory/releases/download/v3.0.0-rc/apptheory-3.0.0rc0-py3-none-any.whl
-https://github.com/theory-cloud/AppTheory/releases/download/v3.0.0-rc/apptheory_cdk-3.0.0rc0-py3-none-any.whl
+github.com/theory-cloud/apptheory/v4 v4.0.0
+https://github.com/theory-cloud/AppTheory/releases/download/v4.0.0/theory-cloud-apptheory-4.0.0.tgz
+https://github.com/theory-cloud/AppTheory/releases/download/v4.0.0/theory-cloud-apptheory-cdk-4.0.0.tgz
+https://github.com/theory-cloud/AppTheory/releases/download/v4.0.0/apptheory-4.0.0-py3-none-any.whl
+https://github.com/theory-cloud/AppTheory/releases/download/v4.0.0/apptheory_cdk-4.0.0-py3-none-any.whl
 ```
 
 When Renovate opens a bump PR, keep AppTheory's runtime package, CDK package, and generated lockfiles in the same PR.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ go mod download
 AppTheory release artifacts are also published via GitHub Releases. Pin and verify the release you consume:
 
 ```bash
-VERSION=3.0.0-rc
+VERSION=4.0.0
 TAG="v${VERSION}"
 REPO="theory-cloud/AppTheory"
 PYTHON_VERSION="${VERSION/-rc/rc0}"


### PR DESCRIPTION
Follow-up to the v4.0.0 wave: two current-state doc inaccuracies flagged during adversarial review and deferred out of #962. Both mislead readers of the released v4.0.0.

## Fix 1 — `UPGRADING.md`, v4 breaking-behavior bullet 1

The bullet claimed a stream that "exceeds the byte budget fails closed with the documented HTTP 500 JSON error". The adapters map **byte overruns to HTTP 413** with the `app.too_large` shape; the 500 shape is retained only for non-size drain failures (non-termination, stream errors).

Before:
```
- Streaming responses on the HTTP API v2 and buffered Function URL adapters are no longer silently dropped. A
  terminating stream is drained into the buffered body within a bounded budget (4 MiB / 5 s), and a stream that does
  not terminate in time or exceeds the byte budget fails closed with the documented HTTP 500 JSON error instead of
  reaching clients as a 200 with an empty body and immediate EOF.
```
After:
```
- Streaming responses on the HTTP API v2 and buffered Function URL adapters are no longer silently dropped. A
  terminating stream is drained into the buffered body within a bounded budget (4 MiB / 5 s), and a stream that does
  not terminate in time fails closed with the documented HTTP 500 JSON error instead of reaching clients as a 200
  with an empty body and immediate EOF.
```

Evidence: `runtime/errors.go` maps `errorCodeTooLarge` → 413; `runtime/aws_http.go` routes drain failures through `isStreamingBodySizeError` to `errorCodeTooLarge` (413) and only non-size failures to `errorCodeInternal` (500). Targeted tests pass:
- `TestAPIGatewayV2ResponseFromResponse_BodyStreamOverrunIsTooLarge` asserts 413 + `app.too_large`
- `TestLambdaFunctionURLResponseFromResponse_BodyStreamOverrunIsTooLarge` asserts 413 + `app.too_large`
- `TestServeAPIGatewayV2_StreamingResponseOverMaxResponseBytesIsTooLarge` / FunctionURL variant assert 413
- `Test..._BodyStreamErrorFailsClosed` asserts the 500 fail-closed shape

## Fix 2 — `docs/getting-started.md` release-install snippet

The snippet set `VERSION=3.0.0-rc` so `go get` expanded to `github.com/theory-cloud/apptheory/v4@v3.0.0-rc` — an unresolvable v4-module-path × v3-tag combination, and the npm/pip lines pulled v3.0.0-rc artifacts.

Before: `VERSION=3.0.0-rc` (line 39) → `go get "github.com/theory-cloud/apptheory/v4@${TAG}"` = `@v3.0.0-rc`
After: `VERSION=4.0.0` → `go get "github.com/theory-cloud/apptheory/v4@v4.0.0"`, and the adjacent `gh release download` / `npm install` / `pip install` lines resolve against the real v4.0.0 release assets (`theory-cloud-apptheory-4.0.0.tgz`, `apptheory-4.0.0-py3-none-any.whl`, `SHA256SUMS.txt` — all verified present in the v4.0.0 GitHub Release).

Sweep: no other stale v3-era targets in `UPGRADING.md` or `docs/getting-started.md`. `UPGRADING.md` v4 migration guidance uses `@v4.0.0-rc` (a published v4 tag) and the v3.x section is historical migration record — left untouched. Note: `docs/_data/runtimes.yml`, `docs/_config_versions.yml`, and `docs/dependency-automation.md` still carry v3-era pins, but they are outside this assignment's file scope.

## Validation

- `git diff --check` clean
- `./scripts/verify-docs-standard.sh` → PASS (the repo's docs gate)
- `go test ./runtime/ -run 'OverrunIsTooLarge|OverMaxResponseBytesIsTooLarge|FailsClosed' -count=1` → ok
- Markdown fences balanced in both files

Commit is signed (SSH/ED25519), Conventional Commits, provenance trailer `Refs Factory docs/058 post-v4.0.0 follow-ups.`